### PR TITLE
ci: Only run Chromatic on PR's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,13 @@ jobs:
       after_success:
         - curl -s https://codecov.io/bash | bash
         - |
-          if [[ $TRAVIS_EVENT_TYPE != "pull_request" || $TRAVIS_PULL_REQUEST_SLUG != $TRAVIS_REPO_SLUG ]]; then
-            if [ "$TRAVIS_BRANCH" == "master" ]; then
-              yarn run chromatic --auto-accept-changes;
-            else
-              yarn run chromatic;
-            fi
+          if [[ "$TRAVIS_BRANCH" == "master" && $TRAVIS_EVENT_TYPE == "push" ]]; then
+            yarn run chromatic --auto-accept-changes;
+          elif [[ $TRAVIS_EVENT_TYPE == "pull_request" ]]; then
+            yarn run chromatic; # This will fail on external PR's as Travis won't have the chromatic token
+
           else
-            echo "Skipping internal PR because of https://docs.chromaticqa.com/setup_ci#travis";
+            echo "Skipping chromatic, as it's more a regression tool...";
           fi
 
     - stage: release


### PR DESCRIPTION
Only run the Chromatic scripts on PR's, rather than on every Travis build event.