### PR TITLE
feat(OutsideClick): OutsideClick exposed as a utility component

### DIFF
--- a/lib/components/ModalBase/ModalPortal.tsx
+++ b/lib/components/ModalBase/ModalPortal.tsx
@@ -2,11 +2,12 @@ import clsx from 'clsx';
 import React, {
 	FunctionComponent,
 	RefObject,
-	useEffect,
+	useCallback,
 	useLayoutEffect,
 	useRef,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { useOutsideClick } from '../OutsideClick';
 import { ECloseCode } from './enums';
 import styles from './style.scss';
 
@@ -33,19 +34,14 @@ export const ModalPortal: FunctionComponent<Props> = ({
 		};
 	}, [isOpen]);
 
-	useEffect(() => {
-		if (typeof window === 'undefined') return void 0;
-
-		function callback(e: any) {
-			if (!contentRef.current.contains(e.target) && isOpen) {
+	useOutsideClick(
+		[contentRef],
+		useCallback(() => {
+			if (isOpen) {
 				onRequestClose(ECloseCode.Overlay);
 			}
-		}
-
-		document.body.addEventListener('mouseup', callback);
-
-		return () => document.body.removeEventListener('mouseup', callback);
-	}, [isOpen, onRequestClose]);
+		}, [onRequestClose, isOpen]),
+	);
 
 	return createPortal(
 		<div

--- a/lib/components/OutsideClick/OutsideClick.spec.jsx
+++ b/lib/components/OutsideClick/OutsideClick.spec.jsx
@@ -1,0 +1,68 @@
+import React, { useRef } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { OutsideClick, useOutsideClick } from '.';
+
+describe('<OutsideClick />', () => {
+	it('should fire the callback when outside is clicked', () => {
+		const outsideClickHandler = jest.fn();
+
+		const { getByText } = render(
+			<>
+				<OutsideClick onOutsideClick={outsideClickHandler}>
+					<p>test</p>
+				</OutsideClick>
+				<p>click</p>
+			</>,
+		);
+
+		fireEvent.mouseUp(getByText('click'));
+
+		expect(outsideClickHandler).toHaveBeenCalledTimes(1);
+	});
+
+	describe('when useOutsideClick', () => {
+		const Example = ({ callback }) => {
+			const refA = useRef();
+			const refB = useRef();
+
+			useOutsideClick([refA, refB], callback);
+
+			return (
+				<>
+					<div ref={refA}>a</div>
+					<div ref={refB}>b</div>
+				</>
+			);
+		};
+
+		it('should callback outside when an array of refs', () => {
+			const outsideClickHandler = jest.fn();
+
+			const { getByText } = render(
+				<>
+					<Example callback={outsideClickHandler} />
+					<p>click</p>
+				</>,
+			);
+
+			fireEvent.mouseUp(getByText('click'));
+
+			expect(outsideClickHandler).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not callback outside when an array of refs', () => {
+			const outsideClickHandler = jest.fn();
+
+			const { getByText } = render(
+				<>
+					<Example callback={outsideClickHandler} />
+					<p>click</p>
+				</>,
+			);
+
+			fireEvent.mouseUp(getByText('a'));
+
+			expect(outsideClickHandler).toHaveBeenCalledTimes(0);
+		});
+	});
+});

--- a/lib/components/OutsideClick/OutsideClick.tsx
+++ b/lib/components/OutsideClick/OutsideClick.tsx
@@ -1,0 +1,68 @@
+import { warning } from '@autoguru/utilities';
+import {
+	Children,
+	cloneElement,
+	memo,
+	NamedExoticComponent,
+	ReactElement,
+	RefObject,
+	useEffect,
+	useRef,
+} from 'react';
+
+export const useOutsideClick = (
+	refs: Array<RefObject<HTMLElement>>,
+	onClickAway: () => void,
+) => {
+	useEffect(() => {
+		if (typeof window === 'undefined' || typeof onClickAway !== 'function')
+			return void 0;
+
+		const defaultEvents = ['mouseup', 'touchstart'];
+
+		const handler = event => {
+			if (
+				refs
+					.filter(item => Boolean(item.current))
+					.every(item => !item.current.contains(event.target))
+			) {
+				onClickAway();
+			}
+		};
+
+		defaultEvents.forEach(ev =>
+			document.body.addEventListener(ev, handler, {
+				passive: true,
+			}),
+		);
+
+		return () => {
+			defaultEvents.forEach(ev =>
+				document.body.removeEventListener(ev, handler),
+			);
+		};
+	}, [onClickAway, refs]);
+};
+
+interface Props {
+	children: ReactElement;
+
+	onOutsideClick?(): void;
+}
+
+export const OutsideClick: NamedExoticComponent<Props> = memo(
+	({ children, onOutsideClick = () => void 0 }) => {
+		warning(
+			true,
+			'This component overrides the child ref, use with caution.',
+		);
+
+		const rootClickRef = useRef<HTMLElement>();
+
+		useOutsideClick([rootClickRef], onOutsideClick);
+
+		return cloneElement(Children.only(children), {
+			ref: rootClickRef,
+		});
+	},
+);

--- a/lib/components/OutsideClick/index.ts
+++ b/lib/components/OutsideClick/index.ts
@@ -1,0 +1,1 @@
+export { useOutsideClick, OutsideClick } from './OutsideClick';

--- a/lib/components/OutsideClick/stories.tsx
+++ b/lib/components/OutsideClick/stories.tsx
@@ -1,0 +1,15 @@
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+
+import { OutsideClick } from '.';
+import { Button } from '../Button';
+
+storiesOf('Utility|OutsideClick', module).add('default', () => (
+	<OutsideClick
+		onOutsideClick={() => {
+			// eslint-disable-next-line no-alert
+			alert('clicking outside');
+		}}>
+		<Button>Click anywhere but here</Button>
+	</OutsideClick>
+));

--- a/lib/components/Positioner/stories.tsx
+++ b/lib/components/Positioner/stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import { select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React, { createRef, useCallback, useRef, useState } from 'react';
@@ -31,7 +32,8 @@ storiesOf('Utility|Positioner', module)
 					<Positioner
 						isOpen={isOpen}
 						triggerRef={triggerRef}
-						alignment={alignmentPicker()}>
+						alignment={alignmentPicker()}
+						onRequestClose={action('onRequestClose')}>
 						<Box distance={1}>
 							<div style={{ padding: 'var(--global--space--2)' }}>
 								Hello im from the consumer:{' '}
@@ -75,7 +77,8 @@ storiesOf('Utility|Positioner', module)
 						<Positioner
 							isOpen
 							triggerRef={triggerRef}
-							alignment={alignmentPicker()}>
+							alignment={alignmentPicker()}
+							onRequestClose={action('onRequestClose')}>
 							<Box distance={1}>
 								<div
 									style={{

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -24,6 +24,7 @@ export * from './LoadingBox';
 export * from './Meta';
 export * from './ModalBase';
 export * from './NumberInput';
+export * from './OutsideClick';
 export * from './Pagination';
 export * from './Positioner';
 export * from './ProgressSpinner';


### PR DESCRIPTION
With this PR I introduce a new component and hook:

- `useOutsideClick` which takes an array of refObjects, and a callback to fire when a click happens outside of those refs
- `<OutsideClick>` which requires exactly 1 child, and an `onOutsideClick` prop. This component is used for when you don't care about using the ref of the child itself. This will cloneElement. 🤷🏼‍♂️