### PR TITLE
feat(withEnhancedInput): Type safe events types

### DIFF
--- a/lib/components/DateInput/DateInput.tsx
+++ b/lib/components/DateInput/DateInput.tsx
@@ -26,7 +26,9 @@ function DateInputComponent({
 
 DateInputComponent.primitiveType = 'date';
 
-export const DateInput = memo(withEnhancedInput(DateInputComponent));
+export const DateInput = memo(
+	withEnhancedInput<{}, HTMLInputElement>(DateInputComponent),
+);
 
 // @deprecated
 export const formatDate = (date: Date = new Date()) => {

--- a/lib/components/NumberInput/NumberInput.tsx
+++ b/lib/components/NumberInput/NumberInput.tsx
@@ -28,4 +28,6 @@ function NumberInputComponent({
 
 NumberInputComponent.primitiveType = type;
 
-export const NumberInput = memo(withEnhancedInput(NumberInputComponent));
+export const NumberInput = memo(
+	withEnhancedInput<{}, HTMLInputElement>(NumberInputComponent),
+);

--- a/lib/components/SelectInput/SelectInput.tsx
+++ b/lib/components/SelectInput/SelectInput.tsx
@@ -26,7 +26,7 @@ const SelectInputComponent = ({
 SelectInputComponent.primitiveType = 'select';
 
 export const SelectInput = memo(
-	withEnhancedInput(SelectInputComponent, {
+	withEnhancedInput<{}, HTMLSelectElement>(SelectInputComponent, {
 		withSuffixIcon: false,
 		withForcedSuffixIconPadding: true,
 	}),

--- a/lib/components/TextAreaInput/TextAreaInput.tsx
+++ b/lib/components/TextAreaInput/TextAreaInput.tsx
@@ -18,7 +18,7 @@ const TextAreaInputComponent = ({
 TextAreaInputComponent.primitiveType = 'textarea';
 
 export const TextAreaInput = memo(
-	withEnhancedInput(TextAreaInputComponent, {
+	withEnhancedInput<{}, HTMLTextAreaElement>(TextAreaInputComponent, {
 		withSuffixIcon: false,
 		withPrefixIcon: false,
 	}),

--- a/lib/components/TextInput/TextInput.tsx
+++ b/lib/components/TextInput/TextInput.tsx
@@ -23,4 +23,6 @@ function TextInputComponent({
 
 TextInputComponent.primitiveType = 'text';
 
-export const TextInput = memo(withEnhancedInput(TextInputComponent));
+export const TextInput = memo(
+	withEnhancedInput<{}, HTMLInputElement>(TextInputComponent),
+);


### PR DESCRIPTION
With this event handlers will be type safe. React onChange handlers, dont have type information of them at the Element level, only at the attribute point. Which is why we have the EventHandler type and pass in the type. It would be a decision we'd need to make, if we pass in the `typescript:dom/HTML*Element` type, and construct the events ourselves, or if we pass in a `react/InputHTMLAttributes<typescript:dom/HTMLInputElement>` type, which we could then `Pick`. 

React:DOMAttributes, which will allow a Pick, has incorrect types for onChange. So something like wouldnt work:
```
interface EventHandlers<PrimitiveElementType> extends Pick<DOMAttributes<PrimitiveElementType>, 'onChange' |
	'onBlur' |
	'onFocus' |
	'onKeyDown'> {
}
```

Working example:
<img width="836" alt="image" src="https://user-images.githubusercontent.com/599459/63905466-b76f4900-ca57-11e9-8e0f-526e56a9dfb4.png">

> Notice how `target` knows its an input html node.