### PR TITLE
fix: Fixes inverted badge text colour

### DIFF
--- a/.changeset/flat-candles-nail.md
+++ b/.changeset/flat-candles-nail.md
@@ -2,4 +2,4 @@
 '@autoguru/overdrive': patch
 ---
 
-**Badge** Fixes inverted text style colours
+**Badge**: Fixes inverted text style colours and incorrect ordering caused by [treat](https://github.com/seek-oss/treat)

--- a/.changeset/flat-candles-nail.md
+++ b/.changeset/flat-candles-nail.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+**Badge** Fixes inverted text style colours

--- a/packages/overdrive/lib/components/Badge/Badge.treat.ts
+++ b/packages/overdrive/lib/components/Badge/Badge.treat.ts
@@ -1,11 +1,11 @@
 import { style, styleMap } from 'treat';
 
-export const label = style(({ typography }) => ({
+export const label = style(({ typography, colours }) => ({
 	lineHeight: typography.size['2'].fontSize,
 	textOverflow: 'ellipsis',
 	letterSpacing: '0.5px',
 	textTransform: 'uppercase',
-	colour: 'white',
+	color: colours.gamut.white,
 }));
 
 // TODO: Derive the inverted colours from a token

--- a/packages/overdrive/lib/components/Badge/Badge.treat.ts
+++ b/packages/overdrive/lib/components/Badge/Badge.treat.ts
@@ -5,6 +5,7 @@ export const label = style(({ typography }) => ({
 	textOverflow: 'ellipsis',
 	letterSpacing: '0.5px',
 	textTransform: 'uppercase',
+	colour: 'white',
 }));
 
 // TODO: Derive the inverted colours from a token

--- a/packages/overdrive/lib/components/Badge/Badge.tsx
+++ b/packages/overdrive/lib/components/Badge/Badge.tsx
@@ -23,7 +23,6 @@ export const Badge = memo<Props>(
 			size: '2',
 			noWrap: true,
 			fontWeight: 'semiBold',
-			colour: 'white',
 		});
 		const inverted = look === 'inverted';
 

--- a/packages/overdrive/lib/components/Badge/__snapshots__/Badge.spec.jsx.snap
+++ b/packages/overdrive/lib/components/Badge/__snapshots__/Badge.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`<Badge /> should match snapshot with label 1`] = `
     class="base 1_mobile_base 1_mobile_base 1_mobile_base 1_mobile_base display_block overflow_hidden 1_mobile_base colours_default_neutral_base"
   >
     <span
-      class="base display_block overflow_hidden label_base root_base colours_white_base fontWeight_semiBold_base noWrap sizes_2_base"
+      class="base display_block overflow_hidden label_base root_base colours_neutral_base fontWeight_semiBold_base noWrap sizes_2_base"
     >
       Hello World!
     </span>


### PR DESCRIPTION
This PR fixes inverted badge colour being overridden with the default colour introduced by the useTextStyles hook  