### PR TITLE
feat: Removes forced autosuggest from fullscreen autosuggest

### DIFF
--- a/lib/components/AutoSuggest/AutoSuggest.tsx
+++ b/lib/components/AutoSuggest/AutoSuggest.tsx
@@ -144,7 +144,6 @@ interface AutoSuggestFullscreenInputProps<PayloadType extends unknown>
 }
 
 const AutoSuggestFullscreenInput = <PayloadType extends unknown>({
-	autoFocus,
 	closeModal,
 
 	...props
@@ -161,7 +160,7 @@ const AutoSuggestFullscreenInput = <PayloadType extends unknown>({
 
 	return createPortal(
 		<div className={styles.fullScreenRoot}>
-			<AutoSuggestInput {...props} autoFocus inlineOptions />
+			<AutoSuggestInput {...props} inlineOptions />
 			<Button
 				minimal
 				rounded


### PR DESCRIPTION
By not enforcing autofocus on fullscreen AutoSuggest view, the consumer will have a chance to to automatically open virtual keyboard