### PR TITLE
fix(Stepper): No longer re-render when incoming change happens

### DIFF
--- a/.changeset/cool-waves-cheer.md
+++ b/.changeset/cool-waves-cheer.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+**Stepper**: Fixes extra re-render on each change

--- a/packages/overdrive/lib/components/Stepper/Stepper.tsx
+++ b/packages/overdrive/lib/components/Stepper/Stepper.tsx
@@ -186,13 +186,14 @@ export const Stepper: FunctionComponent<Props> = ({
 	);
 
 	if (prevValue.current !== value && value !== undefined) {
-		dispatch({
-			type: EActionType.VALUE,
-			value,
-			step,
-			min,
-			max,
-		});
+		if (value !== state.value)
+			dispatch({
+				type: EActionType.VALUE,
+				value,
+				step,
+				min,
+				max,
+			});
 		prevValue.current = value;
 	}
 


### PR DESCRIPTION
Currently Stepper component reacts to change of value prop coming in as a result on internal onChange trigger. This change skips reducer dispatch if incoming value and internal state are the same.