### PR TITLE
feat(AutoSuggest): Introduce an autoWidth prop to size the flyout

### DIFF
--- a/.changeset/shiny-rabbits-teach.md
+++ b/.changeset/shiny-rabbits-teach.md
@@ -1,0 +1,34 @@
+---
+'@autoguru/overdrive': patch
+---
+
+AutoSuggest: Introduce a autoWidth prop that either will size the flyout to
+either the width of the children, or the input.
+
+**FEATURES**
+
+`<AutoSuggest>` can now be given a `autoWidth` prop that will auto the width in
+relation to setting the width, or for it to be automatic.
+
+-   `autoWidth={true}` means, size the flyout to the width of flyout children
+    "automatically"
+-   `autoWidth={false}` means to set to the width of the select input.
+
+eg:
+
+```jsx
+
+// size to the width of the flyout children
+<AutoSuggest
+    placeholder="How are you?"
+    suggestions={[{ text: "Im an item" }]}
+    autoWidth
+/>
+
+// size to the width of the input (current behaviour)
+<AutoSuggest
+    placeholder="How are you?"
+    suggestions={[{ text: "Im an item" }]}
+/>
+
+```

--- a/lib/components/AutoSuggest/AutoSuggest.tsx
+++ b/lib/components/AutoSuggest/AutoSuggest.tsx
@@ -85,6 +85,7 @@ export interface Props<PayloadType>
 		'onChange' | 'value' | 'type'
 	> {
 	autoFocus?: boolean;
+	autoWidth?: boolean;
 	value: AutoSuggestValue<PayloadType> | null;
 	suggestions: Suggestions<PayloadType>;
 
@@ -197,6 +198,7 @@ const inputReducerFactory = <T extends Suggestions<unknown>>(
 export const AutoSuggest = forwardRef(function AutoSuggest(
 	{
 		autoFocus = false,
+		autoWidth = false,
 		suggestions,
 		value,
 		onChange: incomingOnChange,
@@ -243,7 +245,12 @@ export const AutoSuggest = forwardRef(function AutoSuggest(
 			closeModal={closeModal}
 		/>
 	) : (
-		<AutoSuggestInput ref={ref} {...props} autoFocus={autoFocus} />
+		<AutoSuggestInput
+			ref={ref}
+			{...props}
+			autoFocus={autoFocus}
+			autoWidth={autoWidth}
+		/>
 	);
 }) as <PayloadType extends unknown>(
 	p: Props<PayloadType> & { ref?: Ref<HTMLInputElement> },
@@ -295,6 +302,7 @@ const AutoSuggestInput = forwardRef(function AutoSuggestInput(
 	{
 		inlineOptions = false,
 		autoFocus,
+		autoWidth,
 		suggestions,
 		value,
 		onChange,
@@ -429,8 +437,9 @@ const AutoSuggestInput = forwardRef(function AutoSuggestInput(
 				/>
 			) : (
 				<SuggestionListFlyout
+					autoWidth={autoWidth!}
 					triggerRef={triggerRef}
-					alignment={EAlignment.BOTTOM}
+					alignment={EAlignment.BOTTOM_LEFT}
 					isOpen={shouldOpenFlyout}
 					triggerOffset={4}>
 					<SuggestionsList
@@ -591,22 +600,25 @@ const AutoSuggestInputPrimitive = withEnhancedInput(
 
 const getSuggestionId = (id: string, index: number) => `${id}-option-${index}`;
 
-const SuggestionListFlyout = usingPositioner(({ triggerRef, children }) => (
-	<Box
-		borderWidth="1"
-		borderColour="gray"
-		borderRadius="1"
-		backgroundColour="white"
-		boxShadow="2"
-		style={{
-			width: triggerRef.current
-				? triggerRef.current.clientWidth
-				: undefined,
-		}}
-		onMouseDown={(event) => event.preventDefault()}>
-		{children}
-	</Box>
-));
+const SuggestionListFlyout = usingPositioner<{ autoWidth: boolean }>(
+	({ triggerRef, autoWidth, children }) => (
+		<Box
+			borderWidth="1"
+			borderColour="gray"
+			borderRadius="1"
+			backgroundColour="white"
+			boxShadow="2"
+			style={{
+				width:
+					triggerRef.current && !autoWidth
+						? triggerRef.current.clientWidth
+						: undefined,
+			}}
+			onMouseDown={(event) => event.preventDefault()}>
+			{children}
+		</Box>
+	),
+);
 
 const defaultItemRenderer = <PayloadType extends unknown>({
 	value,


### PR DESCRIPTION
AutoSuggest: Introduce a autoWidth prop that either will size the flyout to
either the width of the children, or the input.

**FEATURES**

`<AutoSuggest>` can now be given a `autoWidth` prop that will auto the width in
relation to setting the width, or for it to be automatic.

-   `autoWidth={true}` means, size the flyout to the width of flyout children
    "automatically"
-   `autoWidth={false}` means to set to the width of the select input.

eg:

```jsx
// size to the width of the flyout children
<AutoSuggest
    placeholder="How are you?"
    suggestions={[{ text: "Im an item" }]}
    autoWidth
/>
// size to the width of the input (current behaviour)
<AutoSuggest
    placeholder="How are you?"
    suggestions={[{ text: "Im an item" }]}
/>
```
----

[Playroom link](https://overdrive--d1aae98f8315c2af54a52af8619c78eb85b67fb9.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8BlGYAuBLCA7AfADq4AEJSAQhAB4kAOAhlFFrgOYC8hIAbN0aTLkUGBmADWJAM6MwrTtz4gBQoUgCCAVwwQUmtmxhSMxVaroAbMTAAWEC7ABOXEAAkIAdxINHMEgE8ITQB+blMzMil9Q2McXCkOYABtYBIMGGoMeBJuAEkAW29SLHT87hIAXwBdCvCIhm0IAHUsKAwbRIxHTRhawVUAegE6tS0dPQMjE36zS2s7BxhnbncvHz9AkLCZ1SjJ2LwE5NT0zOy8woZi0vLqvoiyBp0Wto7gADMGCylekbIhkZIAYiMTiFTkAZUagCIFoTBxAQgCpAA)