### PR TITLE
feat(Stack): Renamed spacing prop to space

### DIFF
--- a/.changeset/itchy-days-marry.md
+++ b/.changeset/itchy-days-marry.md
@@ -1,0 +1,17 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Stack: A Renamed prop from spacing to space
+
+eg:
+
+```diff
+<Stack is="ul"
+-    spacing="3">
++    space="3">
+    <li>line 1</li>
+    <li>line 2</li>
+    <li>line 3</li>
+</Stack>
+```

--- a/lib/components/ProgressBar/stories.tsx
+++ b/lib/components/ProgressBar/stories.tsx
@@ -22,7 +22,7 @@ export const Standard = () => {
 	}, []);
 
 	return (
-		<Stack spacing={2}>
+		<Stack space={2}>
 			{!isChromatic() && <ProgressBar value={width} colour="green" />}
 			<ProgressBar value={0.5} colour="green" />
 			<ProgressBar value={0.4} colour="blue" />

--- a/lib/components/Stack/Stack.tsx
+++ b/lib/components/Stack/Stack.tsx
@@ -9,7 +9,7 @@ import { Divider } from './Divider';
 import * as styleRefs from './Stack.treat';
 
 interface Props extends Pick<BoxStyleProps, 'is' | 'width'> {
-	spacing?: keyof typeof styleRefs.child.spaces;
+	space?: keyof typeof styleRefs.child.spaces;
 	className?: string;
 	dividers?: boolean;
 
@@ -17,7 +17,7 @@ interface Props extends Pick<BoxStyleProps, 'is' | 'width'> {
 }
 
 export const Stack: FunctionComponent<Props> = ({
-	spacing = '2',
+	space = '2',
 	children,
 	is = 'div',
 	width,
@@ -38,10 +38,10 @@ export const Stack: FunctionComponent<Props> = ({
 					is={['ul', 'ol'].includes(is) ? 'li' : 'div'}
 					className={[
 						styles.child.default,
-						dividers ? undefined : styles.child.spaces[spacing],
+						dividers ? undefined : styles.child.spaces[space],
 					]}>
 					{dividers && idx > 0 ? (
-						<Box paddingY={spacing} width="full">
+						<Box paddingY={space} width="full">
 							<Divider />
 						</Box>
 					) : null}

--- a/lib/components/Stack/stories.tsx
+++ b/lib/components/Stack/stories.tsx
@@ -7,7 +7,7 @@ import { Stack } from '.';
 export default { title: 'Foundation|Layout/Stack', component: Stack };
 
 export const Standard = () => (
-	<Stack spacing={select('Spacing', [1, 2, 3, 4, 5, 6, 7, 8, 9], 4)}>
+	<Stack space={select('Spacing', [1, 2, 3, 4, 5, 6, 7, 8, 9], 4)}>
 		<Text>Line 1</Text>
 		<Text>Line 2</Text>
 		<Text>Line 3</Text>
@@ -17,7 +17,7 @@ export const Standard = () => (
 export const AsSection = () => (
 	<Stack
 		is="section"
-		spacing={select('Spacing', [1, 2, 3, 4, 5, 6, 7, 8, 9], 4)}>
+		space={select('Spacing', [1, 2, 3, 4, 5, 6, 7, 8, 9], 4)}>
 		<Text>Line 1</Text>
 		<Text>Line 2</Text>
 		<Text>Line 3</Text>
@@ -28,7 +28,7 @@ export const WithDividers = () => (
 	<Stack
 		dividers
 		is="section"
-		spacing={select('Spacing', [1, 2, 3, 4, 5, 6, 7, 8, 9], 4)}>
+		space={select('Spacing', [1, 2, 3, 4, 5, 6, 7, 8, 9], 4)}>
 		<Text>Line 1</Text>
 		<Text>Line 2</Text>
 		<Text>Line 3</Text>

--- a/lib/components/TextContainer/TextContainer.tsx
+++ b/lib/components/TextContainer/TextContainer.tsx
@@ -17,7 +17,7 @@ export const TextContainer: FunctionComponent<Props> = ({
 	children,
 	action,
 }) => (
-	<Stack spacing="2" is="article" className={className}>
+	<Stack space="2" is="article" className={className}>
 		<TextContainerHeading heading={heading} action={action} />
 		{children}
 	</Stack>


### PR DESCRIPTION
This is to get some consistency between our `<Columns />` component and this, in that both use the concept of space, but called differently.

This is a breaking change, but I do believe it's a simple activity to go find-replace. I'm working on a jscodeshift for stuff like this in the future. 

---
A Renamed prop from spacing to space

eg:

```diff
<Stack is="ul"
-    spacing="3">
+    space="3">
    <li>line 1</li>
    <li>line 2</li>
    <li>line 3</li>
</Stack>
```