### PR TITLE
feat: Introduces a new small option for width values

### DIFF
--- a/.changeset/thirty-plants-pull.md
+++ b/.changeset/thirty-plants-pull.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+**Section**: Introduces a new small option for width values

--- a/packages/overdrive/lib/themes/base/tokens.ts
+++ b/packages/overdrive/lib/themes/base/tokens.ts
@@ -89,6 +89,7 @@ export const tokens: Tokens = {
 		largeDesktop: 1440, // 1080p width (1920 - 25%)
 	},
 	contentWidth: {
+		small: 592,
 		large: 1344,
 		medium: 940,
 	},

--- a/packages/overdrive/lib/themes/tokens.ts
+++ b/packages/overdrive/lib/themes/tokens.ts
@@ -79,6 +79,7 @@ export interface ForegroundColours {
 export interface Tokens {
 	breakpoints: Record<Breakpoints, number>;
 	contentWidth: {
+		small: number;
 		medium: number;
 		large: number;
 	};


### PR DESCRIPTION
This PR adds a new 'small' option to Section component. A typical use-case for this new width is when a page displays a small amount of text content causing single lines when inside medium or large section widths.