### PR TITLE
feat(Icon): Expose *Icon components

### DIFF
--- a/lib/components/Anchor/stories.tsx
+++ b/lib/components/Anchor/stories.tsx
@@ -1,10 +1,9 @@
-import { Phone } from '../../icons';
 import { text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { Anchor } from '.';
 import { Button } from '../Button';
-import { Icon } from '../Icon';
+import { Icon, PhoneIcon } from '../Icon';
 
 const baseProps = () => {
 	return {
@@ -18,7 +17,7 @@ storiesOf('Components|Type/Anchor', module)
 		<Anchor
 			{...baseProps()}
 			href={'123'}
-			icon={<Icon icon={Phone} size={16} />}
+			icon={<Icon icon={PhoneIcon} size={16} />}
 		/>
 	))
 	.add('withButton', () => (
@@ -26,6 +25,6 @@ storiesOf('Components|Type/Anchor', module)
 			{...baseProps()}
 			component={Button}
 			to={'./#eldorado'}
-			icon={<Icon icon={Phone} size={16} />}
+			icon={<Icon icon={PhoneIcon} size={16} />}
 		/>
 	));

--- a/lib/components/Icon/index.ts
+++ b/lib/components/Icon/index.ts
@@ -1,1 +1,2 @@
 export { Icon, IProps as IIconProps, TIconPrimitiveType } from './Icon';
+export * from '../../icons';

--- a/lib/components/Icon/stories.tsx
+++ b/lib/components/Icon/stories.tsx
@@ -1,8 +1,8 @@
-import { Calendar } from '../../icons';
+import { CalendarIcon } from './';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { Icon } from './Icon';
 
 storiesOf('Components|Icon', module).add('default', () => (
-	<Icon size={25} icon={Calendar} fill={'green'} />
+	<Icon size={25} icon={CalendarIcon} fill={'green'} />
 ));

--- a/lib/components/Meta/stories.tsx
+++ b/lib/components/Meta/stories.tsx
@@ -1,14 +1,13 @@
-import { Calendar } from '../../icons';
 import { select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { EMetaVariant, Meta } from '.';
-import { Icon } from '../Icon';
+import { CalendarIcon, Icon } from '../Icon';
 
 storiesOf('Components|Meta', module).add('default', () => (
 	<Meta
 		variant={select('Variant', EMetaVariant, EMetaVariant.Primary)}
-		icon={<Icon size={16} icon={Calendar} />}
+		icon={<Icon size={16} icon={CalendarIcon} />}
 		label={'Hello World'}
 	/>
 ));

--- a/lib/components/Pagination/Loading.tsx
+++ b/lib/components/Pagination/Loading.tsx
@@ -1,7 +1,6 @@
 import cx from 'clsx';
 import React, { FunctionComponent, memo } from 'react';
-import { ChevronLeft, ChevronRight } from '../../icons';
-import { Icon } from '../Icon';
+import { ChevronLeftIcon, ChevronRightIcon, Icon } from '../Icon';
 import styles from './style.scss';
 import { Bubble } from './Bubble';
 
@@ -18,11 +17,19 @@ export const LoadingComponent: FunctionComponent<IProps> = ({
 
 	return (
 		<span className={cx([styles.loading, className])}>
-			<Icon size={25} icon={ChevronLeft} className={disabledChevCls} />
+			<Icon
+				size={25}
+				icon={ChevronLeftIcon}
+				className={disabledChevCls}
+			/>
 			{new Array(placeholderBubblesNum).fill('').map((_, index) => (
 				<Bubble key={index} className={styles.disabled} children={''} />
 			))}
-			<Icon size={25} icon={ChevronRight} className={disabledChevCls} />
+			<Icon
+				size={25}
+				icon={ChevronRightIcon}
+				className={disabledChevCls}
+			/>
 		</span>
 	);
 };

--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -1,7 +1,6 @@
 import cx from 'clsx';
 import React, { FunctionComponent, memo } from 'react';
-import { ChevronLeft, ChevronRight } from '../../icons';
-import { Icon } from '../Icon';
+import { ChevronLeftIcon, ChevronRightIcon, Icon } from '../Icon';
 import styles from './style.scss';
 import { Bubble } from './Bubble';
 import { PaginationLoading } from './Loading';
@@ -45,7 +44,7 @@ export const PaginationComponent: FunctionComponent<IProps> = ({
 	return total && pageSize && activePage && numPagesDisplayed ? (
 		<span className={cls}>
 			<a className={chevronLeftCls} onClick={handleClick(activePage - 1)}>
-				<Icon size={24} icon={ChevronLeft} />
+				<Icon size={24} icon={ChevronLeftIcon} />
 			</a>
 			{buildPagesList(
 				numPages,
@@ -64,7 +63,7 @@ export const PaginationComponent: FunctionComponent<IProps> = ({
 			<a
 				className={chevronRightCls}
 				onClick={handleClick(allowedActive + 1)}>
-				<Icon size={24} icon={ChevronRight} />
+				<Icon size={24} icon={ChevronRightIcon} />
 			</a>
 		</span>
 	) : (

--- a/lib/components/SelectInput/SelectInput.tsx
+++ b/lib/components/SelectInput/SelectInput.tsx
@@ -1,6 +1,5 @@
 import React, { memo } from 'react';
-import { ChevronDown } from '../../icons';
-import { Icon } from '../Icon';
+import { ChevronDownIcon, Icon } from '../Icon';
 import { withEnhancedInput } from '../InputBase';
 import styles from './style.scss';
 
@@ -18,7 +17,7 @@ const SelectInputComponent = withEnhancedInput(function SelectInput({
 				{...rest}
 				autoComplete="off"
 			/>
-			<Icon className={styles.arrow} size={25} icon={ChevronDown} />
+			<Icon className={styles.arrow} size={25} icon={ChevronDownIcon} />
 		</>
 	);
 });

--- a/lib/components/SimplePagination/SimplePagination.tsx
+++ b/lib/components/SimplePagination/SimplePagination.tsx
@@ -1,8 +1,7 @@
 import cx from 'clsx';
 import React, { FunctionComponent, memo } from 'react';
-import { ChevronLeft, ChevronRight } from '../../icons';
 import { Button, EButtonSize, EButtonVariant } from '../Button';
-import { Icon } from '../Icon';
+import { ChevronLeftIcon, ChevronRightIcon, Icon } from '../Icon';
 import styles from './style.scss';
 
 export enum EChangeDirection {
@@ -45,7 +44,11 @@ export const SimplePaginationComponent: FunctionComponent<IProps> = ({
 				variant={EButtonVariant.Secondary}
 				className={chevronLeftCls}
 				onClick={handleClick(EChangeDirection.Previous)}>
-				<Icon className={styles.icon} size={24} icon={ChevronLeft} />
+				<Icon
+					className={styles.icon}
+					size={24}
+					icon={ChevronLeftIcon}
+				/>
 			</Button>
 			<Button
 				rounded={true}
@@ -54,7 +57,11 @@ export const SimplePaginationComponent: FunctionComponent<IProps> = ({
 				variant={EButtonVariant.Secondary}
 				className={chevronRightCls}
 				onClick={handleClick(EChangeDirection.Next)}>
-				<Icon className={styles.icon} size={24} icon={ChevronRight} />
+				<Icon
+					className={styles.icon}
+					size={24}
+					icon={ChevronRightIcon}
+				/>
 			</Button>
 		</div>
 	);

--- a/lib/components/StandardModal/StandardModal.tsx
+++ b/lib/components/StandardModal/StandardModal.tsx
@@ -1,8 +1,7 @@
 import cx from 'clsx';
 import React from 'react';
-import { WindowClose } from '../../icons';
 import { EHeadingSize, Heading } from '../Heading';
-import { Icon } from '../Icon';
+import { Icon, WindowCloseIcon } from '../Icon';
 import { EModalCloseCode, withModal } from '../ModalBase';
 import styles from './style.scss';
 
@@ -39,7 +38,7 @@ export const StandardModal = withModal<IProps>(
 					<button
 						className={styles.headerCloseButton}
 						onClick={closeButtonHandler}>
-						<Icon size={20} icon={WindowClose} />
+						<Icon size={20} icon={WindowCloseIcon} />
 					</button>
 					<div className={styles.headerTitle}>
 						<Heading

--- a/lib/icons/AccountBox.tsx
+++ b/lib/icons/AccountBox.tsx
@@ -14,7 +14,6 @@ const Icon = (
 	</svg>
 );
 
-export default function AccountBox() {
+export default function AccountBoxIcon() {
 	return Icon;
 }
-AccountBox.displayName = 'AccountBoxIcon';

--- a/lib/icons/ArrowLeft.tsx
+++ b/lib/icons/ArrowLeft.tsx
@@ -14,7 +14,6 @@ const Icon = (
 	</svg>
 );
 
-export default function ArrowLeft() {
+export default function ArrowLeftIcon() {
 	return Icon;
 }
-ArrowLeft.displayName = 'ArrowLeftIcon';

--- a/lib/icons/Calendar.tsx
+++ b/lib/icons/Calendar.tsx
@@ -14,7 +14,6 @@ const Icon = (
 	</svg>
 );
 
-export default function Calendar() {
+export default function CalendarIcon() {
 	return Icon;
 }
-Calendar.displayName = 'CalendarIcon';

--- a/lib/icons/Check.tsx
+++ b/lib/icons/Check.tsx
@@ -14,7 +14,6 @@ const Icon = (
 	</svg>
 );
 
-export default function Check() {
+export default function CheckIcon() {
 	return Icon;
 }
-Check.displayName = 'CheckIcon';

--- a/lib/icons/ChevronDown.tsx
+++ b/lib/icons/ChevronDown.tsx
@@ -14,7 +14,6 @@ const Icon = (
 	</svg>
 );
 
-export default function ChevronDown() {
+export default function ChevronDownIcon() {
 	return Icon;
 }
-ChevronDown.displayName = 'ChevronDownIcon';

--- a/lib/icons/ChevronLeft.tsx
+++ b/lib/icons/ChevronLeft.tsx
@@ -14,7 +14,6 @@ const Icon = (
 	</svg>
 );
 
-export default function ChevronLeft() {
+export default function ChevronLeftIcon() {
 	return Icon;
 }
-ChevronLeft.displayName = 'ChevronLeftIcon';

--- a/lib/icons/ChevronRight.tsx
+++ b/lib/icons/ChevronRight.tsx
@@ -14,7 +14,6 @@ const Icon = (
 	</svg>
 );
 
-export default function ChevronRight() {
+export default function ChevronRightIcon() {
 	return Icon;
 }
-ChevronRight.displayName = 'ChevronRightIcon';

--- a/lib/icons/Phone.tsx
+++ b/lib/icons/Phone.tsx
@@ -14,7 +14,6 @@ const Icon = (
 	</svg>
 );
 
-export default function Phone() {
+export default function PhoneIcon() {
 	return Icon;
 }
-Phone.displayName = 'PhoneIcon';

--- a/lib/icons/WindowClose.tsx
+++ b/lib/icons/WindowClose.tsx
@@ -14,7 +14,6 @@ const Icon = (
 	</svg>
 );
 
-export default function WindowClose() {
+export default function WindowCloseIcon() {
 	return Icon;
 }
-WindowClose.displayName = 'WindowCloseIcon';

--- a/lib/icons/index.ts
+++ b/lib/icons/index.ts
@@ -6,12 +6,12 @@
  * -----------------------------------------------------------------------------
  */
 
-export { default as AccountBox } from './AccountBox';
-export { default as ArrowLeft } from './ArrowLeft';
-export { default as Calendar } from './Calendar';
-export { default as Check } from './Check';
-export { default as ChevronDown } from './ChevronDown';
-export { default as ChevronLeft } from './ChevronLeft';
-export { default as ChevronRight } from './ChevronRight';
-export { default as Phone } from './Phone';
-export { default as WindowClose } from './WindowClose';
+export { default as AccountBoxIcon } from './AccountBox';
+export { default as ArrowLeftIcon } from './ArrowLeft';
+export { default as CalendarIcon } from './Calendar';
+export { default as CheckIcon } from './Check';
+export { default as ChevronDownIcon } from './ChevronDown';
+export { default as ChevronLeftIcon } from './ChevronLeft';
+export { default as ChevronRightIcon } from './ChevronRight';
+export { default as PhoneIcon } from './Phone';
+export { default as WindowCloseIcon } from './WindowClose';

--- a/scripts/buildIcons.js
+++ b/scripts/buildIcons.js
@@ -18,8 +18,7 @@ const COMPONENT_TEMPLATE = `import React from 'react';
 
 const Icon = (%content%);
 
-export default function %name%() { return Icon; };
-%name%.displayName = '%name%Icon';
+export default function %name%Icon() { return Icon; };
 `;
 
 const root = path.join(__dirname, '../');
@@ -64,7 +63,7 @@ Promise.all(svgs)
 	.then(completed => {
 		const exports = completed.map(icon =>
 			format(
-				`export {default as %s} from './%s';`,
+				`export {default as %sIcon} from './%s';`,
 				icon.name,
 				path.parse(path.relative(outputFolderPath, icon.iconOutputPath))
 					.name


### PR DESCRIPTION
I aim to expose `*Icon` components to our library consumers, so they can also use them. This has needed me to rename `Account` (icon) to be `AccountIcon` so there are no re-export conflicts. 

In the future this could maybe be done again with a seperate bundle this project could expose, eg:

```tsx
import { Icon } from '@autoguru/overdrive';
import { Account } from '@autoguru/overdrive/icons';

<Icon icon={Account}/>
```