### PR TITLE
feat(Button): Ref-forward to the "root" element

### DIFF
--- a/lib/components/Anchor/__snapshots__/Anchor.spec.jsx.snap
+++ b/lib/components/Anchor/__snapshots__/Anchor.spec.jsx.snap
@@ -35,7 +35,12 @@ exports[`<Anchor /> when custom component deprecated still work should match sna
 <a
   aria-disabled={false}
   className="root"
-  compnent={[Function]}
+  compnent={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "render": [Function],
+    }
+  }
   disabled={false}
   to="https://www.hellowrold.com"
 >
@@ -52,7 +57,7 @@ exports[`<Anchor /> when custom component deprecated still work should match sna
 `;
 
 exports[`<Anchor /> when custom component should match snapshot with label, icon custom component 1`] = `
-<Button
+<ForwardRef
   aria-disabled={false}
   className="root"
   disabled={false}
@@ -67,5 +72,5 @@ exports[`<Anchor /> when custom component should match snapshot with label, icon
   >
     Hello World!
   </Text>
-</Button>
+</ForwardRef>
 `;

--- a/lib/components/Button/style.scss
+++ b/lib/components/Button/style.scss
@@ -50,7 +50,8 @@ $widthSmall: 36px;
 	text-decoration: none;
 	cursor: pointer;
 	user-select: none;
-	transform: translate(0, 0);
+	transform: translate(0, 0) scale(1);
+	will-change: transform;
 	border-radius: var(--global--space--1);
 	transition: color 0.2s cubic-bezier(0, 0, 0.2, 1) 0s,
 		background-color 0.2s cubic-bezier(0, 0, 0.2, 1) 0s,
@@ -59,11 +60,11 @@ $widthSmall: 36px;
 		transform 0.2s cubic-bezier(0, 0, 0.2, 1) 0s;
 
 	@include isHoverState() {
-		transform: translate(0, -1px);
+		transform: translate(0, -1px) scale(1);
 	}
 
 	@include isActiveState() {
-		transform: translate(0, 1px);
+		transform: translate(0, 1px) scale(1);
 	}
 }
 


### PR DESCRIPTION
With this PR I aim to address 2 things, but mainly the addition of the `ref={}` prop to our `Buttons`, to allow us to access the "root" element of the Button, granted this is now a contract with this component, so comments here would be nice. And secondly, the `scale(1)`, so when we translate up, we don't blur the contents of the button.