### PR TITLE
feat: Increases select input click area to cover full component width

### DIFF
--- a/.changeset/metal-sloths-call.md
+++ b/.changeset/metal-sloths-call.md
@@ -1,0 +1,6 @@
+---
+'@autoguru/overdrive': patch
+---
+
+**SelectInput**: Increases target click area to cover the full width of
+component.

--- a/packages/overdrive/lib/components/SelectInput/SelectInput.treat.ts
+++ b/packages/overdrive/lib/components/SelectInput/SelectInput.treat.ts
@@ -13,4 +13,3 @@ export const arrow = style({
 	top: '0',
 	right: '0',
 });
-

--- a/packages/overdrive/lib/components/SelectInput/SelectInput.treat.ts
+++ b/packages/overdrive/lib/components/SelectInput/SelectInput.treat.ts
@@ -1,0 +1,16 @@
+import { style } from 'treat';
+
+export const input = style({});
+export const paddedInput = style(({ space }) => ({
+	selectors: {
+		[`${input}&`]: {
+			paddingRight: space['8'],
+		},
+	},
+}));
+
+export const arrow = style({
+	top: '0',
+	right: '0',
+});
+

--- a/packages/overdrive/lib/components/SelectInput/SelectInput.tsx
+++ b/packages/overdrive/lib/components/SelectInput/SelectInput.tsx
@@ -2,37 +2,56 @@ import { ChevronDownIcon } from '@autoguru/icons';
 import * as React from 'react';
 import { ReactNode } from 'react';
 
-import { Box, useBoxStyles } from '../Box';
+import { Box } from '../Box';
 import { Icon } from '../Icon';
 import { withEnhancedInput } from '../private/InputBase';
+import { useStyles } from 'react-treat';
+import * as styleRefs from './SelectInput.treat';
 
 export const SelectInput = withEnhancedInput<
 	{
 		children: ReactNode[];
+		c
 	},
 	HTMLSelectElement
 >(
-	({ field, eventHandlers, suffixed, prefixed, validation, ...rest }) => (
-		<Box
-			display="flex"
-			flexWrap="nowrap"
-			alignItems="center"
-			justifyContent="center">
+	({ field, eventHandlers, suffixed, prefixed, validation, ...rest }) => {
+
+		const styles = useStyles(styleRefs);
+		return (
 			<Box
-				is="select"
-				flexGrow={1}
-				{...eventHandlers}
-				{...field}
-				{...rest}
-				autoComplete="off"
-			/>
-			<Icon
-				size="medium"
-				icon={ChevronDownIcon}
-				className={useBoxStyles({ marginRight: '4', flexShrink: 0 })}
-			/>
-		</Box>
-	),
+				display="flex"
+				flexWrap="nowrap"
+				alignItems="center"
+				justifyContent="center"
+				position="relative">
+				<Box
+					is="select"
+					flexGrow={1}
+					{...eventHandlers}
+					{...field}
+					{...rest}
+					className={[styles.input, styles.paddedInput, field.className]}
+					autoComplete="off"
+				/>
+				<Box
+					className={styles.arrow}
+					display="flex"
+					alignItems="center"
+					height="full"
+					marginRight= '4'
+					flexShrink={0}
+					pointerEvents='none'
+					position='absolute'>
+					<Icon
+						size="medium"
+						icon={ChevronDownIcon}
+					/>
+				</Box>
+
+			</Box>
+		);
+	},
 	{
 		primitiveType: 'select',
 		withSuffixIcon: false,

--- a/packages/overdrive/lib/components/SelectInput/SelectInput.tsx
+++ b/packages/overdrive/lib/components/SelectInput/SelectInput.tsx
@@ -1,22 +1,21 @@
 import { ChevronDownIcon } from '@autoguru/icons';
 import * as React from 'react';
 import { ReactNode } from 'react';
+import { useStyles } from 'react-treat';
 
 import { Box } from '../Box';
 import { Icon } from '../Icon';
 import { withEnhancedInput } from '../private/InputBase';
-import { useStyles } from 'react-treat';
 import * as styleRefs from './SelectInput.treat';
 
 export const SelectInput = withEnhancedInput<
 	{
 		children: ReactNode[];
-		c
+		c;
 	},
 	HTMLSelectElement
 >(
 	({ field, eventHandlers, suffixed, prefixed, validation, ...rest }) => {
-
 		const styles = useStyles(styleRefs);
 		return (
 			<Box
@@ -31,7 +30,11 @@ export const SelectInput = withEnhancedInput<
 					{...eventHandlers}
 					{...field}
 					{...rest}
-					className={[styles.input, styles.paddedInput, field.className]}
+					className={[
+						styles.input,
+						styles.paddedInput,
+						field.className,
+					]}
 					autoComplete="off"
 				/>
 				<Box
@@ -39,16 +42,12 @@ export const SelectInput = withEnhancedInput<
 					display="flex"
 					alignItems="center"
 					height="full"
-					marginRight= '4'
+					marginRight="4"
 					flexShrink={0}
-					pointerEvents='none'
-					position='absolute'>
-					<Icon
-						size="medium"
-						icon={ChevronDownIcon}
-					/>
+					pointerEvents="none"
+					position="absolute">
+					<Icon size="medium" icon={ChevronDownIcon} />
 				</Box>
-
 			</Box>
 		);
 	},

--- a/packages/overdrive/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
+++ b/packages/overdrive/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
@@ -11,11 +11,11 @@ exports[`<SelectInput /> should have some hintText 1`] = `
       class="base width_full height_full"
     >
       <div
-        class="base display_flex center_mobile_base flexWrap_nowrap center_mobile_base"
+        class="base display_flex position_relative center_mobile_base flexWrap_nowrap center_mobile_base"
       >
         <select
           autocomplete="off"
-          class="base block appearance select flexGrow_1 base block appearance input display_flex width_full position_relative input_itself_root_base"
+          class="base block appearance select flexGrow_1 input paddedInput_base base block appearance input display_flex width_full position_relative input_itself_root_base"
         >
           <option
             value="a"
@@ -33,21 +33,25 @@ exports[`<SelectInput /> should have some hintText 1`] = `
             Value 3
           </option>
         </select>
-        <i
-          class="base display_block medium_mobile_base 4_mobile_base flexShrink_0"
-          role="presentation"
+        <div
+          class="base 4_mobile_base display_flex height_full position_absolute pointerEvents_none center_mobile_base flexShrink_0 arrow"
         >
-          <svg
-            class="base display_block width_full height_full"
-            fill="currentColor"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <i
+            class="base display_block medium_mobile_base"
+            role="presentation"
           >
-            <path
-              d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
-            />
-          </svg>
-        </i>
+            <svg
+              class="base display_block width_full height_full"
+              fill="currentColor"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
+              />
+            </svg>
+          </i>
+        </div>
       </div>
     </div>
     <div
@@ -90,11 +94,11 @@ exports[`<SelectInput /> should match snapshot 1`] = `
       class="base width_full height_full"
     >
       <div
-        class="base display_flex center_mobile_base flexWrap_nowrap center_mobile_base"
+        class="base display_flex position_relative center_mobile_base flexWrap_nowrap center_mobile_base"
       >
         <select
           autocomplete="off"
-          class="base block appearance select flexGrow_1 base block appearance input display_flex width_full position_relative input_itself_root_base"
+          class="base block appearance select flexGrow_1 input paddedInput_base base block appearance input display_flex width_full position_relative input_itself_root_base"
         >
           <option
             value="a"
@@ -112,21 +116,25 @@ exports[`<SelectInput /> should match snapshot 1`] = `
             Value 3
           </option>
         </select>
-        <i
-          class="base display_block medium_mobile_base 4_mobile_base flexShrink_0"
-          role="presentation"
+        <div
+          class="base 4_mobile_base display_flex height_full position_absolute pointerEvents_none center_mobile_base flexShrink_0 arrow"
         >
-          <svg
-            class="base display_block width_full height_full"
-            fill="currentColor"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <i
+            class="base display_block medium_mobile_base"
+            role="presentation"
           >
-            <path
-              d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
-            />
-          </svg>
-        </i>
+            <svg
+              class="base display_block width_full height_full"
+              fill="currentColor"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
+              />
+            </svg>
+          </i>
+        </div>
       </div>
     </div>
     <div
@@ -164,11 +172,11 @@ exports[`<SelectInput /> should match snapshot when active 1`] = `
       class="base width_full height_full"
     >
       <div
-        class="base display_flex center_mobile_base flexWrap_nowrap center_mobile_base"
+        class="base display_flex position_relative center_mobile_base flexWrap_nowrap center_mobile_base"
       >
         <select
           autocomplete="off"
-          class="base block appearance select flexGrow_1 base block appearance input display_flex width_full position_relative input_itself_root_base"
+          class="base block appearance select flexGrow_1 input paddedInput_base base block appearance input display_flex width_full position_relative input_itself_root_base"
         >
           <option
             value="a"
@@ -186,21 +194,25 @@ exports[`<SelectInput /> should match snapshot when active 1`] = `
             Value 3
           </option>
         </select>
-        <i
-          class="base display_block medium_mobile_base 4_mobile_base flexShrink_0"
-          role="presentation"
+        <div
+          class="base 4_mobile_base display_flex height_full position_absolute pointerEvents_none center_mobile_base flexShrink_0 arrow"
         >
-          <svg
-            class="base display_block width_full height_full"
-            fill="currentColor"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <i
+            class="base display_block medium_mobile_base"
+            role="presentation"
           >
-            <path
-              d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
-            />
-          </svg>
-        </i>
+            <svg
+              class="base display_block width_full height_full"
+              fill="currentColor"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
+              />
+            </svg>
+          </i>
+        </div>
       </div>
     </div>
     <div
@@ -238,11 +250,11 @@ exports[`<SelectInput /> should match snapshot when touched 1`] = `
       class="base width_full height_full"
     >
       <div
-        class="base display_flex center_mobile_base flexWrap_nowrap center_mobile_base"
+        class="base display_flex position_relative center_mobile_base flexWrap_nowrap center_mobile_base"
       >
         <select
           autocomplete="off"
-          class="base block appearance select flexGrow_1 base block appearance input display_flex width_full position_relative input_itself_root_base"
+          class="base block appearance select flexGrow_1 input paddedInput_base base block appearance input display_flex width_full position_relative input_itself_root_base"
         >
           <option
             value="a"
@@ -260,21 +272,25 @@ exports[`<SelectInput /> should match snapshot when touched 1`] = `
             Value 3
           </option>
         </select>
-        <i
-          class="base display_block medium_mobile_base 4_mobile_base flexShrink_0"
-          role="presentation"
+        <div
+          class="base 4_mobile_base display_flex height_full position_absolute pointerEvents_none center_mobile_base flexShrink_0 arrow"
         >
-          <svg
-            class="base display_block width_full height_full"
-            fill="currentColor"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <i
+            class="base display_block medium_mobile_base"
+            role="presentation"
           >
-            <path
-              d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
-            />
-          </svg>
-        </i>
+            <svg
+              class="base display_block width_full height_full"
+              fill="currentColor"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
+              />
+            </svg>
+          </i>
+        </div>
       </div>
     </div>
     <div
@@ -312,11 +328,11 @@ exports[`<SelectInput /> should match snapshot when touched and invalid 1`] = `
       class="base width_full height_full"
     >
       <div
-        class="base display_flex center_mobile_base flexWrap_nowrap center_mobile_base"
+        class="base display_flex position_relative center_mobile_base flexWrap_nowrap center_mobile_base"
       >
         <select
           autocomplete="off"
-          class="base block appearance select flexGrow_1 base block appearance input display_flex width_full position_relative input_itself_root_base"
+          class="base block appearance select flexGrow_1 input paddedInput_base base block appearance input display_flex width_full position_relative input_itself_root_base"
         >
           <option
             value="a"
@@ -334,21 +350,25 @@ exports[`<SelectInput /> should match snapshot when touched and invalid 1`] = `
             Value 3
           </option>
         </select>
-        <i
-          class="base display_block medium_mobile_base 4_mobile_base flexShrink_0"
-          role="presentation"
+        <div
+          class="base 4_mobile_base display_flex height_full position_absolute pointerEvents_none center_mobile_base flexShrink_0 arrow"
         >
-          <svg
-            class="base display_block width_full height_full"
-            fill="currentColor"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <i
+            class="base display_block medium_mobile_base"
+            role="presentation"
           >
-            <path
-              d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
-            />
-          </svg>
-        </i>
+            <svg
+              class="base display_block width_full height_full"
+              fill="currentColor"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
+              />
+            </svg>
+          </i>
+        </div>
       </div>
     </div>
     <div
@@ -386,11 +406,11 @@ exports[`<SelectInput /> should match snapshot when touched and valid 1`] = `
       class="base width_full height_full"
     >
       <div
-        class="base display_flex center_mobile_base flexWrap_nowrap center_mobile_base"
+        class="base display_flex position_relative center_mobile_base flexWrap_nowrap center_mobile_base"
       >
         <select
           autocomplete="off"
-          class="base block appearance select flexGrow_1 base block appearance input display_flex width_full position_relative input_itself_root_base"
+          class="base block appearance select flexGrow_1 input paddedInput_base base block appearance input display_flex width_full position_relative input_itself_root_base"
         >
           <option
             value="a"
@@ -408,21 +428,25 @@ exports[`<SelectInput /> should match snapshot when touched and valid 1`] = `
             Value 3
           </option>
         </select>
-        <i
-          class="base display_block medium_mobile_base 4_mobile_base flexShrink_0"
-          role="presentation"
+        <div
+          class="base 4_mobile_base display_flex height_full position_absolute pointerEvents_none center_mobile_base flexShrink_0 arrow"
         >
-          <svg
-            class="base display_block width_full height_full"
-            fill="currentColor"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <i
+            class="base display_block medium_mobile_base"
+            role="presentation"
           >
-            <path
-              d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
-            />
-          </svg>
-        </i>
+            <svg
+              class="base display_block width_full height_full"
+              fill="currentColor"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
+              />
+            </svg>
+          </i>
+        </div>
       </div>
     </div>
     <div
@@ -474,27 +498,31 @@ exports[`<SelectInput /> should match snapshot with prefix icon 1`] = `
         </svg>
       </i>
       <div
-        class="base display_flex center_mobile_base flexWrap_nowrap center_mobile_base"
+        class="base display_flex position_relative center_mobile_base flexWrap_nowrap center_mobile_base"
       >
         <select
           autocomplete="off"
-          class="base block appearance select flexGrow_1 base block appearance input display_flex width_full position_relative input_itself_root_base input_itself_prefixed_base"
+          class="base block appearance select flexGrow_1 input paddedInput_base base block appearance input display_flex width_full position_relative input_itself_root_base input_itself_prefixed_base"
         />
-        <i
-          class="base display_block medium_mobile_base 4_mobile_base flexShrink_0"
-          role="presentation"
+        <div
+          class="base 4_mobile_base display_flex height_full position_absolute pointerEvents_none center_mobile_base flexShrink_0 arrow"
         >
-          <svg
-            class="base display_block width_full height_full"
-            fill="currentColor"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <i
+            class="base display_block medium_mobile_base"
+            role="presentation"
           >
-            <path
-              d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
-            />
-          </svg>
-        </i>
+            <svg
+              class="base display_block width_full height_full"
+              fill="currentColor"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
+              />
+            </svg>
+          </i>
+        </div>
       </div>
     </div>
     <div


### PR DESCRIPTION
With this change SelectInput component stretches native select element to cover full with on the component. With this change the arrow down icon becomes an absolutely positioned element with no pointer events and select input gets additional left padding to reserve the arrow down icon area