### PR TITLE
fix(InputBase): Clear date no longer breaks ui

### DIFF
--- a/lib/components/DateInput/DateInput.tsx
+++ b/lib/components/DateInput/DateInput.tsx
@@ -3,13 +3,7 @@ import React, { memo } from 'react';
 
 import { withEnhancedInput } from '../InputBase';
 
-// @deprecated
-const DateInputComponent = withEnhancedInput(function DateInput({
-	field,
-	eventHandlers,
-	validation,
-	...rest
-}) {
+function DateInputComponent({ field, eventHandlers, validation, ...rest }) {
 	warning(field.value === '', `Date Input does not support empty values.`);
 
 	return (
@@ -21,9 +15,11 @@ const DateInputComponent = withEnhancedInput(function DateInput({
 			type="date"
 		/>
 	);
-});
+}
 
-export const DateInput = memo(DateInputComponent);
+DateInputComponent.primitiveType = 'date';
+
+export const DateInput = memo(withEnhancedInput(DateInputComponent));
 
 // @deprecated
 export const formatDate = (date: Date = new Date()) => {

--- a/lib/components/DateInput/stories.tsx
+++ b/lib/components/DateInput/stories.tsx
@@ -11,7 +11,6 @@ const todayStr: string = formatDate(
 );
 
 const sharedKnobs = placeholder => ({
-	value: text('Value', todayStr),
 	placeholder: text('Placeholder', placeholder),
 	disabled: boolean('disabled', false),
 	onChange: action('onChange'),
@@ -29,7 +28,11 @@ storiesOf('Components|Inputs/Date', module)
 		<DateInput name="date" {...sharedKnobs('What is your DOB?')} />
 	))
 	.add('with a value', () => (
-		<DateInput {...sharedKnobs('What is your DOB?')} name="abc" />
+		<DateInput
+			value={todayStr}
+			{...sharedKnobs('What is your DOB?')}
+			name="abc"
+		/>
 	))
 	.add('with hint text', () => (
 		<DateInput
@@ -40,6 +43,7 @@ storiesOf('Components|Inputs/Date', module)
 	))
 	.add('with validation', () => (
 		<DateInput
+			value={todayStr}
 			{...sharedKnobs('What is your DOB?')}
 			name="abc"
 			isValid={isValid(false)}
@@ -50,8 +54,8 @@ storiesOf('Components|Inputs/Date', module)
 	.add('disabled', () => (
 		<DateInput
 			disabled
+			value={todayStr}
 			placeholder="What si your DOB?"
-			value="1996-01-11"
 			name="abc"
 			hintText={text('Hint Text', 'dd/mm/yyy')}
 		/>

--- a/lib/components/InputBase/withEnhancedInput.tsx
+++ b/lib/components/InputBase/withEnhancedInput.tsx
@@ -51,7 +51,9 @@ export type WrappedComponentProps<IncomingProps = {}> = {
 } & IncomingProps;
 
 export function withEnhancedInput<IncomingProps = {}>(
-	WrappingComponent: ComponentType<WrappedComponentProps<IncomingProps>>,
+	WrappingComponent: ComponentType<WrappedComponentProps<IncomingProps>> & {
+		primitiveType: string;
+	},
 ): ComponentType<EnhanceInputProps<IncomingProps>> {
 	type TProps = EnhanceInputProps<IncomingProps>;
 
@@ -187,8 +189,10 @@ export function withEnhancedInput<IncomingProps = {}>(
 					<NotchedBase
 						id={id}
 						isEmpty={
-							this.state.value === '' ||
-							this.state.value === void 0
+							WrappingComponent.primitiveType === 'date' &&
+							this.state.value === ''
+								? false
+								: this.state.value === ''
 						}
 						isActive={this.state.isActive}
 						placeholder={placeholder}>

--- a/lib/components/NumberInput/NumberInput.tsx
+++ b/lib/components/NumberInput/NumberInput.tsx
@@ -4,21 +4,20 @@ import { withEnhancedInput } from '../InputBase';
 
 const isEdge: boolean = navigator && /edge/i.test(navigator.userAgent);
 
-const NumberInputComponent = withEnhancedInput(function NumberInput({
-	field,
-	eventHandlers,
-	validation,
-	...rest
-}) {
+const type = isEdge ? 'text' : 'number';
+
+function NumberInputComponent({ field, eventHandlers, validation, ...rest }) {
 	return (
 		<input
 			{...eventHandlers}
 			{...field}
 			{...rest}
 			autoComplete="off"
-			type={isEdge ? 'text' : 'number'}
+			type={type}
 		/>
 	);
-});
+}
 
-export const NumberInput = memo(NumberInputComponent);
+NumberInputComponent.primitiveType = type;
+
+export const NumberInput = memo(withEnhancedInput(NumberInputComponent));

--- a/lib/components/NumberInput/__snapshots__/NumberInput.spec.jsx.snap
+++ b/lib/components/NumberInput/__snapshots__/NumberInput.spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<NumberInput /> should match snapshot for active number input 1`] = `
-<EnhancedInput(NumberInput)
+<EnhancedInput(NumberInputComponent)
   className="number-input-class"
   placeholder="placeholder something"
 >
@@ -16,7 +16,7 @@ exports[`<NumberInput /> should match snapshot for active number input 1`] = `
       <div
         className="notchedBase notchedBaseShift notchedBaseActive"
       >
-        <NumberInput
+        <NumberInputComponent
           eventHandlers={
             Object {
               "onBlur": [Function],
@@ -50,7 +50,7 @@ exports[`<NumberInput /> should match snapshot for active number input 1`] = `
             type="number"
             value={3}
           />
-        </NumberInput>
+        </NumberInputComponent>
         <div
           className="notchedBaseBorder"
         >
@@ -78,7 +78,7 @@ exports[`<NumberInput /> should match snapshot for active number input 1`] = `
       </div>
     </NotchedBase>
   </div>
-</EnhancedInput(NumberInput)>
+</EnhancedInput(NumberInputComponent)>
 `;
 
 exports[`<NumberInput /> should match snapshot for default number input 1`] = `

--- a/lib/components/SelectInput/SelectInput.tsx
+++ b/lib/components/SelectInput/SelectInput.tsx
@@ -3,12 +3,7 @@ import { ChevronDownIcon, Icon } from '../Icon';
 import { withEnhancedInput } from '../InputBase';
 import styles from './style.scss';
 
-const SelectInputComponent = withEnhancedInput(function SelectInput({
-	field,
-	eventHandlers,
-	validation,
-	...rest
-}) {
+function SelectInputComponent({ field, eventHandlers, validation, ...rest }) {
 	return (
 		<>
 			<select
@@ -20,6 +15,8 @@ const SelectInputComponent = withEnhancedInput(function SelectInput({
 			<Icon className={styles.arrow} size={25} icon={ChevronDownIcon} />
 		</>
 	);
-});
+}
 
-export const SelectInput = memo(SelectInputComponent);
+SelectInputComponent.primitiveType = 'select';
+
+export const SelectInput = memo(withEnhancedInput(SelectInputComponent));

--- a/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
+++ b/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<SelectInput /> should match snapshot for active select input 1`] = `
-<EnhancedInput(SelectInput)
+<EnhancedInput(SelectInputComponent)
   className="select-input-class"
   placeholder="Hello World!"
 >
@@ -16,7 +16,7 @@ exports[`<SelectInput /> should match snapshot for active select input 1`] = `
       <div
         className="notchedBase notchedBaseShift notchedBaseActive"
       >
-        <SelectInput
+        <SelectInputComponent
           eventHandlers={
             Object {
               "onBlur": [Function],
@@ -79,7 +79,7 @@ exports[`<SelectInput /> should match snapshot for active select input 1`] = `
               </svg>
             </i>
           </IconComponent>
-        </SelectInput>
+        </SelectInputComponent>
         <div
           className="notchedBaseBorder"
         >
@@ -107,7 +107,7 @@ exports[`<SelectInput /> should match snapshot for active select input 1`] = `
       </div>
     </NotchedBase>
   </div>
-</EnhancedInput(SelectInput)>
+</EnhancedInput(SelectInputComponent)>
 `;
 
 exports[`<SelectInput /> should match snapshot for default select input 1`] = `

--- a/lib/components/TextAreaInput/TextAreaInput.spec.jsx
+++ b/lib/components/TextAreaInput/TextAreaInput.spec.jsx
@@ -30,7 +30,7 @@ describe('<TextAreaInput />', () => {
 		textAreaInput.unmount();
 	});
 
-	it('should match snapshot for default select input', () => {
+	it('should match snapshot for default textarea input', () => {
 		const textAreaInput = render(
 			<TextAreaInput
 				className="textarea-input-class"

--- a/lib/components/TextAreaInput/TextAreaInput.tsx
+++ b/lib/components/TextAreaInput/TextAreaInput.tsx
@@ -2,15 +2,12 @@ import React, { memo } from 'react';
 
 import { withEnhancedInput } from '../InputBase';
 
-const TextAreaInputComponent = withEnhancedInput(function TextAreaInput({
-	field,
-	eventHandlers,
-	validation,
-	...rest
-}) {
+function TextAreaInputComponent({ field, eventHandlers, validation, ...rest }) {
 	return (
 		<textarea {...eventHandlers} {...field} {...rest} autoComplete="off" />
 	);
-});
+}
 
-export const TextAreaInput = memo(TextAreaInputComponent);
+TextAreaInputComponent.primitiveType = 'textarea';
+
+export const TextAreaInput = memo(withEnhancedInput(TextAreaInputComponent));

--- a/lib/components/TextAreaInput/__snapshots__/TextAreaInput.spec.jsx.snap
+++ b/lib/components/TextAreaInput/__snapshots__/TextAreaInput.spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<TextAreaInput /> should match snapshot for active select input 1`] = `
-<EnhancedInput(TextAreaInput)
+<EnhancedInput(TextAreaInputComponent)
   className="textarea-input-class"
   placeholder="placeholder something"
 >
@@ -16,7 +16,7 @@ exports[`<TextAreaInput /> should match snapshot for active select input 1`] = `
       <div
         className="notchedBase notchedBaseShift notchedBaseActive"
       >
-        <TextAreaInput
+        <TextAreaInputComponent
           eventHandlers={
             Object {
               "onBlur": [Function],
@@ -49,7 +49,7 @@ exports[`<TextAreaInput /> should match snapshot for active select input 1`] = `
             onFocus={[Function]}
             value="Test value"
           />
-        </TextAreaInput>
+        </TextAreaInputComponent>
         <div
           className="notchedBaseBorder"
         >
@@ -77,10 +77,10 @@ exports[`<TextAreaInput /> should match snapshot for active select input 1`] = `
       </div>
     </NotchedBase>
   </div>
-</EnhancedInput(TextAreaInput)>
+</EnhancedInput(TextAreaInputComponent)>
 `;
 
-exports[`<TextAreaInput /> should match snapshot for default select input 1`] = `
+exports[`<TextAreaInput /> should match snapshot for default textarea input 1`] = `
 <div
   class="root textarea-input-class"
 >

--- a/lib/components/TextInput/TextInput.tsx
+++ b/lib/components/TextInput/TextInput.tsx
@@ -2,12 +2,7 @@ import React, { memo } from 'react';
 
 import { withEnhancedInput } from '../InputBase';
 
-const TextInputComponent = withEnhancedInput(function TextInput({
-	field,
-	eventHandlers,
-	validation,
-	...rest
-}) {
+function TextInputComponent({ field, eventHandlers, validation, ...rest }) {
 	return (
 		<input
 			{...eventHandlers}
@@ -17,6 +12,8 @@ const TextInputComponent = withEnhancedInput(function TextInput({
 			type="text"
 		/>
 	);
-});
+}
 
-export const TextInput = memo(TextInputComponent);
+TextInputComponent.primitiveType = 'text';
+
+export const TextInput = memo(withEnhancedInput(TextInputComponent));

--- a/lib/components/TextInput/__snapshots__/TextInput.spec.jsx.snap
+++ b/lib/components/TextInput/__snapshots__/TextInput.spec.jsx.snap
@@ -84,7 +84,7 @@ exports[`<TextInput /> should match snapshot 1`] = `
 `;
 
 exports[`<TextInput /> should match snapshot for active text input 1`] = `
-<EnhancedInput(TextInput)
+<EnhancedInput(TextInputComponent)
   className="text-input-class"
   placeholder="placeholder something"
 >
@@ -99,7 +99,7 @@ exports[`<TextInput /> should match snapshot for active text input 1`] = `
       <div
         className="notchedBase notchedBaseShift notchedBaseActive"
       >
-        <TextInput
+        <TextInputComponent
           eventHandlers={
             Object {
               "onBlur": [Function],
@@ -133,7 +133,7 @@ exports[`<TextInput /> should match snapshot for active text input 1`] = `
             type="text"
             value="Test value"
           />
-        </TextInput>
+        </TextInputComponent>
         <div
           className="notchedBaseBorder"
         >
@@ -161,7 +161,7 @@ exports[`<TextInput /> should match snapshot for active text input 1`] = `
       </div>
     </NotchedBase>
   </div>
-</EnhancedInput(TextInput)>
+</EnhancedInput(TextInputComponent)>
 `;
 
 exports[`<TextInput /> should match snapshot for default text input 1`] = `


### PR DESCRIPTION
With this PR I aim to address the webkit clear button that clears date input values - this is a temporary solution until we implement a bespoke date picker.