### PR TITLE
feat(Box): Introduces overflow and passing in clsx compat prop

### DIFF
--- a/.changeset/good-elephants-study.md
+++ b/.changeset/good-elephants-study.md
@@ -1,0 +1,23 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Box: Adds an overflow prop and allows className to be clsx compatible
+
+**FEATURES**
+
+`ClassName` can now be sent in directly to Box instead of through clsx.
+
+eg.
+
+```diff
+- <Box className={clsx(styles.one, styles.two)}>
++ <Box className={[styles.one, styles.two]}>
+    Hello
+</Box>
+
+- <Box className={clsx({[styles.one]: maybeDoMe}, styles.two)}>
++ <Box className={[{[styles.one]: maybeDoMe}, styles.two]}>
+    Hello
+</Box>
+```

--- a/lib/components/Box/Box.tsx
+++ b/lib/components/Box/Box.tsx
@@ -11,9 +11,8 @@ import { BoxStyleProps, useBoxStyles } from './useBoxStyles';
 
 interface Props<Element extends keyof JSX.IntrinsicElements>
 	extends BoxStyleProps,
-		Omit<AllHTMLAttributes<Element>, 'width' | 'height'> {
+		Omit<AllHTMLAttributes<Element>, 'width' | 'height' | 'className'> {
 	is?: Element;
-	className?: string;
 }
 
 // TODO: Solve this any
@@ -22,7 +21,6 @@ export const Box = forwardRef<HTMLElement, Props<any>>(
 		{
 			is: Component,
 
-			display,
 			padding,
 			paddingX,
 			paddingY,
@@ -30,6 +28,7 @@ export const Box = forwardRef<HTMLElement, Props<any>>(
 			paddingBottom,
 			paddingLeft,
 			paddingRight,
+
 			margin,
 			marginX,
 			marginY,
@@ -37,14 +36,12 @@ export const Box = forwardRef<HTMLElement, Props<any>>(
 			marginBottom,
 			marginLeft,
 			marginRight,
-			boxShadow,
-			borderWidth,
-			borderWidthX,
-			borderWidthY,
-			borderWidthTop,
-			borderWidthRight,
-			borderWidthBottom,
-			borderWidthLeft,
+
+			display,
+			width,
+			position,
+			overflow,
+
 			borderColour,
 			borderColourX,
 			borderColourY,
@@ -52,55 +49,63 @@ export const Box = forwardRef<HTMLElement, Props<any>>(
 			borderColourRight,
 			borderColourBottom,
 			borderColourLeft,
+			borderWidth,
+			borderWidthX,
+			borderWidthY,
+			borderWidthTop,
+			borderWidthRight,
+			borderWidthBottom,
+			borderWidthLeft,
+
+			boxShadow,
 			borderRadius,
+
 			backgroundColour,
 
-			width,
-			position,
-
 			className = '',
-			children,
 
+			children,
 			...allOtherProps
 		},
 		ref,
 	) => {
 		const cls = useBoxStyles({
 			is: Component,
-			display,
+			backgroundColour,
 			borderColour,
-			padding,
-			paddingX,
-			paddingY,
-			paddingTop,
-			paddingBottom,
-			paddingLeft,
-			paddingRight,
+			borderColourBottom,
+			borderColourLeft,
+			borderColourRight,
+			borderColourTop,
+			borderColourX,
+			borderColourY,
+			borderRadius,
+			borderWidth,
+			borderWidthBottom,
+			borderWidthLeft,
+			borderWidthRight,
+			borderWidthTop,
+			borderWidthX,
+			borderWidthY,
+			boxShadow,
+			display,
 			margin,
-			marginX,
-			marginY,
-			marginTop,
 			marginBottom,
 			marginLeft,
 			marginRight,
-			boxShadow,
-			borderWidth,
-			borderWidthX,
-			borderWidthY,
-			borderWidthTop,
-			borderWidthRight,
-			borderWidthBottom,
-			borderWidthLeft,
-			borderColourX,
-			borderColourY,
-			borderColourTop,
-			borderColourRight,
-			borderColourBottom,
-			borderColourLeft,
-			borderRadius,
-			backgroundColour,
-			width,
+			marginTop,
+			marginX,
+			marginY,
+			overflow,
+			padding,
+			paddingBottom,
+			paddingLeft,
+			paddingRight,
+			paddingTop,
+			paddingX,
+			paddingY,
 			position,
+			width,
 		});
 
 		invariant(!isValidElement(Component), 'Box only supports intrinsics');

--- a/lib/components/Box/useBoxStyles.treat.ts
+++ b/lib/components/Box/useBoxStyles.treat.ts
@@ -87,10 +87,25 @@ export const width = styleMap({
 	},
 });
 
-const positionRules = {
-	absolute: 'absolute',
-	fixed: 'fixed',
-	relative: 'relative',
-};
+export const position = styleMap(
+	mapTokenToProperty(
+		{
+			absolute: 'absolute',
+			fixed: 'fixed',
+			relative: 'relative',
+		},
+		'position',
+	),
+);
 
-export const position = styleMap(mapTokenToProperty(positionRules, 'position'));
+export const overflow = styleMap(
+	mapTokenToProperty(
+		{
+			hidden: 'hidden',
+			scroll: 'scroll',
+			visible: 'visible',
+			auto: 'auto',
+		},
+		'overflow',
+	),
+);

--- a/lib/components/Box/useBoxStyles.ts
+++ b/lib/components/Box/useBoxStyles.ts
@@ -57,6 +57,10 @@ export interface BoxStyleProps extends Padding, Margin, Border {
 	width?: keyof typeof styleRefs.width;
 
 	backgroundColour?: keyof typeof styleRefs.backgroundColours;
+
+	overflow?: keyof typeof styleRefs.overflow;
+
+	className?: Parameters<typeof clsx>[0];
 }
 
 export const useBoxStyles = ({
@@ -95,6 +99,8 @@ export const useBoxStyles = ({
 	backgroundColour,
 	width,
 	position,
+	overflow,
+	className,
 }: BoxStyleProps) => {
 	const resetStyles = useStyles(resetStyleRefs);
 	const styles = useStyles(styleRefs);
@@ -135,6 +141,7 @@ export const useBoxStyles = ({
 
 	return clsx(
 		resetStyles.base,
+
 		is &&
 			typeof is === 'string' &&
 			resetStyles.element[is as keyof typeof resetStyles.element],
@@ -150,9 +157,9 @@ export const useBoxStyles = ({
 		resolveResponsiveStyle(resolvedMarginLeft, styles.margin.left),
 
 		styles.display[display!],
-
 		styles.width[width!],
 		styles.position[position!],
+		styles.overflow[overflow!],
 
 		hasBorder && styles.border.style,
 		hasBorder &&
@@ -197,5 +204,7 @@ export const useBoxStyles = ({
 			resolveResponsiveStyle(borderRadius, styles.borderRadius),
 
 		backgroundColour && styles.backgroundColours[backgroundColour],
+
+		className,
 	);
 };


### PR DESCRIPTION
Box: Adds an overflow prop and allows className to be clsx compatible

**FEATURES**

`ClassName` can now be sent in directly to Box instead of through clsx.

eg.

```diff
- <Box className={clsx(styles.one, styles.two)}>
+ <Box className={[styles.one, styles.two]}>
    Hello
</Box>
- <Box className={clsx({[styles.one]: maybeDoMe}, styles.two)}>
+ <Box className={[{[styles.one]: maybeDoMe}, styles.two]}>
    Hello
</Box>
```