### PR TITLE
feat: Inline alignY prop

### DIFF
--- a/.changeset/tall-ravens-double.md
+++ b/.changeset/tall-ravens-double.md
@@ -1,0 +1,16 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Inline: Supporting alignY responsive prop
+StarRating: Consumes `<Inline />`
+
+**FEATURES**
+
+**`<Inline />`**
+
+Now supports an alignY responsive prop to vertically center its items to either `top | center | bottom`, eg: `<Inline alignY="center">`
+
+**`<StarRating />`**
+
+Uses the `<Inline />` component instead of columns, so should use less DOM

--- a/lib/components/Inline/Inline.treat.ts
+++ b/lib/components/Inline/Inline.treat.ts
@@ -1,7 +1,17 @@
 import { style } from 'treat';
 
+import { makeResponsiveStyle } from '../../utils';
+
 export const root = style({
 	display: 'flex',
 	justifyContent: 'flex-start',
 	flexWrap: 'wrap',
 });
+
+const alignRules = {
+	top: 'flex-start',
+	center: 'center',
+	bottom: 'flex-end',
+};
+
+export const align = makeResponsiveStyle(() => alignRules, 'alignItems');

--- a/lib/components/Inline/Inline.tsx
+++ b/lib/components/Inline/Inline.tsx
@@ -8,15 +8,20 @@ import {
 	useNegativeMarginLeft,
 	useNegativeMarginTop,
 } from '../../hooks/useNegativeMargin/useNegativeMargin';
-import { ResponsiveProp } from '../../utils';
+import { resolveResponsiveStyle, ResponsiveProp } from '../../utils';
 import { Box } from '../Box';
 import * as styleRefs from './Inline.treat';
 
 interface Props {
 	space?: ResponsiveProp<keyof Theme['space']>;
+	alignY?: ResponsiveProp<keyof typeof styleRefs.align>;
 }
 
-export const Inline: FunctionComponent<Props> = ({ children, space = '2' }) => {
+export const Inline: FunctionComponent<Props> = ({
+	children,
+	space = '2',
+	alignY,
+}) => {
 	const negativeMarginLeft = useNegativeMarginLeft(space);
 	const negativeMarginTop = useNegativeMarginTop(space);
 
@@ -24,7 +29,12 @@ export const Inline: FunctionComponent<Props> = ({ children, space = '2' }) => {
 
 	return (
 		<Box className={negativeMarginTop}>
-			<Box className={clsx(styles.root, negativeMarginLeft)}>
+			<Box
+				className={clsx(
+					styles.root,
+					negativeMarginLeft,
+					resolveResponsiveStyle(alignY, styles.align),
+				)}>
 				{Children.map(children, (child) => (
 					<Box
 						display="inline-block"

--- a/lib/components/StarRating/StarRating.treat.ts
+++ b/lib/components/StarRating/StarRating.treat.ts
@@ -1,16 +1,4 @@
-import { style, styleMap } from 'treat';
-
-export const starList = style({
-	display: 'flex',
-	alignContent: 'center',
-	alignItems: 'center',
-	flexDirection: 'row',
-	justifyContent: 'flex-start',
-	boxSizing: 'border-box',
-});
-export const label = style((theme) => ({
-	marginLeft: theme.space['2'],
-}));
+import { styleMap } from 'treat';
 
 export const star = styleMap((theme) => ({
 	default: {

--- a/lib/components/StarRating/StarRating.tsx
+++ b/lib/components/StarRating/StarRating.tsx
@@ -10,8 +10,9 @@ import {
 import { useStyles } from 'react-treat';
 import { Theme } from 'treat/theme';
 
-import { Column, Columns } from '../Columns';
+import { Box } from '../Box';
 import { Icon } from '../Icon';
+import { Inline } from '../Inline';
 import { Text } from '../Typography';
 import * as styleRefs from './StarRating.treat';
 
@@ -42,7 +43,7 @@ const labelSizeMap: Map<
 ]);
 
 interface Props {
-	className?: string;
+	className?: string; // TODO: Remove this in the future
 	rating: number;
 	size?: EStarRatingSize;
 	label?: string;
@@ -54,12 +55,10 @@ export const StarRating: NamedExoticComponent<Props> = memo(
 		rating,
 		label = rating,
 		size = EStarRatingSize.Medium,
-	}) => {
-		const styles = useStyles(styleRefs);
-
-		return (
-			<Columns className={clsx([styles.starList, className])} space="2">
-				<Column className={styles.starList}>
+	}) => (
+		<Box className={className}>
+			<Inline space="2" alignY="center">
+				<Inline space="none" alignY="center">
 					{new Array(totalStars).fill(0).map((_, index) => (
 						<Star
 							key={index}
@@ -68,19 +67,13 @@ export const StarRating: NamedExoticComponent<Props> = memo(
 							size={size}
 						/>
 					))}
-				</Column>
+				</Inline>
 				{label === null ? null : (
-					<Column>
-						<Text
-							size={labelSizeMap.get(size)}
-							className={styles.label}>
-							{label}
-						</Text>
-					</Column>
+					<Text size={labelSizeMap.get(size)}>{label}</Text>
 				)}
-			</Columns>
-		);
-	},
+			</Inline>
+		</Box>
+	),
 );
 
 const getStarIconType = (index: number, rating: number): EStarType => {

--- a/lib/components/StarRating/StarRating.tsx
+++ b/lib/components/StarRating/StarRating.tsx
@@ -57,7 +57,7 @@ export const StarRating: NamedExoticComponent<Props> = memo(
 		size = EStarRatingSize.Medium,
 	}) => (
 		<Box className={className}>
-			<Inline space="2" alignY="center">
+			<Inline space="4" alignY="center">
 				<Inline space="none" alignY="center">
 					{new Array(totalStars).fill(0).map((_, index) => (
 						<Star


### PR DESCRIPTION
**FEATURES**

**`<Inline />`**

Now supports an alignY responsive prop to vertically center its items to either `top | center | bottom`, eg: `<Inline alignY="center">`

**`<StarRating />`**

Uses the `<Inline />` component instead of columns, so should use less DOM