### PR TITLE
feat: Anchors are now cursor pointer by default

### DIFF
--- a/.changeset/serious-cobras-sleep.md
+++ b/.changeset/serious-cobras-sleep.md
@@ -1,0 +1,7 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Anchors are now cursor pointer by default
+
+Seeing as we use `<TextLink />` or `<Box is="a" href="" />` in a few places, it only makes sense to use `a { cursor: pointer }`.

--- a/lib/components/Alert/__snapshots__/Alert.spec.jsx.snap
+++ b/lib/components/Alert/__snapshots__/Alert.spec.jsx.snap
@@ -23,7 +23,7 @@ exports[`<Alert /> should match the snapshot 1`] = `
   />
   <button
     aria-label="close"
-    class="base appearance button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base minimal_defaults_base minimalStates_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base enabled width_default closeButton"
+    class="base appearance cursorPointer button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base minimal_defaults_base minimalStates_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base enabled width_default closeButton"
     type="button"
   >
     <div

--- a/lib/components/Button/__snapshots__/Button.spec.jsx.snap
+++ b/lib/components/Button/__snapshots__/Button.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Button /> should match snapshot for default button 1`] = `
 <button
-  class="base appearance button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_default"
+  class="base appearance cursorPointer button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_default"
   type="button"
 >
   <div
@@ -13,7 +13,7 @@ exports[`<Button /> should match snapshot for default button 1`] = `
 
 exports[`<Button /> when as button should use html button element by default 1`] = `
 <button
-  class="base appearance button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_default"
+  class="base appearance cursorPointer button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_default"
   type="button"
 >
   <div
@@ -24,7 +24,7 @@ exports[`<Button /> when as button should use html button element by default 1`]
 
 exports[`<Button /> when colour variants should match snapshot for Danger button 1`] = `
 <button
-  class="base appearance button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_danger_base variant_danger_base size_medium_default_base enabled width_default"
+  class="base appearance cursorPointer button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_danger_base variant_danger_base size_medium_default_base enabled width_default"
   type="button"
 >
   <div
@@ -35,7 +35,7 @@ exports[`<Button /> when colour variants should match snapshot for Danger button
 
 exports[`<Button /> when colour variants should match snapshot for Primary button 1`] = `
 <button
-  class="base appearance button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_primary_base variant_primary_base size_medium_default_base enabled width_default"
+  class="base appearance cursorPointer button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_primary_base variant_primary_base size_medium_default_base enabled width_default"
   type="button"
 >
   <div
@@ -46,7 +46,7 @@ exports[`<Button /> when colour variants should match snapshot for Primary butto
 
 exports[`<Button /> when colour variants should match snapshot for Secondary button 1`] = `
 <button
-  class="base appearance button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_default"
+  class="base appearance cursorPointer button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_default"
   type="button"
 >
   <div
@@ -68,7 +68,7 @@ exports[`<Button /> when custom component should use html anchor element if href
 
 exports[`<Button /> when isFullWidth should match snapshot 1`] = `
 <button
-  class="base appearance button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_fullWidth"
+  class="base appearance cursorPointer button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_fullWidth"
   type="button"
 >
   <div
@@ -79,7 +79,7 @@ exports[`<Button /> when isFullWidth should match snapshot 1`] = `
 
 exports[`<Button /> when loading should match snapshot for default button 1`] = `
 <button
-  class="base appearance button none_mobile_base none_mobile_base none_mobile_base none_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base variant_secondary_base size_medium_default_base loading width_default"
+  class="base appearance cursorPointer button none_mobile_base none_mobile_base none_mobile_base none_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base variant_secondary_base size_medium_default_base loading width_default"
   disabled=""
   type="button"
 >
@@ -105,7 +105,7 @@ exports[`<Button /> when loading should match snapshot for default button 1`] = 
 
 exports[`<Button /> when loading should match snapshot for medium button 1`] = `
 <button
-  class="base appearance button none_mobile_base none_mobile_base none_mobile_base none_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base variant_secondary_base size_medium_default_base loading width_default"
+  class="base appearance cursorPointer button none_mobile_base none_mobile_base none_mobile_base none_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base variant_secondary_base size_medium_default_base loading width_default"
   disabled=""
   type="button"
 >
@@ -131,7 +131,7 @@ exports[`<Button /> when loading should match snapshot for medium button 1`] = `
 
 exports[`<Button /> when loading should match snapshot for small button 1`] = `
 <button
-  class="base appearance button none_mobile_base none_mobile_base none_mobile_base none_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base variant_secondary_base size_small_default_base loading width_default"
+  class="base appearance cursorPointer button none_mobile_base none_mobile_base none_mobile_base none_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base variant_secondary_base size_small_default_base loading width_default"
   disabled=""
   type="button"
 >
@@ -157,7 +157,7 @@ exports[`<Button /> when loading should match snapshot for small button 1`] = `
 
 exports[`<Button /> when rounded should match snapshot 1`] = `
 <button
-  class="base appearance button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base size_medium_rounded_base enabled width_default"
+  class="base appearance cursorPointer button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base size_medium_rounded_base enabled width_default"
   type="button"
 >
   <div
@@ -168,7 +168,7 @@ exports[`<Button /> when rounded should match snapshot 1`] = `
 
 exports[`<Button /> when size variant should match snapshot for medium button 1`] = `
 <button
-  class="base appearance button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_default"
+  class="base appearance cursorPointer button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_default"
   type="button"
 >
   <div
@@ -179,7 +179,7 @@ exports[`<Button /> when size variant should match snapshot for medium button 1`
 
 exports[`<Button /> when size variant should match snapshot for small button 1`] = `
 <button
-  class="base appearance button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_small_default_base enabled width_default"
+  class="base appearance cursorPointer button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_small_default_base enabled width_default"
   type="button"
 >
   <div

--- a/lib/components/Pagination/__snapshots__/Pagination.spec.jsx.snap
+++ b/lib/components/Pagination/__snapshots__/Pagination.spec.jsx.snap
@@ -22,13 +22,13 @@ exports[`<Pagination /> should match snapshot for loading phase 1`] = `
     </i>
   </span>
   <button
-    class="base appearance button bubble_disabled_base activeItem_default_base bubble_default_base"
+    class="base appearance cursorPointer button bubble_disabled_base activeItem_default_base bubble_default_base"
   />
   <button
-    class="base appearance button bubble_disabled_base activeItem_default_base bubble_default_base"
+    class="base appearance cursorPointer button bubble_disabled_base activeItem_default_base bubble_default_base"
   />
   <button
-    class="base appearance button bubble_disabled_base activeItem_default_base bubble_default_base"
+    class="base appearance cursorPointer button bubble_disabled_base activeItem_default_base bubble_default_base"
   />
   <span
     class="activeItem_default_base chevron_default_base chevron_disabled_base"

--- a/lib/components/SimplePagination/__snapshots__/SimplePagination.spec.jsx.snap
+++ b/lib/components/SimplePagination/__snapshots__/SimplePagination.spec.jsx.snap
@@ -7,7 +7,7 @@ exports[`<SimplePagination /> should match snapshot for hasNext 1`] = `
 >
   <button
     aria-label="previous page"
-    class="base appearance button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base disabled width_default pagination chevron_default_base chevron_disabled_base"
+    class="base appearance cursorPointer button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base disabled width_default pagination chevron_default_base chevron_disabled_base"
     disabled=""
     type="button"
   >
@@ -31,7 +31,7 @@ exports[`<SimplePagination /> should match snapshot for hasNext 1`] = `
   </button>
   <button
     aria-label="next page"
-    class="base appearance button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base enabled width_default pagination chevron_default_base"
+    class="base appearance cursorPointer button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base enabled width_default pagination chevron_default_base"
     type="button"
   >
     <div
@@ -62,7 +62,7 @@ exports[`<SimplePagination /> should match snapshot for hasNext and hasPrevious 
 >
   <button
     aria-label="previous page"
-    class="base appearance button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base enabled width_default pagination chevron_default_base"
+    class="base appearance cursorPointer button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base enabled width_default pagination chevron_default_base"
     type="button"
   >
     <div
@@ -85,7 +85,7 @@ exports[`<SimplePagination /> should match snapshot for hasNext and hasPrevious 
   </button>
   <button
     aria-label="next page"
-    class="base appearance button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base enabled width_default pagination chevron_default_base"
+    class="base appearance cursorPointer button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base enabled width_default pagination chevron_default_base"
     type="button"
   >
     <div
@@ -116,7 +116,7 @@ exports[`<SimplePagination /> should match snapshot for hasPrevious 1`] = `
 >
   <button
     aria-label="previous page"
-    class="base appearance button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base enabled width_default pagination chevron_default_base"
+    class="base appearance cursorPointer button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base enabled width_default pagination chevron_default_base"
     type="button"
   >
     <div
@@ -139,7 +139,7 @@ exports[`<SimplePagination /> should match snapshot for hasPrevious 1`] = `
   </button>
   <button
     aria-label="next page"
-    class="base appearance button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base disabled width_default pagination chevron_default_base chevron_disabled_base"
+    class="base appearance cursorPointer button none_mobile_base 3_mobile_base none_mobile_base 3_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base pill_mobile_base root_base themedButton_base variant_secondary_base size_small_default_base size_small_rounded_base size_small_iconOnly_base disabled width_default pagination chevron_default_base chevron_disabled_base"
     disabled=""
     type="button"
   >

--- a/lib/components/Stepper/__snapshots__/Stepper.spec.jsx.snap
+++ b/lib/components/Stepper/__snapshots__/Stepper.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`<Stepper /> should match snapshot with label formatter 1`] = `
 >
   <button
     aria-label="step down"
-    class="base appearance button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
+    class="base appearance cursorPointer button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
     tabindex="-1"
   >
     <i
@@ -32,7 +32,7 @@ exports[`<Stepper /> should match snapshot with label formatter 1`] = `
   </span>
   <button
     aria-label="step up"
-    class="base appearance button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
+    class="base appearance cursorPointer button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
     tabindex="-1"
   >
     <i
@@ -60,7 +60,7 @@ exports[`<Stepper /> should match snapshot with props 1`] = `
 >
   <button
     aria-label="step down"
-    class="base appearance button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
+    class="base appearance cursorPointer button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
     tabindex="-1"
   >
     <i
@@ -84,7 +84,7 @@ exports[`<Stepper /> should match snapshot with props 1`] = `
   </span>
   <button
     aria-label="step up"
-    class="base appearance button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
+    class="base appearance cursorPointer button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
     tabindex="-1"
   >
     <i
@@ -112,7 +112,7 @@ exports[`<Stepper /> should match snapshot without props 1`] = `
 >
   <button
     aria-label="step down"
-    class="base appearance button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
+    class="base appearance cursorPointer button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
     disabled=""
     tabindex="-1"
   >
@@ -137,7 +137,7 @@ exports[`<Stepper /> should match snapshot without props 1`] = `
   </span>
   <button
     aria-label="step up"
-    class="base appearance button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
+    class="base appearance cursorPointer button none_mobile_base none_mobile_base none_mobile_base none_mobile_base full_mobile_base handle_default_base flexCenter"
     disabled=""
     tabindex="-1"
   >

--- a/lib/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
+++ b/lib/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
@@ -11,7 +11,7 @@ exports[`<Tabs /> should allow id overriding 1`] = `
     <button
       aria-controls="tab-1-title-0"
       aria-selected="true"
-      class="base appearance button display_block navItem_default_base navItem_active_base"
+      class="base appearance cursorPointer button display_block navItem_default_base navItem_active_base"
       role="tab"
     >
       <span
@@ -23,7 +23,7 @@ exports[`<Tabs /> should allow id overriding 1`] = `
     <button
       aria-controls="tab-2-title-1"
       aria-selected="false"
-      class="base appearance button display_block navItem_default_base"
+      class="base appearance cursorPointer button display_block navItem_default_base"
       role="tab"
       tabindex="-1"
     >
@@ -36,7 +36,7 @@ exports[`<Tabs /> should allow id overriding 1`] = `
     <button
       aria-controls="tab-3-title-2"
       aria-selected="false"
-      class="base appearance button display_block navItem_default_base"
+      class="base appearance cursorPointer button display_block navItem_default_base"
       role="tab"
       tabindex="-1"
     >
@@ -73,7 +73,7 @@ exports[`<Tabs /> should allow rendering indications 1`] = `
     <button
       aria-controls="10-0-tab"
       aria-selected="true"
-      class="base appearance button display_block navItem_default_base navItem_active_base"
+      class="base appearance cursorPointer button display_block navItem_default_base navItem_active_base"
       role="tab"
     >
       <span
@@ -90,7 +90,7 @@ exports[`<Tabs /> should allow rendering indications 1`] = `
     <button
       aria-controls="10-1-tab"
       aria-selected="false"
-      class="base appearance button display_block navItem_default_base"
+      class="base appearance cursorPointer button display_block navItem_default_base"
       role="tab"
       tabindex="-1"
     >
@@ -108,7 +108,7 @@ exports[`<Tabs /> should allow rendering indications 1`] = `
     <button
       aria-controls="10-2-tab"
       aria-selected="false"
-      class="base appearance button display_block navItem_default_base"
+      class="base appearance cursorPointer button display_block navItem_default_base"
       role="tab"
       tabindex="-1"
     >
@@ -150,7 +150,7 @@ exports[`<Tabs /> should match snapshot (high level) 1`] = `
     <button
       aria-controls="1-0-tab"
       aria-selected="true"
-      class="base appearance button display_block navItem_default_base navItem_active_base"
+      class="base appearance cursorPointer button display_block navItem_default_base navItem_active_base"
       role="tab"
     >
       <span
@@ -162,7 +162,7 @@ exports[`<Tabs /> should match snapshot (high level) 1`] = `
     <button
       aria-controls="1-1-tab"
       aria-selected="false"
-      class="base appearance button display_block navItem_default_base"
+      class="base appearance cursorPointer button display_block navItem_default_base"
       role="tab"
       tabindex="-1"
     >
@@ -175,7 +175,7 @@ exports[`<Tabs /> should match snapshot (high level) 1`] = `
     <button
       aria-controls="1-2-tab"
       aria-selected="false"
-      class="base appearance button display_block navItem_default_base"
+      class="base appearance cursorPointer button display_block navItem_default_base"
       role="tab"
       tabindex="-1"
     >

--- a/lib/components/Typography/Anchor/__snapshots__/Anchor.spec.jsx.snap
+++ b/lib/components/Typography/Anchor/__snapshots__/Anchor.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Anchor /> should match snapshot with label, icon and to props 1`] = `
 <a
-  class="root_base base a"
+  class="root_base base cursorPointer a"
   href="https://www.autoguru.com.au"
 >
   <i
@@ -27,7 +27,7 @@ exports[`<Anchor /> should match snapshot with label, icon and to props 1`] = `
 
 exports[`<Anchor /> should match snapshot without label 1`] = `
 <a
-  class="root_base base a"
+  class="root_base base cursorPointer a"
 >
   <span
     class="base root_base sizes_4_base align_left colours_link_base fontWeight_bold_base"
@@ -37,7 +37,7 @@ exports[`<Anchor /> should match snapshot without label 1`] = `
 
 exports[`<Anchor /> when custom component should match snapshot with label, icon custom component 1`] = `
 <button
-  class="base appearance button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_default root_base base"
+  class="base appearance cursorPointer button none_mobile_base 4_mobile_base none_mobile_base 4_mobile_base display_inline-block border_style none_mobile_base none_mobile_base none_mobile_base none_mobile_base 1_mobile_base root_base themedButton_base defaultStates_secondary_base variant_secondary_base size_medium_default_base enabled width_default root_base base"
   type="button"
 >
   <div

--- a/lib/components/Typography/TextLink/__snapshots__/TextLink.spec.jsx.snap
+++ b/lib/components/Typography/TextLink/__snapshots__/TextLink.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`<TextLink /> should allow as override 1`] = `
 <a
   as="[object Object]"
-  class="base a anchor"
+  class="base cursorPointer a anchor"
   rel="noopener noreferrer"
 >
   <span
@@ -16,7 +16,7 @@ exports[`<TextLink /> should allow as override 1`] = `
 
 exports[`<TextLink /> should match the snapshot 1`] = `
 <a
-  class="base a anchor"
+  class="base cursorPointer a anchor"
   rel="noopener noreferrer"
 >
   <span

--- a/lib/reset/reset.treat.ts
+++ b/lib/reset/reset.treat.ts
@@ -12,15 +12,17 @@ const appearance = style({
 	appearance: 'none',
 });
 
+const cursorPointer = style({ cursor: 'pointer' });
+
 const block = style({ display: 'block' });
 const list = style({ listStyle: 'none' });
 
 const button = [
 	appearance,
+	cursorPointer,
 	style({
 		outline: 'none',
 		background: 'none',
-		cursor: 'pointer',
 		userSelect: 'none',
 	}),
 ];
@@ -54,10 +56,12 @@ const input = [
 	}),
 ];
 
-const a = style({
-	textDecoration: 'none',
-	color: 'inherit',
-});
+const a = [
+	cursorPointer,
+	style({
+		textDecoration: 'none',
+	}),
+];
 
 export const element = {
 	article: block,


### PR DESCRIPTION
Seeing as we use `<TextLink />` or `<Box is="a" href="" />` in a few places, it only makes sense to use `a { cursor: pointer }`.