### PR TITLE
fix(InputBase): Fullwidth the input wrapper

### DIFF
--- a/.changeset/tender-adults-yawn.md
+++ b/.changeset/tender-adults-yawn.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Input: Notchless inputs will no longer break when part of a flex container

--- a/lib/components/DateInput/__snapshots__/DateInput.spec.jsx.snap
+++ b/lib/components/DateInput/__snapshots__/DateInput.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`<DateInput /> should have some hintText 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -56,7 +56,7 @@ exports[`<DateInput /> should match snapshot 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -99,7 +99,7 @@ exports[`<DateInput /> should match snapshot when active 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -140,7 +140,7 @@ exports[`<DateInput /> should match snapshot when touched 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -181,7 +181,7 @@ exports[`<DateInput /> should match snapshot when touched and invalid 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -222,7 +222,7 @@ exports[`<DateInput /> should match snapshot when touched and valid 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -263,7 +263,7 @@ exports[`<DateInput /> should match snapshot with both icons 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <i
         class="base display_block iconRoot_base icon_prefix styleNode_base medium_mobile_base"
@@ -328,7 +328,7 @@ exports[`<DateInput /> should match snapshot with prefix icon 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <i
         class="base display_block iconRoot_base icon_prefix styleNode_base medium_mobile_base"
@@ -381,7 +381,7 @@ exports[`<DateInput /> should match snapshot with suffix icon 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <i
         class="base display_block iconRoot_base icon_suffix styleNode_base medium_mobile_base"

--- a/lib/components/InputBase/withEnhancedInput.treat.ts
+++ b/lib/components/InputBase/withEnhancedInput.treat.ts
@@ -16,7 +16,6 @@ export const icon = {
 
 export const input = {
 	root: style({
-		display: 'block',
 		height: '100%',
 	}),
 	itself: styleMap((theme) => ({

--- a/lib/components/InputBase/withEnhancedInput.tsx
+++ b/lib/components/InputBase/withEnhancedInput.tsx
@@ -253,9 +253,10 @@ export const withEnhancedInput = <
 							[derivedColours.colour]: !isEmpty,
 						})}
 						borderColourClassName={derivedColours.borderColour}>
-						<div
+						<Box
 							ref={wrapperRef}
-							className={clsx(styles.input.root)}>
+							width="full"
+							className={styles.input.root}>
 							{prefixIcon && (
 								<Icon
 									icon={prefixIcon}
@@ -277,7 +278,7 @@ export const withEnhancedInput = <
 								/>
 							)}
 							<WrappingComponent {...wrappingComponent} />
-						</div>
+						</Box>
 					</NotchedBase>
 					{!disabled && hintText?.length && (
 						<HintText className={derivedColours.colour}>

--- a/lib/components/NumberInput/__snapshots__/NumberInput.spec.jsx.snap
+++ b/lib/components/NumberInput/__snapshots__/NumberInput.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`<NumberInput /> should have some hintText 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -56,7 +56,7 @@ exports[`<NumberInput /> should match snapshot 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -99,7 +99,7 @@ exports[`<NumberInput /> should match snapshot when active 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -140,7 +140,7 @@ exports[`<NumberInput /> should match snapshot when touched 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -181,7 +181,7 @@ exports[`<NumberInput /> should match snapshot when touched and invalid 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -222,7 +222,7 @@ exports[`<NumberInput /> should match snapshot when touched and valid 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -263,7 +263,7 @@ exports[`<NumberInput /> should match snapshot with both icons 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <i
         class="base display_block iconRoot_base icon_prefix styleNode_base medium_mobile_base"
@@ -328,7 +328,7 @@ exports[`<NumberInput /> should match snapshot with prefix icon 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <i
         class="base display_block iconRoot_base icon_prefix styleNode_base medium_mobile_base"
@@ -381,7 +381,7 @@ exports[`<NumberInput /> should match snapshot with suffix icon 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <i
         class="base display_block iconRoot_base icon_suffix styleNode_base medium_mobile_base"

--- a/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
+++ b/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`<SelectInput /> should have some hintText 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <div
         class="base root"
@@ -85,7 +85,7 @@ exports[`<SelectInput /> should match snapshot 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <div
         class="base root"
@@ -157,7 +157,7 @@ exports[`<SelectInput /> should match snapshot when active 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <div
         class="base root"
@@ -229,7 +229,7 @@ exports[`<SelectInput /> should match snapshot when touched 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <div
         class="base root"
@@ -301,7 +301,7 @@ exports[`<SelectInput /> should match snapshot when touched and invalid 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <div
         class="base root"
@@ -373,7 +373,7 @@ exports[`<SelectInput /> should match snapshot when touched and valid 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <div
         class="base root"
@@ -445,7 +445,7 @@ exports[`<SelectInput /> should match snapshot with prefix icon 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <i
         class="base display_block iconRoot_base icon_prefix styleNode_base medium_mobile_base"

--- a/lib/components/TextAreaInput/__snapshots__/TextAreaInput.spec.jsx.snap
+++ b/lib/components/TextAreaInput/__snapshots__/TextAreaInput.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`<TextAreaInput /> should have some hintText 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <textarea
         autocomplete="off"
@@ -54,7 +54,7 @@ exports[`<TextAreaInput /> should match snapshot 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <textarea
         autocomplete="off"
@@ -95,7 +95,7 @@ exports[`<TextAreaInput /> should match snapshot when active 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <textarea
         autocomplete="off"
@@ -136,7 +136,7 @@ exports[`<TextAreaInput /> should match snapshot when touched 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <textarea
         autocomplete="off"
@@ -175,7 +175,7 @@ exports[`<TextAreaInput /> should match snapshot when touched and invalid 1`] = 
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <textarea
         autocomplete="off"
@@ -214,7 +214,7 @@ exports[`<TextAreaInput /> should match snapshot when touched and valid 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <textarea
         autocomplete="off"

--- a/lib/components/TextInput/__snapshots__/TextInput.spec.jsx.snap
+++ b/lib/components/TextInput/__snapshots__/TextInput.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`<TextInput /> should have some hintText 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -56,7 +56,7 @@ exports[`<TextInput /> should match snapshot 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -99,7 +99,7 @@ exports[`<TextInput /> should match snapshot when active 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -140,7 +140,7 @@ exports[`<TextInput /> should match snapshot when touched 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -181,7 +181,7 @@ exports[`<TextInput /> should match snapshot when touched and invalid 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -222,7 +222,7 @@ exports[`<TextInput /> should match snapshot when touched and valid 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <input
         autocomplete="off"
@@ -263,7 +263,7 @@ exports[`<TextInput /> should match snapshot with both icons 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <i
         class="base display_block iconRoot_base icon_prefix styleNode_base medium_mobile_base"
@@ -328,7 +328,7 @@ exports[`<TextInput /> should match snapshot with prefix icon 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <i
         class="base display_block iconRoot_base icon_prefix styleNode_base medium_mobile_base"
@@ -381,7 +381,7 @@ exports[`<TextInput /> should match snapshot with suffix icon 1`] = `
     class="base root_base"
   >
     <div
-      class="input_root"
+      class="base width_full input_root"
     >
       <i
         class="base display_block iconRoot_base icon_suffix styleNode_base medium_mobile_base"


### PR DESCRIPTION
Notchless inputs will no longer break when part of a flex container

---

Reproduction
```jsx
<Columns width="full">
  <Column grow>
    <TextInput name="test" placeholder="test" ></TextInput>
  </Column>
</Columns>
```