### PR TITLE
fix: Badge to use text style as source

### DIFF
--- a/.changeset/red-crabs-tease.md
+++ b/.changeset/red-crabs-tease.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+**Badge**: Fixes default text style colour incorrect style ordering ordering

--- a/packages/overdrive/lib/components/Badge/Badge.treat.ts
+++ b/packages/overdrive/lib/components/Badge/Badge.treat.ts
@@ -10,9 +10,6 @@ export const label = style(({ typography }) => ({
 // TODO: Derive the inverted colours from a token
 export const colours = {
 	default: styleMap((theme) => ({
-		defaultText: {
-			color: theme.colours.gamut.white,
-		},
 		neutral: {
 			backgroundColor: theme.colours.intent.neutral.background,
 		},

--- a/packages/overdrive/lib/components/Badge/Badge.treat.ts
+++ b/packages/overdrive/lib/components/Badge/Badge.treat.ts
@@ -1,16 +1,18 @@
 import { style, styleMap } from 'treat';
 
-export const label = style(({ typography, colours }) => ({
+export const label = style(({ typography }) => ({
 	lineHeight: typography.size['2'].fontSize,
 	textOverflow: 'ellipsis',
 	letterSpacing: '0.5px',
 	textTransform: 'uppercase',
-	color: colours.gamut.white,
 }));
 
 // TODO: Derive the inverted colours from a token
 export const colours = {
 	default: styleMap((theme) => ({
+		defaultText: {
+			color: theme.colours.gamut.white,
+		},
 		neutral: {
 			backgroundColor: theme.colours.intent.neutral.background,
 		},

--- a/packages/overdrive/lib/components/Badge/Badge.tsx
+++ b/packages/overdrive/lib/components/Badge/Badge.tsx
@@ -1,5 +1,4 @@
 import { invariant } from '@autoguru/utilities';
-import clsx from 'clsx';
 import * as React from 'react';
 import { memo } from 'react';
 import { useStyles } from 'react-treat';

--- a/packages/overdrive/lib/components/Badge/Badge.tsx
+++ b/packages/overdrive/lib/components/Badge/Badge.tsx
@@ -24,6 +24,7 @@ export const Badge = memo<Props>(
 			size: '2',
 			noWrap: true,
 			fontWeight: 'semiBold',
+			colour: 'unset',
 		});
 		const inverted = look === 'inverted';
 
@@ -49,10 +50,13 @@ export const Badge = memo<Props>(
 						is="span"
 						display="block"
 						overflow="hidden"
-						className={clsx(styles.label, textStyles, {
-							[styles.colours.inverted[colour].text]: inverted,
-							[styles.colours.default.text]: !inverted,
-						})}>
+						className={[
+							textStyles,
+							styles.label,
+							inverted
+								? styles.colours.inverted[colour].text
+								: useTextStyles({ colour: 'white' }),
+						]}>
 						{label}
 					</Box>
 				</Box>

--- a/packages/overdrive/lib/components/Badge/Badge.tsx
+++ b/packages/overdrive/lib/components/Badge/Badge.tsx
@@ -1,4 +1,5 @@
 import { invariant } from '@autoguru/utilities';
+import clsx from 'clsx';
 import * as React from 'react';
 import { memo } from 'react';
 import { useStyles } from 'react-treat';
@@ -48,11 +49,10 @@ export const Badge = memo<Props>(
 						is="span"
 						display="block"
 						overflow="hidden"
-						className={[
-							styles.label,
-							textStyles,
-							inverted && styles.colours.inverted[colour].text,
-						]}>
+						className={clsx(styles.label, textStyles, {
+							[styles.colours.inverted[colour].text]: inverted,
+							[styles.colours.default.text]: !inverted,
+						})}>
 						{label}
 					</Box>
 				</Box>

--- a/packages/overdrive/lib/components/Badge/__snapshots__/Badge.spec.jsx.snap
+++ b/packages/overdrive/lib/components/Badge/__snapshots__/Badge.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`<Badge /> should match snapshot with label 1`] = `
     class="base 1_mobile_base 1_mobile_base 1_mobile_base 1_mobile_base display_block overflow_hidden 1_mobile_base colours_default_neutral_base"
   >
     <span
-      class="base display_block overflow_hidden label_base root_base colours_neutral_base fontWeight_semiBold_base noWrap sizes_2_base"
+      class="base display_block overflow_hidden label_base root_base colours_neutral_base fontWeight_semiBold_base noWrap sizes_2_base undefined"
     >
       Hello World!
     </span>

--- a/packages/overdrive/lib/components/Badge/__snapshots__/Badge.spec.jsx.snap
+++ b/packages/overdrive/lib/components/Badge/__snapshots__/Badge.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`<Badge /> should match snapshot with label 1`] = `
     class="base 1_mobile_base 1_mobile_base 1_mobile_base 1_mobile_base display_block overflow_hidden 1_mobile_base colours_default_neutral_base"
   >
     <span
-      class="base display_block overflow_hidden label_base root_base colours_neutral_base fontWeight_semiBold_base noWrap sizes_2_base undefined"
+      class="base display_block overflow_hidden root_base fontWeight_semiBold_base noWrap sizes_2_base label_base root_base colours_white_base"
     >
       Hello World!
     </span>


### PR DESCRIPTION
This PR fixes incorrect default badge text styles caused by wrong ordering caused by [/pull/545]