### PR TITLE
feat(TextLink): Hover states with inset shadow instead

### DIFF
--- a/lib/components/Typography/TextLink/TextLink.scss
+++ b/lib/components/Typography/TextLink/TextLink.scss
@@ -1,36 +1,19 @@
 @import '../../../theme/tokens/facade';
 
 .root {
-	position: relative;
+	box-shadow: inset 0 -2px 0 0 getColour(green, 400);
+	transition: box-shadow 0.2s cubic-bezier(0, 0, 0.2, 1) 0s;
 
 	&.strong {
-		&:after {
-			bottom: -1px;
-			height: 3px;
-		}
-
-		&:hover {
-			&:after {
-				height: calc(100% + 1px);
-			}
-		}
-	}
-
-	&:after {
-		position: absolute;
-		z-index: -1;
-		bottom: 0;
-		left: 0;
-		width: 100%;
-		height: 2px;
-		content: '';
-		background-color: getColour(green, 400);
-		transition: height 0.2s cubic-bezier(0, 0, 0.2, 1) 0s;
+		box-shadow: inset 0 -3px 0 0 getColour(green, 400);
 	}
 
 	&:hover {
-		&:after {
-			height: 100%;
-		}
+		box-shadow: inset 0 -1.6em 0 0 getColour(green, 400);
 	}
+}
+
+.anchor {
+	outline: none;
+	text-decoration: none;
 }

--- a/lib/components/Typography/TextLink/TextLink.tsx
+++ b/lib/components/Typography/TextLink/TextLink.tsx
@@ -56,13 +56,17 @@ export const TextLink: RefForwardingComponent<
 				<a
 					ref={ref as any}
 					rel={props.rel || 'noopener noreferrer'}
-					className={className}
+					className={clsx(className, styles.anchor)}
 					{...props}>
 					{body}
 				</a>
 			);
 		}
 
-		return cloneElement(as, { ref, className }, body);
+		return cloneElement(
+			as,
+			{ ref, className: clsx(className, styles.anchor) },
+			body,
+		);
 	},
 );

--- a/lib/components/Typography/TextLink/__snapshots__/TextLink.spec.jsx.snap
+++ b/lib/components/Typography/TextLink/__snapshots__/TextLink.spec.jsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<TextLink /> should allow as override 1`] = `
-<p>
+<p
+  class="anchor"
+>
   <span
     class="root sizeScale4 strong root strong"
   >
@@ -12,6 +14,7 @@ exports[`<TextLink /> should allow as override 1`] = `
 
 exports[`<TextLink /> should match the snapshot 1`] = `
 <a
+  class="anchor"
   rel="noopener noreferrer"
 >
   <span

--- a/lib/components/Typography/TextLink/stories.tsx
+++ b/lib/components/Typography/TextLink/stories.tsx
@@ -9,22 +9,19 @@ storiesOf('Foundation|Typography/TextLink', module)
 	.addDecorator(story => (
 		<div style={{ width: '100%', maxWidth: 300 }}>{story()}</div>
 	))
-	.add('default', () => {
-		return (
-			<>
-				<Text is="p">
-					Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-					Ad,{' '}
-					<TextLink href="test" strong={boolean('Strong', false)}>
-						Hello
-					</TextLink>{' '}
-					autem consectetur consequuntur eius ex{' '}
-					<TextLink href="test" strong={boolean('Strong', false)}>
-						Hello
-					</TextLink>{' '}
-					fugiat illo ipsum nobis numquam, officiis placeat quia,
-					quidem reprehenderit rerum temporibus veniam vero.
-				</Text>
-			</>
-		);
-	});
+	.add('default', () => (
+		<>
+			<Text is="p">
+				Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ad,{' '}
+				<TextLink href="test" strong={boolean('Strong', true)}>
+					Hello
+				</TextLink>{' '}
+				autem consectetur consequuntur eius ex{' '}
+				<TextLink href="test" strong={boolean('Strong', true)}>
+					Hello
+				</TextLink>{' '}
+				fugiat illo ipsum nobis numquam, officiis placeat quia, quidem
+				reprehenderit rerum temporibus veniam vero.
+			</Text>
+		</>
+	));


### PR DESCRIPTION
With this PR I aim to bring anchors back into flow, which essentially alleviates the need for position: absolute