### PR TITLE
feat(Tabs): Support stretching tablist items

### DIFF
--- a/.changeset/clean-tomatoes-leave.md
+++ b/.changeset/clean-tomatoes-leave.md
@@ -1,0 +1,22 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Tabs: Support stretching tablist items to the width of the container
+
+**FEATURES**
+
+**`<TabList />`**
+
+In small contexts, like sidebars, or mobile viewports with minimal tablist items. It makes sense to stretch items to meet the width of the container.
+
+eg:
+
+```
+<Tabs>
+    <TabList stretch>
+        <Tab>Tab a</Tab>
+        <Tab>Tab b</Tab>
+    </TabList>
+</Tabs>
+```

--- a/lib/components/Tabs/TabList.tsx
+++ b/lib/components/Tabs/TabList.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import * as React from 'react';
 import { Children, FunctionComponent } from 'react';
 import { useStyles } from 'react-treat';
@@ -6,7 +7,14 @@ import { Box } from '../Box';
 import { IndexContext } from './context';
 import * as styleRefs from './Tabs.treat';
 
-export const TabList: FunctionComponent = ({ children }) => {
+interface Props {
+	stretch?: boolean;
+}
+
+export const TabList: FunctionComponent<Props> = ({
+	children,
+	stretch = false,
+}) => {
 	const styles = useStyles(styleRefs);
 
 	return (
@@ -15,7 +23,9 @@ export const TabList: FunctionComponent = ({ children }) => {
 			borderWidthBottom="1"
 			borderColour="gray"
 			role="tablist"
-			className={styles.tabsList}>
+			className={clsx(styles.tabsList.root, {
+				[styles.tabsList.stretch]: stretch,
+			})}>
 			{Children.map(children, (child, index) => (
 				<IndexContext.Provider value={index}>
 					{child}

--- a/lib/components/Tabs/Tabs.treat.ts
+++ b/lib/components/Tabs/Tabs.treat.ts
@@ -3,10 +3,13 @@ import { style, styleMap } from 'treat';
 const lineBottomHeight = '1px';
 const size = '20px';
 
-export const tabsList = style({
-	display: 'flex',
-	flexWrap: 'nowrap',
-});
+export const tabsList = {
+	root: style({
+		display: 'flex',
+		flexWrap: 'nowrap',
+	}),
+	stretch: style({ justifyContent: 'space-between' }),
+};
 
 export const tabPane = style({
 	display: 'block',

--- a/lib/components/Tabs/Tabs.treat.ts
+++ b/lib/components/Tabs/Tabs.treat.ts
@@ -8,7 +8,9 @@ export const tabsList = {
 		display: 'flex',
 		flexWrap: 'nowrap',
 	}),
-	stretch: style({ justifyContent: 'space-between' }),
+	stretch: style({
+		justifyContent: 'space-between',
+	}),
 };
 
 export const tabPane = style({
@@ -58,6 +60,12 @@ export const navItem = {
 
 		':focus': {
 			color: theme.colours.gamut.green900,
+		},
+
+		selectors: {
+			[`${tabsList.stretch} &`]: {
+				flex: 'auto',
+			},
 		},
 	})),
 	active: style((theme) => ({

--- a/lib/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
+++ b/lib/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
@@ -5,7 +5,7 @@ exports[`<Tabs /> should allow id overriding 1`] = `
   class="base"
 >
   <div
-    class="base border_style border_colour_top_gray_base border_colour_right_gray_base border_colour_bottom_gray_base border_colour_left_gray_base none_mobile_base none_mobile_base 1_mobile_base none_mobile_base tabsList"
+    class="base border_style border_colour_top_gray_base border_colour_right_gray_base border_colour_bottom_gray_base border_colour_left_gray_base none_mobile_base none_mobile_base 1_mobile_base none_mobile_base tabsList_root"
     role="tablist"
   >
     <button
@@ -67,7 +67,7 @@ exports[`<Tabs /> should allow rendering indications 1`] = `
   class="base"
 >
   <div
-    class="base border_style border_colour_top_gray_base border_colour_right_gray_base border_colour_bottom_gray_base border_colour_left_gray_base none_mobile_base none_mobile_base 1_mobile_base none_mobile_base tabsList"
+    class="base border_style border_colour_top_gray_base border_colour_right_gray_base border_colour_bottom_gray_base border_colour_left_gray_base none_mobile_base none_mobile_base 1_mobile_base none_mobile_base tabsList_root"
     role="tablist"
   >
     <button
@@ -144,7 +144,7 @@ exports[`<Tabs /> should match snapshot (high level) 1`] = `
   class="base"
 >
   <div
-    class="base border_style border_colour_top_gray_base border_colour_right_gray_base border_colour_bottom_gray_base border_colour_left_gray_base none_mobile_base none_mobile_base 1_mobile_base none_mobile_base tabsList"
+    class="base border_style border_colour_top_gray_base border_colour_right_gray_base border_colour_bottom_gray_base border_colour_left_gray_base none_mobile_base none_mobile_base 1_mobile_base none_mobile_base tabsList_root"
     role="tablist"
   >
     <button

--- a/lib/components/Tabs/stories.tsx
+++ b/lib/components/Tabs/stories.tsx
@@ -66,6 +66,28 @@ export const TabsWithoutPanes = () => (
 	</>
 );
 
+export const WithStretch = () => (
+	<Tabs>
+		<TabList stretch>
+			<Tab>Tab 1</Tab>
+			<Tab>Tab 2</Tab>
+		</TabList>
+
+		<TabPanes>
+			<TabPane>Content A</TabPane>
+			<TabPane>
+				<Stack>
+					<TestChild label="5" />
+					<TestChild label="4" />
+					<TestChild label="3" />
+					<TestChild label="2" />
+					<TestChild label="1" />
+				</Stack>
+			</TabPane>
+		</TabPanes>
+	</Tabs>
+);
+
 const TestChild = ({ label }) => {
 	const [thing, sething] = useState(isChromatic() ? 0.5 : Math.random() * 5);
 


### PR DESCRIPTION
**FEATURES**

**`<TabList />`**

In small contexts, like sidebars, or mobile viewports with minimal tablist items. It makes sense to stretch items to meet the width of the container.

eg:

```
<Tabs>
    <TabList stretch>
        <Tab>Tab a</Tab>
        <Tab>Tab b</Tab>
    </TabList>
</Tabs>
```

---
[Playroom example](https://overdrive--616fd3a619b2285b3d37b6dca9e2bbf439923bd9.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8BlGYAuBLCA7ABAA4CGUUWuA5gBoC8AOiAMyMB89B+SAKsQEYBndp3xdefADJYBGfDIBOMDGAAWw0RrH9WABRi5yVJAHpx6zVr74K5MMWx5awJgF9WAeQBuMeVHkBXGBMzDgtLawMsOwdcJwBGOLcAYQgAW0IAGyUYKGDtUI08yWkMcyKhDhM0TBxcYRAXIA)