### PR TITLE
feat: Adds forwardRef to all checkables

### DIFF
--- a/.changeset/healthy-singers-trade.md
+++ b/.changeset/healthy-singers-trade.md
@@ -1,0 +1,9 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Checkbox: Accepts ref
+
+RadioGroup: Accepts ref
+
+Radio: Accepts ref

--- a/packages/overdrive/lib/components/CheckBox/CheckBox.tsx
+++ b/packages/overdrive/lib/components/CheckBox/CheckBox.tsx
@@ -1,7 +1,7 @@
 import { CheckIcon } from '@autoguru/icons';
 import clsx from 'clsx';
 import * as React from 'react';
-import { FunctionComponent, memo, ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { useStyles } from 'react-treat';
 
 import { noop } from '../../utils';
@@ -26,17 +26,20 @@ export interface Props {
 	onChange?(checked: boolean): void;
 }
 
-export const CheckBox: FunctionComponent<Props> = memo(
-	({
-		value,
-		className = '',
-		name = '',
-		disabled = false,
-		checked = false,
-		onClick = noop,
-		onChange = noop,
-		children,
-	}) => {
+export const CheckBox = forwardRef<HTMLInputElement, Props>(
+	(
+		{
+			value,
+			className = '',
+			name = '',
+			disabled = false,
+			checked = false,
+			onClick = noop,
+			onChange = noop,
+			children,
+		},
+		ref,
+	) => {
 		const styles = useStyles(styleRefs);
 		const iconStyles = clsx(
 			useTextStyles({ colour: 'white' }),
@@ -46,6 +49,7 @@ export const CheckBox: FunctionComponent<Props> = memo(
 
 		return (
 			<CheckableBase
+				ref={ref}
 				inputType="checkbox"
 				className={className}
 				inputName={name}
@@ -55,13 +59,13 @@ export const CheckBox: FunctionComponent<Props> = memo(
 				checked={checked}
 				handleClick={onClick}
 				handleChange={onChange}>
-				{checked && (
+				{checked ? (
 					<Icon
 						className={clsx(styles.icon, iconStyles)}
 						icon={CheckIcon}
 						size="small"
 					/>
-				)}
+				) : null}
 				<Box
 					borderWidth="2"
 					borderColour="gray"

--- a/packages/overdrive/lib/components/Radio/Radio.tsx
+++ b/packages/overdrive/lib/components/Radio/Radio.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import * as React from 'react';
-import { FunctionComponent, memo, ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { useStyles } from 'react-treat';
 
 import { Box } from '../Box';
@@ -18,8 +18,8 @@ export interface Props {
 	children: ReactNode;
 }
 
-export const Radio: FunctionComponent<Props> = memo(
-	({ value, className = '', children, disabled = false }) => {
+export const Radio = forwardRef<HTMLInputElement, Props>(
+	({ value, className = '', children, disabled = false }, ref) => {
 		const styles = useStyles(styleRefs);
 		const { checkableItem } = useCheckableStyles();
 		const radioContext = useRadioContext();
@@ -30,6 +30,7 @@ export const Radio: FunctionComponent<Props> = memo(
 
 		return (
 			<CheckableBase
+				ref={ref}
 				inputType="radio"
 				className={className}
 				inputName={radioContext.inputName}

--- a/packages/overdrive/lib/components/Radio/RadioGroup.tsx
+++ b/packages/overdrive/lib/components/Radio/RadioGroup.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { createContext, FunctionComponent, useContext, useMemo } from 'react';
+import {
+	createContext,
+	forwardRef,
+	ReactNode,
+	useContext,
+	useMemo,
+} from 'react';
 
 import { Box } from '../Box';
 
@@ -7,6 +13,7 @@ export interface Props {
 	name: string;
 	className?: string;
 	value: string;
+	children: ReactNode;
 
 	onChange?(value: string): void;
 }
@@ -23,29 +30,26 @@ export const RadioContext = createContext<RadioGroupContext | null>(null);
 export const useRadioContext = (): RadioGroupContext =>
 	useContext(RadioContext)!;
 
-export const RadioGroup: FunctionComponent<Props> = ({
-	name,
-	value,
-	className = '',
-	onChange,
-	children,
-}) => {
-	const contextValue = useMemo(
-		() => ({ value, inputName: name, radioSelected: onChange }),
-		[value, name, onChange],
-	);
+export const RadioGroup = forwardRef<HTMLDivElement, Props>(
+	({ name, value, className = '', onChange, children }, ref) => {
+		const contextValue = useMemo(
+			() => ({ value, inputName: name, radioSelected: onChange }),
+			[value, name, onChange],
+		);
 
-	return (
-		<RadioContext.Provider value={contextValue}>
-			<Box
-				position="relative"
-				display="flex"
-				flexDirection="column"
-				width="full"
-				padding="none"
-				className={className}>
-				{children}
-			</Box>
-		</RadioContext.Provider>
-	);
-};
+		return (
+			<RadioContext.Provider value={contextValue}>
+				<Box
+					ref={ref}
+					position="relative"
+					display="flex"
+					flexDirection="column"
+					width="full"
+					padding="none"
+					className={className}>
+					{children}
+				</Box>
+			</RadioContext.Provider>
+		);
+	},
+);

--- a/packages/overdrive/lib/components/private/CheckableBase/CheckableBase.tsx
+++ b/packages/overdrive/lib/components/private/CheckableBase/CheckableBase.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import * as React from 'react';
-import { ChangeEvent, FunctionComponent, ReactNode } from 'react';
+import { ChangeEvent, forwardRef, ReactNode } from 'react';
 import { useStyles } from 'react-treat';
 
 import { Box, useBoxStyles } from '../../Box';
@@ -16,92 +16,102 @@ export interface Props {
 	inputName: string;
 	inputType: string;
 	value: string;
+	children: ReactNode;
 
 	handleClick(event): void;
 
 	handleChange?(checked: boolean): void;
 }
 
-export const CheckableBase: FunctionComponent<Props> = ({
-	className = '',
-	label = '',
-	checked = false,
-	disabled = false,
-	inputType,
-	inputName,
-	value,
-	children,
-	handleClick,
-	handleChange,
-}) => {
-	const styles = useStyles(styleRefs);
-	const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-		if (typeof handleChange === 'function') {
-			handleChange(e.currentTarget.checked);
-		}
-	};
+export const CheckableBase = forwardRef<HTMLInputElement, Props>(
+	(
+		{
+			className = '',
+			label = '',
+			checked = false,
+			disabled = false,
+			inputType,
+			inputName,
+			value,
+			children,
+			handleClick,
+			handleChange,
+		},
+		ref,
+	) => {
+		const styles = useStyles(styleRefs);
+		const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+			if (typeof handleChange === 'function') {
+				handleChange(e.currentTarget.checked);
+			}
+		};
 
-	const nakedLabel = ['string', 'number'].includes(typeof label);
+		const nakedLabel = ['string', 'number'].includes(typeof label);
 
-	return (
-		<Box
-			display="flex"
-			alignItems="center"
-			flexDirection="row"
-			justifyContent="flexStart"
-			padding="3"
-			paddingLeft="none"
-			position="relative"
-			className={[
-				styles.root,
-				useBoxStyles({ is: 'button' }),
-				className,
-				{ [styles.disabled]: disabled },
-			]}>
-			<Box
-				is="input"
-				position="absolute"
-				width="full"
-				height="full"
-				margin="none"
-				padding="none"
-				name={inputName}
-				value={value}
-				checked={checked}
-				disabled={disabled}
-				type={inputType}
-				pointerEvents={disabled ? 'none' : void 0}
-				className={clsx(
-					useBoxStyles({ is: 'button' }),
-					styles.nativeInput.default,
-					{
-						[styles.nativeInput.checked]: checked,
-					},
-				)}
-				onClick={handleClick}
-				onChange={onChange}
-			/>
+		return (
 			<Box
 				display="flex"
 				alignItems="center"
-				justifyContent="center"
+				flexDirection="row"
+				justifyContent="flexStart"
+				padding="3"
+				paddingLeft="none"
 				position="relative"
-				className={[styles.checkable, useBoxStyles({ is: 'button' })]}>
-				{children}
-			</Box>
-			<Box
-				is="label"
-				width="full"
-				pointerEvents={disabled ? 'none' : void 0}
-				className={clsx(
+				className={[
+					styles.root,
 					useBoxStyles({ is: 'button' }),
-					useTextStyles({ size: '4' }),
-					{
-						[styles.label.disabled]: disabled,
-					},
-				)}>
-				{nakedLabel ? <Text is="span">{label}</Text> : label}
+					className,
+					{ [styles.disabled]: disabled },
+				]}>
+				<Box
+					ref={ref}
+					is="input"
+					position="absolute"
+					width="full"
+					height="full"
+					margin="none"
+					padding="none"
+					name={inputName}
+					value={value}
+					checked={checked}
+					disabled={disabled}
+					type={inputType}
+					pointerEvents={disabled ? 'none' : void 0}
+					className={clsx(
+						useBoxStyles({ is: 'button' }),
+						styles.nativeInput.default,
+						{
+							[styles.nativeInput.checked]: checked,
+						},
+					)}
+					onClick={handleClick}
+					onChange={onChange}
+				/>
+				<Box
+					display="flex"
+					alignItems="center"
+					justifyContent="center"
+					position="relative"
+					className={[
+						styles.checkable,
+						useBoxStyles({ is: 'button' }),
+					]}>
+					{children}
+				</Box>
+				<Box
+					is="label"
+					width="full"
+					pointerEvents={disabled ? 'none' : void 0}
+					className={clsx(
+						useBoxStyles({ is: 'button' }),
+						useTextStyles({ size: '4' }),
+						{
+							[styles.label.disabled]: disabled,
+						},
+					)}>
+					{nakedLabel ? <Text is="span">{label}</Text> : label}
+				</Box>
 			</Box>
-		</Box>
-	);
-};
+		);
+	},
+);


### PR DESCRIPTION
In order to facilitate Radio and CheckBoxes to be integrated with form management libraries such as Formik, we need to be bale to pas element refs down to input elements.