### PR TITLE
feat: Using new `is` prop instead of `component`

### DIFF
--- a/lib/components/Anchor/Anchor.spec.jsx
+++ b/lib/components/Anchor/Anchor.spec.jsx
@@ -26,34 +26,11 @@ describe('<Anchor />', () => {
 		expect(anchor).toMatchSnapshot();
 	});
 
-	it('should match snapshot with label, icon custom component', () => {
-		const anchor = shallow(
-			<Anchor
-				icon={TestIcon}
-				compnent={Button}
-				label={testLabel}
-				to={testLink}
-			/>
-		);
-		expect(anchor).toMatchSnapshot();
-	});
-
 	it('should add an a dom element', () => {
 		const anchor = shallow(
 			<Anchor className="anchor-class" label={testLabel} />
 		);
 		expect(anchor.type()).toEqual(`a`);
-	});
-
-	it('should add Button dom element if button component is passed down to it', () => {
-		const anchor = shallow(
-			<Anchor
-				className="anchor-class"
-				label={testLabel}
-				component={Button}
-			/>
-		);
-		expect(anchor.find(Button)).toBeTruthy();
 	});
 
 	it('should pass on className to dom element', () => {
@@ -81,5 +58,55 @@ describe('<Anchor />', () => {
 			<Anchor icon={TestIcon} label={testLabel} href={testLink} />
 		);
 		expect(anchor.find('a').prop('href')).toEqual(testLink);
+	});
+
+	describe('when custom component', () => {
+		it('should add Button dom element if button component is passed down to it', () => {
+			const anchor = shallow(
+				<Anchor
+					className="anchor-class"
+					label={testLabel}
+					is={<Button />}
+				/>
+			);
+			expect(anchor.find(Button)).toBeTruthy();
+		});
+
+		it('should match snapshot with label, icon custom component', () => {
+			const anchor = shallow(
+				<Anchor
+					icon={TestIcon}
+					is={<Button />}
+					label={testLabel}
+					to={testLink}
+				/>
+			);
+			expect(anchor).toMatchSnapshot();
+		});
+
+		describe('deprecated still work', () => {
+			it('should add Button dom element if button component is passed down to it', () => {
+				const anchor = shallow(
+					<Anchor
+						className="anchor-class"
+						label={testLabel}
+						component={Button}
+					/>
+				);
+				expect(anchor.find(Button)).toBeTruthy();
+			});
+
+			it('should match snapshot with label, icon custom component', () => {
+				const anchor = shallow(
+					<Anchor
+						icon={TestIcon}
+						compnent={Button}
+						label={testLabel}
+						to={testLink}
+					/>
+				);
+				expect(anchor).toMatchSnapshot();
+			});
+		});
 	});
 });

--- a/lib/components/Anchor/Anchor.tsx
+++ b/lib/components/Anchor/Anchor.tsx
@@ -1,43 +1,56 @@
+import { warning } from '@autoguru/utilities';
 import cx from 'clsx';
 import React, {
-	AnchorHTMLAttributes,
+	cloneElement,
 	ComponentType,
-	createElement,
 	FunctionComponent,
 	memo,
+	ReactNode,
 } from 'react';
 import { DetailText, EDetailTextSize } from '../DetailText';
 import { TIconPrimitiveType } from '../Icon';
 import styles from './style.scss';
 
-type TAnchorPropType = IProps & AnchorHTMLAttributes<Element>;
-
 export interface IProps {
 	className?: string;
 	icon?: TIconPrimitiveType;
-	component?: ComponentType;
+	is?: ComponentType | ReactNode;
+	component?: ComponentType; // @deprecated
 	disabled?: boolean;
 	href?: string;
 	to?: string;
 	label?: string;
 }
 
-const AnchorComponent: FunctionComponent<TAnchorPropType> = ({
+const AnchorComponent: FunctionComponent<IProps & any> = ({
 	className = '',
-	component = 'a',
+	is: Component = 'a',
+	component = void 0,
 	icon = void 0,
 	label,
 	disabled = false,
 	...rest
-}) =>
-	createElement<TAnchorPropType>(
-		component,
-		{
-			className: cx([className, styles.root]),
-			'aria-disabled': disabled,
-			disabled,
-			...rest,
-		},
+}) => {
+	// @deprecated block
+	{
+		warning(
+			component !== void 0,
+			`The \`component\` prop deprecated, please use the \`is\` prop instead.\n\nBefore:\n<Anchor component="{<Link/">}>\n\tHello\n</Anchor>\n\nAfter:\n<Anchor is="{<Link/">}>\n\tHello\n</Anchor>`
+		);
+
+		if (component !== void 0) {
+			Component = component;
+		}
+	}
+
+	const props = {
+		className: cx([className, styles.root]),
+		'aria-disabled': disabled,
+		disabled,
+		...rest,
+	};
+
+	const childs = (
 		<>
 			{icon &&
 				React.cloneElement(icon, {
@@ -49,5 +62,12 @@ const AnchorComponent: FunctionComponent<TAnchorPropType> = ({
 			</DetailText>
 		</>
 	);
+
+	return typeof Component === 'string' ? (
+		<Component {...props}>{childs}</Component>
+	) : (
+		cloneElement(Component, props, childs)
+	);
+};
 
 export const Anchor = memo(AnchorComponent);

--- a/lib/components/Anchor/__snapshots__/Anchor.spec.jsx.snap
+++ b/lib/components/Anchor/__snapshots__/Anchor.spec.jsx.snap
@@ -20,7 +20,20 @@ exports[`<Anchor /> should match snapshot with label, icon and to props 1`] = `
 </a>
 `;
 
-exports[`<Anchor /> should match snapshot with label, icon custom component 1`] = `
+exports[`<Anchor /> should match snapshot without label 1`] = `
+<a
+  aria-disabled={false}
+  className="root"
+  disabled={false}
+>
+  <DetailText
+    className="label"
+    size="detail-2"
+  />
+</a>
+`;
+
+exports[`<Anchor /> when custom component deprecated still work should match snapshot with label, icon custom component 1`] = `
 <a
   aria-disabled={false}
   className="root"
@@ -41,15 +54,22 @@ exports[`<Anchor /> should match snapshot with label, icon custom component 1`] 
 </a>
 `;
 
-exports[`<Anchor /> should match snapshot without label 1`] = `
-<a
+exports[`<Anchor /> when custom component should match snapshot with label, icon custom component 1`] = `
+<Button
   aria-disabled={false}
   className="root"
   disabled={false}
+  to="https://www.hellowrold.com"
 >
+  <Component
+    className="icon"
+    size={16}
+  />
   <DetailText
     className="label"
     size="detail-2"
-  />
-</a>
+  >
+    Hello World!
+  </DetailText>
+</Button>
 `;

--- a/lib/components/Anchor/stories.tsx
+++ b/lib/components/Anchor/stories.tsx
@@ -21,7 +21,7 @@ storiesOf('Components|Type/Anchor', module)
 	.add('withButton', () => (
 		<Anchor
 			{...baseProps()}
-			component={Button}
+			is={<Button />}
 			to={'./#eldorado'}
 			icon={<Icon icon={PhoneIcon} size={16} />}
 		/>

--- a/lib/components/Button/Button.spec.jsx
+++ b/lib/components/Button/Button.spec.jsx
@@ -23,15 +23,27 @@ describe('<Button />', () => {
 		});
 	});
 
-	describe('when as anchor', () => {
+	describe('when custom component', () => {
 		it('should use html anchor element if href value exists', () => {
-			const button = shallow(<Button component="a" href="abc" />);
+			const button = shallow(<Button is="a" href="abc" />);
 			expect(button.type()).toEqual('a');
 		});
 
 		it('should pass href value to the DOM element', () => {
-			const button = mount(<Button component="a" href="/abcd" />);
+			const button = mount(<Button is="a" href="/abcd" />);
 			expect(button.html()).toContain(`href="/abcd"`);
+		});
+
+		describe('deprecated still work', () => {
+			it('should use html anchor element if href value exists', () => {
+				const button = shallow(<Button component="a" href="abc" />);
+				expect(button.type()).toEqual('a');
+			});
+
+			it('should pass href value to the DOM element', () => {
+				const button = mount(<Button component="a" href="/abcd" />);
+				expect(button.html()).toContain(`href="/abcd"`);
+			});
 		});
 	});
 

--- a/lib/components/Button/stories.tsx
+++ b/lib/components/Button/stories.tsx
@@ -60,7 +60,7 @@ storiesOf('Components|Buttons', module)
 		<Button
 			href="https://www.autoguru.com.au"
 			target="_blank"
-			component="a"
+			is="a"
 			{...baseProps()}
 			{...nonRoundedProps()}>
 			Hello World


### PR DESCRIPTION
Migration of `component={}` props to the new `is={}` prop, this is backward compatible, but pending a future removal.