### PR TITLE
feat(Toaster): Init impl of a notification manager component

### DIFF
--- a/lib/components/Alert/Alert.scss
+++ b/lib/components/Alert/Alert.scss
@@ -16,6 +16,7 @@ $buttonOffset: 8px;
 	box-shadow: var(--global--elevationBoxShadow--4);
 	background-color: white;
 	max-width: 650px;
+	min-width: 280px;
 
 	&.inline {
 		box-shadow: var(--global--elevationBoxShadow--2);

--- a/lib/components/Toaster/Toaster.scss
+++ b/lib/components/Toaster/Toaster.scss
@@ -1,0 +1,16 @@
+.root {
+	position: fixed;
+	top: var(--global--space--3);
+	left: 0;
+	right: 0;
+	display: grid;
+	grid-template-rows: 1fr;
+	justify-items: center;
+	align-items: center;
+}
+
+.alert {
+	&:not(:last-of-type) {
+		margin-bottom: var(--global--space--2);
+	}
+}

--- a/lib/components/Toaster/index.ts
+++ b/lib/components/Toaster/index.ts
@@ -1,0 +1,1 @@
+export { toast } from './toast';

--- a/lib/components/Toaster/stories.tsx
+++ b/lib/components/Toaster/stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { Button } from '../Button';
+import { Text } from '../Typography';
+import { toast } from '.';
+
+export default { title: 'Utility|Toaster' };
+
+export const standard = () => {
+	const doThing = () => {
+		delay(() => toast.success('test'));
+		delay(() => toast.danger(<Text>test</Text>));
+		delay(() => toast(<Text>test</Text>));
+	};
+
+	return <Button onClick={() => doThing()}>Toast 🍻</Button>;
+};
+
+let count = 0;
+
+function delay(cb) {
+	setTimeout(() => cb(), 1e3 * ++count);
+}

--- a/lib/components/Toaster/toast.spec.js
+++ b/lib/components/Toaster/toast.spec.js
@@ -1,0 +1,13 @@
+import { act } from '@testing-library/react';
+
+import { toast } from '.';
+
+describe('toast', () => {
+	it('should run no problem', () => {
+		act(() => {
+			toast('test message');
+		});
+
+		expect(document.body).toHaveTextContent('message');
+	});
+});

--- a/lib/components/Toaster/toast.tsx
+++ b/lib/components/Toaster/toast.tsx
@@ -1,0 +1,176 @@
+import React, {
+	Dispatch,
+	FunctionComponent,
+	ReactElement,
+	ReactText,
+	Reducer,
+	ReducerAction,
+	useEffect,
+	useLayoutEffect,
+	useReducer,
+} from 'react';
+import { render } from 'react-dom';
+
+import { Alert, EAlertIntent } from '../Alert';
+import styles from './Toaster.scss';
+
+type MessageType = ReactText | ReactElement;
+
+interface MessageConfig {
+	message: MessageType;
+	intent: EAlertIntent;
+	id: number;
+	duration: number;
+}
+
+interface ToastFn
+	extends Required<
+		Record<
+			EAlertIntent,
+			(message: MessageType, duration?: number) => () => void
+		>
+	> {
+	(message: MessageType, duration?: number): () => void;
+}
+
+enum ActionTypes {
+	ADD,
+	REMOVE,
+}
+
+type Actions =
+	| { type: ActionTypes.ADD; config: MessageConfig }
+	| { type: ActionTypes.REMOVE; id: number };
+
+let portalInstance = null;
+let dispatchFn: Dispatch<Actions>;
+let preMountQueue: Array<Readonly<MessageConfig>> = [];
+const DEFAULT_DURATION = 5e3;
+
+let ids = -1;
+const getNewId = () => ++ids;
+
+const init = () => {
+	const onMount = dispatcher => {
+		dispatchFn = dispatcher;
+		preMountQueue.forEach(config =>
+			dispatcher({ type: ActionTypes.ADD, config }),
+		);
+		preMountQueue = [];
+	};
+
+	if (portalInstance === null && typeof window !== 'undefined') {
+		portalInstance = document.createElement('div');
+		portalInstance.className = styles.root;
+		portalInstance.setAttribute('data-toast-owner', 'overdrive');
+		document.body.append(portalInstance);
+
+		render(<ToastManager onMount={onMount} />, portalInstance);
+	}
+};
+
+export const container = () => {
+	if (portalInstance === null) {
+		init();
+	}
+
+	return {
+		dispatch(message: MessageType, duration: number, intent: EAlertIntent) {
+			const config: MessageConfig = {
+				id: getNewId(),
+				message,
+				intent,
+				duration,
+			};
+
+			if (portalInstance === null || typeof dispatchFn === 'undefined') {
+				preMountQueue.push(config);
+			} else {
+				dispatchFn({ type: ActionTypes.ADD, config });
+			}
+
+			return () => {
+				dispatchFn({ type: ActionTypes.REMOVE, id: config.id });
+			};
+		},
+	};
+};
+
+type ToastManagerReducer = Reducer<{ messages: MessageConfig[] }, Actions>;
+const toastManagerReducer: ToastManagerReducer = (prevState, action) => {
+	switch (action.type) {
+		default:
+		case ActionTypes.ADD: {
+			return {
+				messages: [...prevState.messages, action.config],
+			};
+		}
+
+		case ActionTypes.REMOVE: {
+			return {
+				messages: prevState.messages.filter(
+					item => item.id !== action.id,
+				),
+			};
+		}
+	}
+};
+
+const ToastManager: FunctionComponent<{
+	onMount: (dispatch: Dispatch<Actions>) => void;
+}> = ({ onMount }) => {
+	const [state, dispatch] = useReducer<ToastManagerReducer>(
+		toastManagerReducer,
+		{ messages: [] },
+	);
+
+	useEffect(() => {
+		onMount(dispatch);
+	}, []);
+
+	return (
+		<>
+			{state.messages.map(item => (
+				<Toast key={item.id} {...item} dispatch={dispatch} />
+			))}
+		</>
+	);
+};
+
+const Toast: FunctionComponent<
+	MessageConfig & { dispatch: Dispatch<ReducerAction<ToastManagerReducer>> }
+> = ({ dispatch, duration, message, id, intent }) => {
+	useLayoutEffect(() => {
+		const timeout = setTimeout(() => {
+			dispatch({ type: ActionTypes.REMOVE, id });
+		}, duration);
+
+		return () => {
+			clearTimeout(timeout);
+		};
+	}, []);
+
+	return (
+		<Alert
+			dismissible
+			intent={intent}
+			className={styles.alert}
+			onRequestClose={() => {
+				dispatch({ type: ActionTypes.REMOVE, id });
+			}}>
+			{message}
+		</Alert>
+	);
+};
+
+export const toast: ToastFn = (message, duration = DEFAULT_DURATION) =>
+	container().dispatch(message, duration, EAlertIntent.info);
+
+toast.success = (message, duration = DEFAULT_DURATION) =>
+	container().dispatch(message, duration, EAlertIntent.success);
+toast.danger = (message, duration = DEFAULT_DURATION) =>
+	container().dispatch(message, duration, EAlertIntent.danger);
+toast.info = (message, duration = DEFAULT_DURATION) =>
+	container().dispatch(message, duration, EAlertIntent.info);
+toast.warning = (message, duration = DEFAULT_DURATION) =>
+	container().dispatch(message, duration, EAlertIntent.warning);

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -42,5 +42,6 @@ export * from './Tabs';
 export * from './TextAreaInput';
 export * from './TextContainer';
 export * from './TextInput';
+export * from './Toaster';
 export * from './Tooltip';
 export * from './Typography';


### PR DESCRIPTION
The idea is to simply import `import { toast } from '@autoguru/overdrive';` and by calling that method, you get a toast to appear on the screen. And without needing to wire up a collector component.