### PR TITLE
feat(StarRating): Moved to the rating prop

### DIFF
--- a/lib/components/StarRating/StarRating.spec.jsx
+++ b/lib/components/StarRating/StarRating.spec.jsx
@@ -21,12 +21,12 @@ describe('<StarRating />', () => {
 	});
 
 	it('should match snapshot with value', () => {
-		expect(render(<StarRating ratingValue={2.7} />)).toMatchSnapshot();
+		expect(render(<StarRating rating={2.7} />)).toMatchSnapshot();
 	});
 
 	it('should match snapshot with label', () => {
 		const rating = render(
-			<StarRating ratingValue={3.8} label={'Hello World!'} />
+			<StarRating rating={3.8} label={'Hello World!'} />
 		);
 		expect(rating).toMatchSnapshot();
 	});
@@ -34,7 +34,7 @@ describe('<StarRating />', () => {
 	it('should match snapshot for small size', () => {
 		const rating = render(
 			<StarRating
-				ratingValue={3.8}
+				rating={3.8}
 				label={'Hello World!'}
 				size={EStarRatingSize.Small}
 			/>
@@ -45,7 +45,7 @@ describe('<StarRating />', () => {
 	it('should add a span dom element', () => {
 		const rating = shallow(
 			<StarRating
-				ratingValue={2.6}
+				rating={2.6}
 				label={'Hello World!'}
 				size={EStarRatingSize.Small}
 			/>
@@ -64,7 +64,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should add a span element inside with the rating value if label is not provided value', () => {
-		const rating = mount(<StarRating ratingValue={4.1} />);
+		const rating = mount(<StarRating rating={4.1} />);
 		expect(
 			rating
 				.find('span')
@@ -86,7 +86,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should have correct star combination for rating 0', () => {
-		const rating = shallow(<StarRating ratingValue={0} />);
+		const rating = shallow(<StarRating rating={0} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(0);
@@ -95,7 +95,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should have correct star combination for rating 1', () => {
-		const rating = shallow(<StarRating ratingValue={1} />);
+		const rating = shallow(<StarRating rating={1} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(1);
@@ -104,7 +104,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should have correct star combination for rating 2', () => {
-		const rating = shallow(<StarRating ratingValue={2} />);
+		const rating = shallow(<StarRating rating={2} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(2);
@@ -113,7 +113,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should have correct star combination for rating 3', () => {
-		const rating = shallow(<StarRating ratingValue={3} />);
+		const rating = shallow(<StarRating rating={3} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(3);
@@ -122,7 +122,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should have correct star combination for rating 4', () => {
-		const rating = shallow(<StarRating ratingValue={4} />);
+		const rating = shallow(<StarRating rating={4} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(4);
@@ -131,7 +131,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should have correct star combination for rating 5', () => {
-		const rating = shallow(<StarRating ratingValue={5} />);
+		const rating = shallow(<StarRating rating={5} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(5);
@@ -140,7 +140,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should round down to 0 for decimals lower than 0.2', () => {
-		const rating = shallow(<StarRating ratingValue={3.1} />);
+		const rating = shallow(<StarRating rating={3.1} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(3);
@@ -149,7 +149,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should round down to 0 for decimals equal to 0.2', () => {
-		const rating = shallow(<StarRating ratingValue={4.2} />);
+		const rating = shallow(<StarRating rating={4.2} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(4);
@@ -158,7 +158,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should round down to 0.5 for decimals larger than 0.2 and smaller 0.5', () => {
-		const rating = shallow(<StarRating ratingValue={2.3} />);
+		const rating = shallow(<StarRating rating={2.3} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(2);
@@ -167,7 +167,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should keep 0.5 decimals', () => {
-		const rating = shallow(<StarRating ratingValue={1.5} />);
+		const rating = shallow(<StarRating rating={1.5} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(1);
@@ -176,7 +176,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should round u to 1 for decimals equal to 0.8', () => {
-		const rating = shallow(<StarRating ratingValue={4.8} />);
+		const rating = shallow(<StarRating rating={4.8} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(5);
@@ -185,7 +185,7 @@ describe('<StarRating />', () => {
 	});
 
 	it('should round up to 1 for decimals larger than 0.8', () => {
-		const rating = shallow(<StarRating ratingValue={3.9} />);
+		const rating = shallow(<StarRating rating={3.9} />);
 
 		getFullStarsNum(rating);
 		expect(getFullStarsNum(rating)).toEqual(4);

--- a/lib/components/StarRating/StarRating.tsx
+++ b/lib/components/StarRating/StarRating.tsx
@@ -1,3 +1,4 @@
+import { warning } from '@autoguru/utilities';
 import cx from 'clsx';
 import React, { FunctionComponent, memo, ReactElement } from 'react';
 import { StarHalfIcon, StarIcon } from '../../icons';
@@ -36,23 +37,24 @@ const starCssMap: Map<EStarType, string> = new Map([
 
 export interface IProps {
 	className?: string;
-	ratingValue: number;
+	ratingValue?: number; // @deprecated
+	rating: number;
 	size?: ESize;
 	label?: string;
 }
 
-const getStarIconType = (index: number, ratingValue: number): EStarType => {
-	if (index + 1 <= Math.floor(ratingValue)) {
+const getStarIconType = (index: number, rating: number): EStarType => {
+	if (index + 1 <= Math.floor(rating)) {
 		// Is definitely full star
 		return EStarType.Full;
 	}
 
-	if (index + 1 > Math.ceil(ratingValue)) {
+	if (index + 1 > Math.ceil(rating)) {
 		// Is definitely empty star
 		return EStarType.Empty;
 	}
 
-	const decimalPart = Math.round((ratingValue - index) * 1e1);
+	const decimalPart = Math.round((rating - index) * 1e1);
 
 	if (decimalPart <= 2) {
 		return EStarType.Empty;
@@ -67,10 +69,10 @@ const getStarIconType = (index: number, ratingValue: number): EStarType => {
 
 const getStar = (
 	index: number,
-	ratingValue: number = 0,
+	rating: number = 0,
 	size: ESize
 ): ReactElement => {
-	const starType = getStarIconType(index, ratingValue);
+	const starType = getStarIconType(index, rating);
 	const star: () => JSX.Element =
 		starType === EStarType.Half ? StarHalfIcon : StarIcon;
 
@@ -86,20 +88,35 @@ const getStar = (
 
 const StarRatingComponent: FunctionComponent<IProps> = ({
 	className = '',
+	rating,
+	ratingValue = void 0,
+	label = rating || ratingValue,
 	size = ESize.Medium,
-	ratingValue,
-	label = ratingValue,
-}) => (
-	<span className={cx([styles.root, className])}>
-		<span className={styles.starList}>
-			{new Array(totalStars)
-				.fill(0)
-				.map((_, index) => getStar(index, ratingValue, size))}
+}) => {
+	// @deprecated block
+	{
+		warning(
+			ratingValue !== void 0,
+			'The `ratingValue` prop is deprecated, please use the `rating` prop'
+		);
+
+		if (ratingValue !== void 0) {
+			rating = ratingValue;
+		}
+	}
+
+	return (
+		<span className={cx([styles.root, className])}>
+			<span className={styles.starList}>
+				{new Array(totalStars)
+					.fill(0)
+					.map((_, index) => getStar(index, rating, size))}
+			</span>
+			<DetailText size={labelSizeMap.get(size)} className={styles.label}>
+				{label}
+			</DetailText>
 		</span>
-		<DetailText size={labelSizeMap.get(size)} className={styles.label}>
-			{label}
-		</DetailText>
-	</span>
-);
+	);
+};
 
 export const StarRating = memo(StarRatingComponent);

--- a/lib/components/StarRating/stories.tsx
+++ b/lib/components/StarRating/stories.tsx
@@ -4,20 +4,20 @@ import React from 'react';
 import { EStarRatingSize, StarRating } from '.';
 
 const baseProps = () => ({
-	ratingValue: number('Rating', 2.7),
+	rating: number('Rating', 2.7),
 	size: select('Size', EStarRatingSize, EStarRatingSize.Medium),
 });
 
 storiesOf('Components|StarRating', module)
 	.add('default', () => (
-		<StarRating {...baseProps()} label={text('Label', '')} />
+		<StarRating {...baseProps()} label={text('Label', void 0)} />
 	))
 	.add('small size', () => (
-		<StarRating ratingValue={3.2} size={EStarRatingSize.Small} />
+		<StarRating rating={3.2} size={EStarRatingSize.Small} />
 	))
 	.add('medium size', () => (
-		<StarRating ratingValue={1.6} size={EStarRatingSize.Medium} />
+		<StarRating rating={1.6} size={EStarRatingSize.Medium} />
 	))
 	.add('with label', () => (
-		<StarRating ratingValue={3.9} label="product rating" />
+		<StarRating rating={3.9} label="product rating" />
 	));


### PR DESCRIPTION
With this PR I aim to address the pointlessly long prop `ratingValue`, and move to simply `rating`.

There is a backward support there, for with a console warn. This will be removed in future releases.

Seeing as the snapshot file for this component, is untouched, you can guarantee that there is no material change to the component itself.