### PR TITLE
feat: StandardModal mobile and tablet view fix

### DIFF
--- a/.changeset/chatty-rice-play.md
+++ b/.changeset/chatty-rice-play.md
@@ -2,8 +2,5 @@
 '@autoguru/overdrive': patch
 ---
 
-**StandardModal**: Fixes mobile view to be pinned to the bottom of the
-page
-
-**StandardModal**: Fixes tablet view to have all round corners
-
+**StandardModal**: Fixes mobile view to be pinned to the bottom and table view
+is all rounded corners

--- a/.changeset/chatty-rice-play.md
+++ b/.changeset/chatty-rice-play.md
@@ -1,0 +1,9 @@
+---
+'@autoguru/overdrive': patch
+---
+
+**StandardModal**: Fixes mobile view to be pinned to the bottom of the
+page
+
+**StandardModal**: Fixes tablet view to have all round corners
+

--- a/packages/overdrive/lib/components/StandardModal/StandardModal.treat.ts
+++ b/packages/overdrive/lib/components/StandardModal/StandardModal.treat.ts
@@ -7,15 +7,19 @@ export const container = style({
 export const modal = style((theme) => ({
 	width: '100vw',
 	height: 'auto',
+	alignSelf: 'flex-end',
 	minHeight: `calc(3 * ${theme.space['8']})`,
 	maxHeight: `calc(100vh - ${theme.space['8']})`,
 	borderRadius: `${theme.space['2']} ${theme.space['2']} 0 0`,
 	...theme.utils.responsiveStyle({
+		tablet: {
+			alignSelf: 'center',
+			borderRadius: `${theme.space['1']}`,
+		},
 		desktop: {
 			maxWidth: `calc(100% - ${theme.space['9']} * 2)`,
 			height: 'auto',
 			maxHeight: `calc(100vh - ${theme.space['9']} * 2)`,
-			borderRadius: `${theme.space['1']}`,
 			boxShadow:
 				'0 0 32px 0 rgba(0,0,0, 0.012), 0 24px 96px 0 rgba(0,0,0, 0.08)',
 			marginTop: 0,


### PR DESCRIPTION
This PR make two changes to the standard modal

1. Ensures the mobile view always has modal pinned to the bottom of the page
2. In tablet view rounds all corners to be consistent with desktop view