### PR TITLE
feat(Text): Supports a noWrap prop to not wrap its content

### DIFF
--- a/.changeset/short-cherries-push.md
+++ b/.changeset/short-cherries-push.md
@@ -1,0 +1,19 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Text: Exposes a new white-space nowrap prop
+
+This is an **experimental** prop, we know of one use-case where this can be
+used, but will likely also appear on the Box.
+
+So do let us know if you're using this, and it hasnt worked in your use-case.
+
+**FEATURES**
+
+You can now pass a `noWrap` prop to any `<Text />` which applies a
+`white-space: nowrap` to itself.
+
+```jsx
+<Text noWrap>I wont wrap</Text>
+```

--- a/lib/components/Typography/Text/Text.tsx
+++ b/lib/components/Typography/Text/Text.tsx
@@ -20,6 +20,7 @@ export const Text: FunctionComponent<Props> = ({
 	colour,
 	align = 'left',
 	fontWeight = 'normal',
+	noWrap,
 }) => (
 	<Box
 		is={Component}
@@ -29,6 +30,7 @@ export const Text: FunctionComponent<Props> = ({
 				align,
 				colour: colour ?? (strong ? 'dark' : undefined),
 				fontWeight: strong ? 'bold' : fontWeight,
+				noWrap,
 			}),
 			className,
 		)}>

--- a/lib/components/Typography/Text/useTextStyles.treat.ts
+++ b/lib/components/Typography/Text/useTextStyles.treat.ts
@@ -48,3 +48,5 @@ export const align = styleMap({
 export const fontWeight = styleMap((theme) =>
 	mapTokenToProperty(theme.typography.fontWeight, 'fontWeight'),
 );
+
+export const noWrap = style({ whiteSpace: 'nowrap' });

--- a/lib/components/Typography/Text/useTextStyles.ts
+++ b/lib/components/Typography/Text/useTextStyles.ts
@@ -9,6 +9,7 @@ export interface TextStyleProps {
 	colour?: keyof Theme['typography']['colour'] | 'unset';
 	align?: 'left' | 'center' | 'right';
 	fontWeight?: keyof Theme['typography']['fontWeight'];
+	noWrap?: boolean;
 }
 
 export const useTextStyles = ({
@@ -16,6 +17,7 @@ export const useTextStyles = ({
 	fontWeight,
 	colour,
 	align,
+	noWrap,
 }: TextStyleProps) => {
 	const styles = useStyles(styleRefs);
 
@@ -25,5 +27,6 @@ export const useTextStyles = ({
 		styles.align[align!],
 		colour !== 'unset' && styles.colours[colour ?? 'neutral'],
 		styles.fontWeight[fontWeight!],
+		noWrap && styles.noWrap,
 	);
 };


### PR DESCRIPTION
As mentioned in the changeset - I'm not 100% convinced in the change here. It'll inadvertently mean that text need to be a block-like element now. Meaning this will only work on `<Text is="p" />`. But will release, and see how we go using it. So the API _might_ change.

For now, lets consume this PR directly internally and dog-food for a bit.

```
"@autoguru/overdrive": "autoguru-au/overdrive#no-wrap-text"
```
> package.json

---

Text: Exposes a new white-space nowrap prop

This is an **experimental** prop, we know of one use-case where this can be
used, but will likely also appear on the Box.

So do let us know if you're using this, and it hasnt worked in your use-case.

**FEATURES**

You can now pass a `noWrap` prop to any `<Text />` which applies a
`white-space: nowrap` to itself.

```jsx
<Text noWrap>I wont wrap</Text>
```