### PR TITLE
feat: Utilise new scroll contain css property

### DIFF
--- a/lib/components/AutoSuggest/AutoSuggest.scss
+++ b/lib/components/AutoSuggest/AutoSuggest.scss
@@ -10,8 +10,9 @@
 .suggestionList {
 	display: grid;
 	overflow-y: auto;
-	max-height: 256px;
+	overscroll-behavior: contain;
 	-webkit-overflow-scrolling: touch;
+	max-height: 256px;
 	grid-auto-flow: row;
 	grid-gap: 0;
 }

--- a/lib/components/StandardModal/style.scss
+++ b/lib/components/StandardModal/style.scss
@@ -62,4 +62,6 @@
 	flex-grow: 1;
 	height: 100%;
 	overflow-y: auto;
+	overscroll-behavior: contain;
+	-webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
Albeit still in draft this feature will be very likely to make its way into the spec - and is currently supported by all major browsers we care about.

https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior