### PR TITLE
feat(InputBase): Allows for notchless inputs

### DIFF
--- a/.changeset/breezy-horses-smoke.md
+++ b/.changeset/breezy-horses-smoke.md
@@ -6,7 +6,7 @@ InputBase: Allow for notchless inputs
 
 **FEATURES**
 
-Sometimes the notch behaviour won't work because of its context - much like an
+Sometimes the notch behavior won't work because of its context - much like an
 input that sites within a table, where the column already denotes what should be
 entered into the input.
 

--- a/.changeset/breezy-horses-smoke.md
+++ b/.changeset/breezy-horses-smoke.md
@@ -7,7 +7,7 @@ InputBase: Allow for notchless inputs
 **FEATURES**
 
 Sometimes the notch behavior won't work because of its context - much like an
-input that sites within a table, where the column already denotes what should be
+input that sits within a table, where the column already denotes what should be
 entered into the input.
 
 > Please be aware that this should be avoided, as in most cases we should notch,

--- a/.changeset/breezy-horses-smoke.md
+++ b/.changeset/breezy-horses-smoke.md
@@ -1,0 +1,14 @@
+---
+'@autoguru/overdrive': patch
+---
+
+InputBase: Allow for notchless inputs
+
+**FEATURES**
+
+Sometimes the notch behaviour won't work because of its context - much like an
+input that sites within a table, where the column already denotes what should be
+entered into the input.
+
+> Please be aware that this should be avoided, as in most cases we should notch,
+> so a user knows what's in the input especially when its defaulted.

--- a/lib/components/DateInput/__snapshots__/DateInput.spec.jsx.snap
+++ b/lib/components/DateInput/__snapshots__/DateInput.spec.jsx.snap
@@ -19,24 +19,24 @@ exports[`<DateInput /> should have some hintText 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base styleNode_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base styleNode_base placeholderPlacement_shifted_base"
           for="id"
         >
           placeholder
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -67,24 +67,24 @@ exports[`<DateInput /> should match snapshot 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base styleNode_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base styleNode_base placeholderPlacement_shifted_base"
           for="id"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -109,23 +109,23 @@ exports[`<DateInput /> should match snapshot when active 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_leading_base activeBorderColour_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_middle_base activeBorderColour_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base activeColour_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base activeColour_base placeholderPlacement_shifted_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_trailing_base activeBorderColour_base"
       />
     </div>
   </div>
@@ -150,23 +150,23 @@ exports[`<DateInput /> should match snapshot when touched 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base styleNode_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base styleNode_base placeholderPlacement_shifted_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -191,23 +191,23 @@ exports[`<DateInput /> should match snapshot when touched and invalid 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base styleNode_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base styleNode_base placeholderPlacement_shifted_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -232,23 +232,23 @@ exports[`<DateInput /> should match snapshot when touched and valid 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base styleNode_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base styleNode_base placeholderPlacement_shifted_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -297,23 +297,23 @@ exports[`<DateInput /> should match snapshot with both icons 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base styleNode_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base styleNode_base placeholderPlacement_shifted_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -350,23 +350,23 @@ exports[`<DateInput /> should match snapshot with prefix icon 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base styleNode_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base styleNode_base placeholderPlacement_shifted_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -403,23 +403,23 @@ exports[`<DateInput /> should match snapshot with suffix icon 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base styleNode_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base styleNode_base placeholderPlacement_shifted_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>

--- a/lib/components/InputBase/NotchedBase.treat.ts
+++ b/lib/components/InputBase/NotchedBase.treat.ts
@@ -8,35 +8,47 @@ export const root = style((theme) => ({
 	transition: `fill 0.2s ${theme.animation.easing.decelerate} 0s`,
 }));
 
-const borderDefaults = style((theme) => ({
+const borderRegionDefaults = style((theme) => ({
 	borderWidth: '1px',
 	borderStyle: 'solid',
 	display: 'inline-flex',
 	transition: `border-color 0.2s ${theme.animation.easing.decelerate} 0s`,
-	pointerEvents: 'none',
+}));
+
+const borderVisualDefaults = style((theme) => ({
+	borderRadius: theme.space['1'],
+	boxShadow:
+		'0 1px 10px 0 rgba(0,0,0,.03), 0 4px 5px 0 rgba(0,0,0,.03), 0 2px 4px -1px rgba(0,0,0,.05)',
 }));
 
 export const borders = {
-	root: styleMap((theme) => ({
-		default: {
-			position: 'absolute',
-			zIndex: 2,
-			top: 0,
-			right: 0,
-			left: 0,
-			display: 'flex',
-			width: '100%',
-			height: '100%',
-			textAlign: 'left',
-			pointerEvents: 'none',
-			borderRadius: theme.space['1'],
-			boxShadow:
-				'0 1px 10px 0 rgba(0,0,0,.03), 0 4px 5px 0 rgba(0,0,0,.03), 0 2px 4px -1px rgba(0,0,0,.05)',
-		},
-		disabled: { boxShadow: 'none' },
-	})),
+	root: {
+		default: [
+			borderVisualDefaults,
+			style({
+				position: 'absolute',
+				zIndex: 2,
+				top: 0,
+				right: 0,
+				left: 0,
+				display: 'flex',
+				width: '100%',
+				height: '100%',
+				textAlign: 'left',
+				pointerEvents: 'none',
+			}),
+		],
+		disabled: style({ boxShadow: 'none' }),
+	},
+	complete: [
+		borderVisualDefaults,
+		borderRegionDefaults,
+		style((theme) => ({
+			borderRadius: `${theme.space['1']}`,
+		})),
+	],
 	leading: [
-		borderDefaults,
+		borderRegionDefaults,
 		style((theme) => ({
 			width: theme.space['2'],
 			borderRight: 'none',
@@ -44,7 +56,7 @@ export const borders = {
 		})),
 	],
 	middle: [
-		borderDefaults,
+		borderRegionDefaults,
 		style((theme) => ({
 			transition: `width 0.15s ${theme.animation.easing.decelerate}, border-color 0.2s ${theme.animation.easing.decelerate} 0s`,
 			borderTopWidth: 0,
@@ -53,7 +65,7 @@ export const borders = {
 		})),
 	],
 	trailing: [
-		borderDefaults,
+		borderRegionDefaults,
 		style((theme) => ({
 			flexGrow: 1,
 			borderLeft: 'none',
@@ -63,19 +75,22 @@ export const borders = {
 };
 
 export const placeholder = {
-	default: style((theme) => ({
-		fontSize: theme.typography.size['4'].fontSize,
-		lineHeight: 1,
-		position: 'absolute',
-		top: 0,
-		left: 0,
-		display: 'inline',
-		margin: 0,
-		padding: 0,
-		transition: `color 0.2s ${theme.animation.easing.decelerate} 0s, transform 0.2s ${theme.animation.easing.decelerate} 0s`,
-		transformOrigin: 'top left',
-		whiteSpace: 'nowrap',
-		pointerEvents: 'none',
+	default: styleMap((theme) => ({
+		standard: {
+			fontSize: theme.typography.size['4'].fontSize,
+			lineHeight: 1,
+			position: 'absolute',
+			top: 0,
+			left: 0,
+			display: 'inline',
+			margin: 0,
+			padding: 0,
+			transition: `color 0.2s ${theme.animation.easing.decelerate} 0s, transform 0.2s ${theme.animation.easing.decelerate} 0s`,
+			transformOrigin: 'top left',
+			whiteSpace: 'nowrap',
+			pointerEvents: 'none',
+		},
+		notNotched: { display: 'none' },
 	})),
 	empty: style((theme) => ({ color: theme.colours.gamut.gray400 })),
 };

--- a/lib/components/InputBase/NotchedBase.tsx
+++ b/lib/components/InputBase/NotchedBase.tsx
@@ -18,6 +18,7 @@ interface Props {
 	prefixed: boolean;
 	borderColourClassName: string;
 	placeholderColourClassName: string;
+	notch?: boolean;
 	className?: string;
 }
 
@@ -28,6 +29,7 @@ export const NotchedBase: FunctionComponent<Props> = ({
 	disabled,
 	prefixed,
 	children,
+	notch = true,
 	borderColourClassName,
 	placeholderColourClassName,
 	className = '',
@@ -49,49 +51,58 @@ export const NotchedBase: FunctionComponent<Props> = ({
 	const notchedWidth = getNotchedComputedWidthForWidth(labelWidth);
 
 	return (
-		<Box className={clsx(styles.root, className)}>
+		<Box
+			className={clsx(
+				styles.root,
+				!notch && [styles.borders.complete, borderColourClassName],
+				className,
+			)}>
 			{children}
-			<div
-				className={clsx(styles.borders.root.default, {
-					[styles.borders.root.disabled]: disabled,
-				})}>
+			{notch && (
 				<div
-					className={clsx(
-						styles.borders.leading,
-						borderColourClassName,
-					)}
-				/>
-				<div
-					className={clsx(
-						styles.borders.middle,
-						borderColourClassName,
-					)}
-					style={{ width: isEmpty ? 0 : notchedWidth }}>
-					<label
-						ref={labelRef}
-						htmlFor={id}
+					className={clsx(styles.borders.root.default, {
+						[styles.borders.root.disabled]: disabled,
+					})}>
+					<div
 						className={clsx(
-							styles.placeholder.default,
-							placeholderColourClassName,
-							{
-								[styles.placeholder.empty]: isEmpty || disabled,
-								[styles.placeholderPlacement.default]:
-									isEmpty && !prefixed,
-								[styles.placeholderPlacement.defaultPrefixed]:
-									isEmpty && prefixed,
-								[styles.placeholderPlacement.shifted]: !isEmpty,
-							},
-						)}>
-						{placeholder}
-					</label>
+							styles.borders.leading,
+							borderColourClassName,
+						)}
+					/>
+					<div
+						className={clsx(
+							styles.borders.middle,
+							borderColourClassName,
+						)}
+						style={{ width: isEmpty ? 0 : notchedWidth }}>
+						<label
+							ref={labelRef}
+							htmlFor={id}
+							className={clsx(
+								styles.placeholder.default.standard,
+								placeholderColourClassName,
+								{
+									[styles.placeholder.empty]:
+										isEmpty || disabled,
+									[styles.placeholderPlacement.default]:
+										isEmpty && !prefixed,
+									[styles.placeholderPlacement
+										.defaultPrefixed]: isEmpty && prefixed,
+									[styles.placeholderPlacement
+										.shifted]: !isEmpty,
+								},
+							)}>
+							{placeholder}
+						</label>
+					</div>
+					<div
+						className={clsx(
+							styles.borders.trailing,
+							borderColourClassName,
+						)}
+					/>
 				</div>
-				<div
-					className={clsx(
-						styles.borders.trailing,
-						borderColourClassName,
-					)}
-				/>
-			</div>
+			)}
 		</Box>
 	);
 };

--- a/lib/components/InputBase/__snapshots__/NotchedBase.spec.jsx.snap
+++ b/lib/components/InputBase/__snapshots__/NotchedBase.spec.jsx.snap
@@ -5,23 +5,23 @@ exports[`<NotchedBase /> should match snapshot for active notch 1`] = `
   class="base root_base"
 >
   <div
-    class="borders_root_default_base"
+    class="borderVisualDefaults_base borders_root_default"
   >
     <div
-      class="borderDefaults_base borders_leading_base"
+      class="borderRegionDefaults_base borders_leading_base"
     />
     <div
-      class="borderDefaults_base borders_middle_base"
+      class="borderRegionDefaults_base borders_middle_base"
       style="width: 16px;"
     >
       <label
-        class="placeholder_default_base placeholderPlacement_shifted_base"
+        class="placeholder_default_standard_base placeholderPlacement_shifted_base"
       >
         placeholder something
       </label>
     </div>
     <div
-      class="borderDefaults_base borders_trailing_base"
+      class="borderRegionDefaults_base borders_trailing_base"
     />
   </div>
 </div>
@@ -32,23 +32,23 @@ exports[`<NotchedBase /> should match snapshot for default notch 1`] = `
   class="base root_base"
 >
   <div
-    class="borders_root_default_base"
+    class="borderVisualDefaults_base borders_root_default"
   >
     <div
-      class="borderDefaults_base borders_leading_base"
+      class="borderRegionDefaults_base borders_leading_base"
     />
     <div
-      class="borderDefaults_base borders_middle_base"
+      class="borderRegionDefaults_base borders_middle_base"
       style="width: 16px;"
     >
       <label
-        class="placeholder_default_base placeholderPlacement_shifted_base"
+        class="placeholder_default_standard_base placeholderPlacement_shifted_base"
       >
         placeholder something
       </label>
     </div>
     <div
-      class="borderDefaults_base borders_trailing_base"
+      class="borderRegionDefaults_base borders_trailing_base"
     />
   </div>
 </div>
@@ -59,23 +59,23 @@ exports[`<NotchedBase /> should match snapshot for dirty and active notch 1`] = 
   class="base root_base"
 >
   <div
-    class="borders_root_default_base"
+    class="borderVisualDefaults_base borders_root_default"
   >
     <div
-      class="borderDefaults_base borders_leading_base"
+      class="borderRegionDefaults_base borders_leading_base"
     />
     <div
-      class="borderDefaults_base borders_middle_base"
+      class="borderRegionDefaults_base borders_middle_base"
       style="width: 16px;"
     >
       <label
-        class="placeholder_default_base placeholderPlacement_shifted_base"
+        class="placeholder_default_standard_base placeholderPlacement_shifted_base"
       >
         placeholder something
       </label>
     </div>
     <div
-      class="borderDefaults_base borders_trailing_base"
+      class="borderRegionDefaults_base borders_trailing_base"
     />
   </div>
 </div>
@@ -86,23 +86,23 @@ exports[`<NotchedBase /> should match snapshot for dirty notch 1`] = `
   class="base root_base"
 >
   <div
-    class="borders_root_default_base"
+    class="borderVisualDefaults_base borders_root_default"
   >
     <div
-      class="borderDefaults_base borders_leading_base"
+      class="borderRegionDefaults_base borders_leading_base"
     />
     <div
-      class="borderDefaults_base borders_middle_base"
+      class="borderRegionDefaults_base borders_middle_base"
       style="width: 16px;"
     >
       <label
-        class="placeholder_default_base placeholderPlacement_shifted_base"
+        class="placeholder_default_standard_base placeholderPlacement_shifted_base"
       >
         placeholder something
       </label>
     </div>
     <div
-      class="borderDefaults_base borders_trailing_base"
+      class="borderRegionDefaults_base borders_trailing_base"
     />
   </div>
 </div>

--- a/lib/components/InputBase/withEnhancedInput.treat.ts
+++ b/lib/components/InputBase/withEnhancedInput.treat.ts
@@ -36,6 +36,12 @@ export const input = {
 					color: theme.colours.gamut.gray400,
 					cursor: 'not-allowed',
 				},
+				'&::placeholder': {
+					fontSize: theme.typography.size['4'].fontSize,
+					lineHeight: theme.typography.size['4'].lineHeight,
+					color: theme.colours.gamut.gray400,
+					opacity: 1,
+				},
 			},
 		},
 		prefixed: {

--- a/lib/components/InputBase/withEnhancedInput.tsx
+++ b/lib/components/InputBase/withEnhancedInput.tsx
@@ -46,6 +46,7 @@ export interface EnhanceInputPrimitiveProps extends AriaAttributes {
 	hintText?: string;
 	autoFocus?: boolean;
 	disabled?: boolean;
+	notch?: boolean;
 	prefixIcon?: IconType;
 	suffixIcon?: IconType;
 	wrapperRef?: Ref<HTMLDivElement>;
@@ -110,6 +111,7 @@ export const withEnhancedInput = <
 				className,
 				isTouched,
 				isValid,
+				notch = true,
 
 				value: incomingValue = '',
 				onChange: incomingOnChange,
@@ -218,6 +220,7 @@ export const withEnhancedInput = <
 					value,
 					autoFocus,
 					className: inputItselfClassName,
+					placeholder: notch ? undefined : placeholder,
 					ref,
 				},
 				prefixed: Boolean(prefixIcon),
@@ -244,6 +247,7 @@ export const withEnhancedInput = <
 						prefixed={Boolean(prefixIcon)}
 						isEmpty={isEmpty}
 						disabled={disabled}
+						notch={notch}
 						placeholder={placeholder}
 						placeholderColourClassName={clsx({
 							[derivedColours.colour]: !isEmpty,

--- a/lib/components/NumberInput/__snapshots__/NumberInput.spec.jsx.snap
+++ b/lib/components/NumberInput/__snapshots__/NumberInput.spec.jsx.snap
@@ -19,24 +19,24 @@ exports[`<NumberInput /> should have some hintText 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
           for="id"
         >
           placeholder
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -67,24 +67,24 @@ exports[`<NumberInput /> should match snapshot 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
           for="id"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -109,23 +109,23 @@ exports[`<NumberInput /> should match snapshot when active 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_leading_base activeBorderColour_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_middle_base activeBorderColour_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_trailing_base activeBorderColour_base"
       />
     </div>
   </div>
@@ -150,23 +150,23 @@ exports[`<NumberInput /> should match snapshot when touched 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -191,23 +191,23 @@ exports[`<NumberInput /> should match snapshot when touched and invalid 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -232,23 +232,23 @@ exports[`<NumberInput /> should match snapshot when touched and valid 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -297,23 +297,23 @@ exports[`<NumberInput /> should match snapshot with both icons 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_defaultPrefixed_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_defaultPrefixed_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -350,23 +350,23 @@ exports[`<NumberInput /> should match snapshot with prefix icon 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_defaultPrefixed_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_defaultPrefixed_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -403,23 +403,23 @@ exports[`<NumberInput /> should match snapshot with suffix icon 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>

--- a/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
+++ b/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
@@ -49,23 +49,23 @@ exports[`<SelectInput /> should have some hintText 1`] = `
       </div>
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           Hello World!
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -126,23 +126,23 @@ exports[`<SelectInput /> should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           Hello World!
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -198,23 +198,23 @@ exports[`<SelectInput /> should match snapshot when active 1`] = `
       </div>
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_leading_base activeBorderColour_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_middle_base activeBorderColour_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base activeColour_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base activeColour_base placeholderPlacement_shifted_base"
         >
           Hello World!
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_trailing_base activeBorderColour_base"
       />
     </div>
   </div>
@@ -270,23 +270,23 @@ exports[`<SelectInput /> should match snapshot when touched 1`] = `
       </div>
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           Hello World!
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -342,23 +342,23 @@ exports[`<SelectInput /> should match snapshot when touched and invalid 1`] = `
       </div>
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           Hello World!
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -414,23 +414,23 @@ exports[`<SelectInput /> should match snapshot when touched and valid 1`] = `
       </div>
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           Hello World!
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -482,23 +482,23 @@ exports[`<SelectInput /> should match snapshot with prefix icon 1`] = `
       </div>
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_defaultPrefixed_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_defaultPrefixed_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>

--- a/lib/components/TextAreaInput/__snapshots__/TextAreaInput.spec.jsx.snap
+++ b/lib/components/TextAreaInput/__snapshots__/TextAreaInput.spec.jsx.snap
@@ -17,24 +17,24 @@ exports[`<TextAreaInput /> should have some hintText 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
           for="id"
         >
           placeholder
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -63,24 +63,24 @@ exports[`<TextAreaInput /> should match snapshot 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
           for="id"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -105,23 +105,23 @@ exports[`<TextAreaInput /> should match snapshot when active 1`] = `
       </textarea>
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_leading_base activeBorderColour_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_middle_base activeBorderColour_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base activeColour_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base activeColour_base placeholderPlacement_shifted_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_trailing_base activeBorderColour_base"
       />
     </div>
   </div>
@@ -144,23 +144,23 @@ exports[`<TextAreaInput /> should match snapshot when touched 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -183,23 +183,23 @@ exports[`<TextAreaInput /> should match snapshot when touched and invalid 1`] = 
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -222,23 +222,23 @@ exports[`<TextAreaInput /> should match snapshot when touched and valid 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>

--- a/lib/components/TextInput/__snapshots__/TextInput.spec.jsx.snap
+++ b/lib/components/TextInput/__snapshots__/TextInput.spec.jsx.snap
@@ -19,24 +19,24 @@ exports[`<TextInput /> should have some hintText 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
           for="id"
         >
           placeholder
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -67,24 +67,24 @@ exports[`<TextInput /> should match snapshot 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
           for="id"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -109,23 +109,23 @@ exports[`<TextInput /> should match snapshot when active 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_leading_base activeBorderColour_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_middle_base activeBorderColour_base"
         style="width: 16px;"
       >
         <label
-          class="placeholder_default_base activeColour_base placeholderPlacement_shifted_base"
+          class="placeholder_default_standard_base activeColour_base placeholderPlacement_shifted_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base activeBorderColour_base"
+        class="borderRegionDefaults_base borders_trailing_base activeBorderColour_base"
       />
     </div>
   </div>
@@ -150,23 +150,23 @@ exports[`<TextInput /> should match snapshot when touched 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -191,23 +191,23 @@ exports[`<TextInput /> should match snapshot when touched and invalid 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -232,23 +232,23 @@ exports[`<TextInput /> should match snapshot when touched and valid 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -297,23 +297,23 @@ exports[`<TextInput /> should match snapshot with both icons 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_defaultPrefixed_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_defaultPrefixed_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -350,23 +350,23 @@ exports[`<TextInput /> should match snapshot with prefix icon 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_defaultPrefixed_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_defaultPrefixed_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>
@@ -403,23 +403,23 @@ exports[`<TextInput /> should match snapshot with suffix icon 1`] = `
       />
     </div>
     <div
-      class="borders_root_default_base"
+      class="borderVisualDefaults_base borders_root_default"
     >
       <div
-        class="borderDefaults_base borders_leading_base styleNode_base"
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
       />
       <div
-        class="borderDefaults_base borders_middle_base styleNode_base"
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
         style="width: 0px;"
       >
         <label
-          class="placeholder_default_base placeholder_empty_base placeholderPlacement_default_base"
+          class="placeholder_default_standard_base placeholder_empty_base placeholderPlacement_default_base"
         >
           placeholder something
         </label>
       </div>
       <div
-        class="borderDefaults_base borders_trailing_base styleNode_base"
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
       />
     </div>
   </div>


### PR DESCRIPTION
InputBase: Allow for notchless inputs

**FEATURES**

Sometimes the notch behaviour won't work because of its context - much like an
input that sits within a table, where the column already denotes what should be
entered into the input.

> Please be aware that this should be avoided, as in most cases we should notch,
> so a user knows what's in the input especially when its defaulted.

![image](https://user-images.githubusercontent.com/599459/80272049-783de880-8709-11ea-97b3-df50eb71636c.png)

[View here](https://overdrive--92aea34e2ec168bf86126605c943d7c1231c9622.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABABwIZSgEsA7AcwF4AdEAFmoD5LjNMkBlAF1zAGtMBnPGBIVqdEI2YtWAFRjoOASWLYArhxwAbbjAAWETbABOVEAAkIAd0y4jMTAE8IqgPzVMxCBzC7ywAGa4mvwwAL6YAPSS0rLySirqWjr6hjAm1BbWtvZOru5RTDFIcgrKahrY2mB6BsammTZ2js5uIB5ePn6BwWGYAG5BqjD1MJqaEPnR0sVxZYmVybVp9VaNOS3uA5pDI2MTbQVSSBGc3DySx2jokiChQA)

---

Technical:

- I fall back to a native placeholder when `notch={false}`.
- Validation states don't quite matter here, as the placeholder will either be grey or hidden in all cases.