### PR TITLE
fix(ModalBase): Backdrop taps now trigger on small viewports

### DIFF
--- a/lib/components/ModalBase/style.scss
+++ b/lib/components/ModalBase/style.scss
@@ -58,11 +58,10 @@
 	display: flex;
 	align-content: flex-end;
 	justify-content: center;
+	height: auto;
 	align-items: flex-end;
-	height: 100%;
 
 	@include isDesktop() {
-		height: auto;
 		align-items: center;
 	}
 }

--- a/lib/components/StandardModal/style.scss
+++ b/lib/components/StandardModal/style.scss
@@ -5,7 +5,8 @@
 	flex-direction: column;
 	background-color: white;
 	width: 100vw;
-	height: calc(100% - var(--global--space--8));
+	height: auto;
+	max-height: calc(100vh - var(--global--space--8));
 	border-radius: var(--global--space--2) var(--global--space--2) 0 0;
 	overflow: hidden;
 


### PR DESCRIPTION
This PR allows backdrops to be clickable "tap-able" to request a closure.