### PR TITLE
feat(Box): Introduce flex style props to box/useBox

### DIFF
--- a/.changeset/yellow-snails-play.md
+++ b/.changeset/yellow-snails-play.md
@@ -1,0 +1,17 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Box: Introduces flex style props to `Box` and `useBoxStyles`
+
+**FEATURES**
+
+You can now send in `alignItems`,`flexDirection`, `flexGrow`, `flexShrink`, `flexWrap`, `justifyContent` to Box and useBoxStyles for whatever you like.
+
+We have specifically chosen `alignItems`, `flexDirection`, `justifyContent` as Responsive candidates as we've found the others won't have a responsive use case.
+
+```jsx
+<Box display="flex" width="full" justifyContent="center">
+    <Button>Hello</Button>
+</Box>
+```

--- a/lib/components/Box/Box.tsx
+++ b/lib/components/Box/Box.tsx
@@ -64,6 +64,13 @@ export const Box = forwardRef<HTMLElement, Props<any>>(
 
 			className = '',
 
+			alignItems,
+			flexDirection,
+			flexGrow,
+			flexShrink,
+			flexWrap,
+			justifyContent,
+
 			children,
 			...allOtherProps
 		},
@@ -71,6 +78,7 @@ export const Box = forwardRef<HTMLElement, Props<any>>(
 	) => {
 		const cls = useBoxStyles({
 			is: Component,
+			alignItems,
 			backgroundColour,
 			borderColour,
 			borderColourBottom,
@@ -89,6 +97,11 @@ export const Box = forwardRef<HTMLElement, Props<any>>(
 			borderWidthY,
 			boxShadow,
 			display,
+			flexDirection,
+			flexGrow,
+			flexShrink,
+			flexWrap,
+			justifyContent,
 			margin,
 			marginBottom,
 			marginLeft,

--- a/lib/components/Box/useBoxStyles.treat.ts
+++ b/lib/components/Box/useBoxStyles.treat.ts
@@ -21,13 +21,6 @@ export const boxShadow = makeResponsiveStyle(
 	'boxShadow',
 );
 
-export const display = styleMap(
-	mapTokenToProperty(
-		{ block: 'block', 'inline-block': 'inline-block' },
-		'display',
-	),
-);
-
 export const border = {
 	style: style({
 		borderStyle: 'solid',
@@ -108,4 +101,71 @@ export const overflow = styleMap(
 		},
 		'overflow',
 	),
+);
+
+export const display = styleMap(
+	mapTokenToProperty(
+		{ block: 'block', 'inline-block': 'inline-block', flex: 'flex' },
+		'display',
+	),
+);
+
+// Flex things
+
+export const alignItems = makeResponsiveStyle(
+	() => ({
+		flexStart: 'flex-start',
+		center: 'center',
+		flexEnd: 'flex-end',
+	}),
+	'alignItems',
+);
+
+export const flexDirection = makeResponsiveStyle(
+	() => ({
+		row: 'row',
+		rowReverse: 'row-reverse',
+		column: 'column',
+		columnReverse: 'column-reverse',
+	}),
+	'flexDirection',
+);
+
+export const flexGrow = styleMap(
+	mapTokenToProperty(
+		{
+			0: 0,
+			1: 1,
+		},
+		'flexGrow',
+	),
+);
+
+export const flexShrink = styleMap(
+	mapTokenToProperty(
+		{
+			0: 0,
+		},
+		'flexShrink',
+	),
+);
+
+export const flexWrap = styleMap(
+	mapTokenToProperty(
+		{
+			wrap: 'wrap',
+			nowrap: 'nowrap',
+		},
+		'flexWrap',
+	),
+);
+
+export const justifyContent = makeResponsiveStyle(
+	() => ({
+		flexStart: 'flex-start',
+		center: 'center',
+		flexEnd: 'flex-end',
+		spaceBetween: 'space-between',
+	}),
+	'justifyContent',
 );

--- a/lib/components/Box/useBoxStyles.ts
+++ b/lib/components/Box/useBoxStyles.ts
@@ -48,10 +48,19 @@ interface Border {
 	borderRadius?: ResponsiveProp<keyof typeof styleRefs.borderRadius>;
 }
 
-export interface BoxStyleProps extends Padding, Margin, Border {
+interface Flex {
+	alignItems?: ResponsiveProp<keyof typeof styleRefs.alignItems>;
+	flexDirection?: ResponsiveProp<keyof typeof styleRefs.flexDirection>;
+	flexGrow?: keyof typeof styleRefs.flexGrow;
+	flexShrink?: keyof typeof styleRefs.flexShrink;
+	flexWrap?: keyof typeof styleRefs.flexWrap;
+	justifyContent?: ResponsiveProp<keyof typeof styleRefs.justifyContent>;
+}
+
+export interface BoxStyleProps extends Padding, Margin, Border, Flex {
 	is?: keyof JSX.IntrinsicElements;
 	boxShadow?: ResponsiveProp<keyof typeof styleRefs.boxShadow>;
-	display?: 'block' | 'inline-block';
+	display?: keyof typeof styleRefs.display;
 
 	position?: keyof typeof styleRefs.position;
 	width?: keyof typeof styleRefs.width;
@@ -100,6 +109,12 @@ export const useBoxStyles = ({
 	width,
 	position,
 	overflow,
+	alignItems,
+	flexDirection,
+	flexGrow,
+	flexShrink,
+	flexWrap,
+	justifyContent,
 	className,
 }: BoxStyleProps) => {
 	const resetStyles = useStyles(resetStyleRefs);
@@ -204,6 +219,15 @@ export const useBoxStyles = ({
 			resolveResponsiveStyle(borderRadius, styles.borderRadius),
 
 		backgroundColour && styles.backgroundColours[backgroundColour],
+
+		alignItems && resolveResponsiveStyle(alignItems, styles.alignItems),
+		flexDirection &&
+			resolveResponsiveStyle(flexDirection, styles.flexDirection),
+		flexGrow && styles.flexGrow,
+		flexShrink && styles.flexShrink,
+		flexWrap && styles.flexWrap,
+		justifyContent &&
+			resolveResponsiveStyle(justifyContent, styles.justifyContent),
 
 		className,
 	);


### PR DESCRIPTION
Box: Introduces flex style props to `Box` and `useBoxStyles`

**FEATURES**

You can now send in `alignItems`,`flexDirection`, `flexGrow`, `flexShrink`, `flexWrap`, `justifyContent` to Box and useBoxStyles for whatever you like.

We have specifically chosen `alignItems`, `flexDirection`, `justifyContent` as Responsive candidates as we've found the others won't have a responsive use case.

```jsx
<Box display="flex" width="full" justifyContent="center">
    <Button>Hello</Button>
</Box>
```