### PR TITLE
feat: Adds loading state for input types

### DIFF
--- a/.changeset/unlucky-apricots-compete.md
+++ b/.changeset/unlucky-apricots-compete.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': minor
+---
+
+Input fields: Get a loading state

--- a/packages/overdrive/lib/components/Alert/__snapshots__/Alert.spec.jsx.snap
+++ b/packages/overdrive/lib/components/Alert/__snapshots__/Alert.spec.jsx.snap
@@ -23,6 +23,7 @@ exports[`<Alert /> should match the snapshot 1`] = `
             fill="currentColor"
             focusable="false"
             viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
               d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm-1 14.502l7-7-1.414-1.414L11 13.674l-3.086-3.086L6.5 12.002l4.5 4.5z"
@@ -61,6 +62,7 @@ exports[`<Alert /> should match the snapshot 1`] = `
                 fill="currentColor"
                 focusable="false"
                 viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
               >
                 <path
                   d="M13.458 12L19 17.543V19h-1.457L12 13.457 6.458 19H5v-1.456L10.544 12 5 6.458V5h1.457L12 10.543 17.544 5H19v1.458L13.458 12z"

--- a/packages/overdrive/lib/components/AutoSuggest/AutoSuggest.tsx
+++ b/packages/overdrive/lib/components/AutoSuggest/AutoSuggest.tsx
@@ -302,6 +302,7 @@ const AutoSuggestFullscreenInput = forwardRef(
 const AutoSuggestInput = forwardRef(function AutoSuggestInput(
 	{
 		inlineOptions = false,
+		isLoading,
 		autoFocus,
 		autoWidth,
 		suggestions,
@@ -352,6 +353,7 @@ const AutoSuggestInput = forwardRef(function AutoSuggestInput(
 			aria-haspopup="listbox"
 			width="full">
 			<AutoSuggestInputPrimitive
+				isLoading={isLoading}
 				autoFocus={autoFocus}
 				wrapperRef={triggerRef}
 				{...textInputProps}
@@ -563,7 +565,15 @@ const SuggestionsList = <PayloadType extends unknown>({
 };
 
 const AutoSuggestInputPrimitive = withEnhancedInput(
-	({ field, eventHandlers, validation, suffixed, prefixed, ...rest }) => {
+	({
+		field,
+		eventHandlers,
+		validation,
+		suffixed,
+		prefixed,
+		isLoading,
+		...rest
+	}) => {
 		const ref = useRef<HTMLInputElement>(null);
 
 		const focusHandler = useCallback(() => {
@@ -598,9 +608,11 @@ const AutoSuggestInputPrimitive = withEnhancedInput(
 					{...rest}
 					type="search"
 				/>
-				<Box flexShrink={0} marginRight="4" onClick={focusHandler}>
-					<Icon size="medium" icon={ChevronDownIcon} />
-				</Box>
+				{isLoading ? null : (
+					<Box flexShrink={0} marginRight="4" onClick={focusHandler}>
+						<Icon size="medium" icon={ChevronDownIcon} />
+					</Box>
+				)}
 			</Box>
 		);
 	},

--- a/packages/overdrive/lib/components/AutoSuggest/stories.tsx
+++ b/packages/overdrive/lib/components/AutoSuggest/stories.tsx
@@ -1,4 +1,4 @@
-import { CarIcon } from '@autoguru/icons';
+import { CarIcon, PlusIcon } from '@autoguru/icons';
 import { action } from '@storybook/addon-actions';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
@@ -110,6 +110,36 @@ export const InsideModal = () => {
 		</>
 	);
 };
+
+export const withIcon = () => (
+	<AutoSuggest
+		value={null}
+		suggestions={[]}
+		prefixIcon={PlusIcon}
+		name="test"
+		placeholder="Pick nothing..."
+	/>
+);
+
+export const loading = () => (
+	<AutoSuggest
+		value={null}
+		suggestions={[]}
+		isLoading
+		name="test"
+		placeholder="Pick nothing..."
+	/>
+);
+export const loadingWithIcon = () => (
+	<AutoSuggest
+		value={null}
+		suggestions={[]}
+		prefixIcon={PlusIcon}
+		isLoading
+		name="test"
+		placeholder="Pick nothing..."
+	/>
+);
 
 InsideModal.story = {
 	parameters: {

--- a/packages/overdrive/lib/components/BulletText/__snapshots__/BulletText.spec.jsx.snap
+++ b/packages/overdrive/lib/components/BulletText/__snapshots__/BulletText.spec.jsx.snap
@@ -20,6 +20,7 @@ exports[`<BulletText /> should match snapshot for custom bullet text 1`] = `
             fill="currentColor"
             focusable="false"
             viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
               d="M21 7L9 19l-5.5-5.5 1.414-1.414L9 16.172 19.586 5.586 21 7z"

--- a/packages/overdrive/lib/components/CheckBox/__snapshots__/CheckBox.spec.jsx.snap
+++ b/packages/overdrive/lib/components/CheckBox/__snapshots__/CheckBox.spec.jsx.snap
@@ -23,6 +23,7 @@ exports[`<CheckBox /> should match the snapshot for a checked check 1`] = `
         fill="currentColor"
         focusable="false"
         viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
       >
         <path
           d="M21 7L9 19l-5.5-5.5 1.414-1.414L9 16.172 19.586 5.586 21 7z"

--- a/packages/overdrive/lib/components/DateInput/DateInput.spec.jsx
+++ b/packages/overdrive/lib/components/DateInput/DateInput.spec.jsx
@@ -131,6 +131,7 @@ describe('<DateInput />', () => {
 					className="input-class"
 					placeholder="placeholder something"
 					prefixIcon={TestIcon}
+					value={todayStr}
 				/>,
 			).container.firstChild,
 		).toMatchSnapshot();
@@ -142,6 +143,7 @@ describe('<DateInput />', () => {
 				<DateInput
 					className="input-class"
 					placeholder="placeholder something"
+					value={todayStr}
 					suffixIcon={TestIcon}
 				/>,
 			).container.firstChild,
@@ -154,6 +156,7 @@ describe('<DateInput />', () => {
 				<DateInput
 					className="input-class"
 					placeholder="placeholder something"
+					value={todayStr}
 					prefixIcon={TestIcon}
 					suffixIcon={TestIcon}
 				/>,

--- a/packages/overdrive/lib/components/DateInput/DateInput.spec.jsx
+++ b/packages/overdrive/lib/components/DateInput/DateInput.spec.jsx
@@ -164,6 +164,22 @@ describe('<DateInput />', () => {
 		).toMatchSnapshot();
 	});
 
+
+	it('should match snapshot when loading', () => {
+		expect(
+			render(
+				<DateInput
+					isLoading
+					className="input-class"
+					placeholder="placeholder something"
+					value={todayStr}
+					prefixIcon={TestIcon}
+					suffixIcon={TestIcon}
+				/>,
+			).container.firstChild,
+		).toMatchSnapshot();
+	});
+
 	it('should display placeholder text', () => {
 		const { container } = render(
 			<DateInput value={todayStr} placeholder="placeholder something" />,

--- a/packages/overdrive/lib/components/DateInput/DateInput.tsx
+++ b/packages/overdrive/lib/components/DateInput/DateInput.tsx
@@ -7,7 +7,7 @@ import { withEnhancedInput } from '../private/InputBase';
 export const DateInput = withEnhancedInput<
 	Partial<Pick<HTMLInputElement, 'min' | 'max'>>
 >(
-	({ field, eventHandlers, validation, suffixed, prefixed, ...rest }) => {
+	({ field, eventHandlers, validation, isLoading, suffixed, prefixed, ...rest }) => {
 		warning(
 			field.value !== '',
 			'Date Input does not support empty values.',

--- a/packages/overdrive/lib/components/DateInput/__snapshots__/DateInput.spec.jsx.snap
+++ b/packages/overdrive/lib/components/DateInput/__snapshots__/DateInput.spec.jsx.snap
@@ -132,6 +132,79 @@ exports[`<DateInput /> should match snapshot when active 1`] = `
 </div>
 `;
 
+exports[`<DateInput /> should match snapshot when loading 1`] = `
+<div
+  class="block width_full input-class"
+>
+  <div
+    class="block none_mobile_base none_mobile_base none_mobile_base none_mobile_base width_full position_relative root_base"
+  >
+    <div
+      class="block width_full height_full"
+    >
+      <i
+        class="display_block medium_mobile_base block position_absolute pointerEvents_none iconRoot_base icon_prefix styleNode_base"
+        role="presentation"
+      >
+        <svg
+          class="display_block width_full height_full"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
+          />
+        </svg>
+      </i>
+      <div
+        class="block size_medium_circular_base colours_primary_base block position_absolute pointerEvents_none iconRoot_base icon_suffix styleNode_base"
+      >
+        <svg
+          class="display_block overflow_hidden circular"
+          viewBox="25 25 50 50"
+        >
+          <circle
+            class="path_base size_medium_path_base"
+            cx="50"
+            cy="50"
+            fill="none"
+            r="20"
+            stroke-miterlimit="10"
+          />
+        </svg>
+      </div>
+      <input
+        aria-busy="true"
+        autocomplete="off"
+        class="trimmedBlockElement appearance input trimmedBlockElement appearance input display_flex width_full position_relative input_itself_root_base input_itself_prefixed_base input_itself_suffixed_base"
+        type="date"
+        value="2019-01-21"
+      />
+    </div>
+    <div
+      class="block display_flex width_full height_full position_absolute textAlign_left pointerEvents_none borderVisualDefaults_base borders_root_default"
+    >
+      <div
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
+      />
+      <div
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
+        style="width: 16px;"
+      >
+        <label
+          class="inlineText none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base display_inline position_absolute pointerEvents_none placeholder_default_base styleNode_base root_base block colours_neutral_base noWrap sizes_4_base placeholderPlacement_shifted_base"
+        >
+          placeholder something
+        </label>
+      </div>
+      <div
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<DateInput /> should match snapshot when touched 1`] = `
 <div
   class="block width_full input-class"

--- a/packages/overdrive/lib/components/DateInput/__snapshots__/DateInput.spec.jsx.snap
+++ b/packages/overdrive/lib/components/DateInput/__snapshots__/DateInput.spec.jsx.snap
@@ -297,7 +297,7 @@ exports[`<DateInput /> should match snapshot with both icons 1`] = `
         autocomplete="off"
         class="trimmedBlockElement appearance input trimmedBlockElement appearance input display_flex width_full position_relative input_itself_root_base input_itself_prefixed_base input_itself_suffixed_base"
         type="date"
-        value=""
+        value="2019-01-21"
       />
     </div>
     <div
@@ -352,7 +352,7 @@ exports[`<DateInput /> should match snapshot with prefix icon 1`] = `
         autocomplete="off"
         class="trimmedBlockElement appearance input trimmedBlockElement appearance input display_flex width_full position_relative input_itself_root_base input_itself_prefixed_base"
         type="date"
-        value=""
+        value="2019-01-21"
       />
     </div>
     <div
@@ -407,7 +407,7 @@ exports[`<DateInput /> should match snapshot with suffix icon 1`] = `
         autocomplete="off"
         class="trimmedBlockElement appearance input trimmedBlockElement appearance input display_flex width_full position_relative input_itself_root_base input_itself_suffixed_base"
         type="date"
-        value=""
+        value="2019-01-21"
       />
     </div>
     <div

--- a/packages/overdrive/lib/components/DateInput/stories.tsx
+++ b/packages/overdrive/lib/components/DateInput/stories.tsx
@@ -115,3 +115,24 @@ export const disabled = () => (
 		hintText={text('Hint Text', 'dd/mm/yyy')}
 	/>
 );
+
+export const loading = () => (
+	<DateInput
+		isLoading
+		value={todayStr}
+		placeholder="What si your DOB?"
+		name="abc"
+		hintText={text('Hint Text', 'dd/mm/yyy')}
+	/>
+);
+
+export const loadingWithIcon = () => (
+	<DateInput
+		isLoading
+		value={todayStr}
+		prefixIcon={AccountEditIcon}
+		placeholder="What si your DOB?"
+		name="abc"
+		hintText={text('Hint Text', 'dd/mm/yyy')}
+	/>
+);

--- a/packages/overdrive/lib/components/NumberInput/NumberInput.spec.jsx
+++ b/packages/overdrive/lib/components/NumberInput/NumberInput.spec.jsx
@@ -17,6 +17,13 @@ describe('<NumberInput />', () => {
 		).toMatchSnapshot();
 	});
 
+	it('should match snapshot when loading', () => {
+		expect(
+			render(<NumberInput placeholder="placeholder something" id="id" />)
+				.container.firstChild,
+		).toMatchSnapshot();
+	});
+
 	it('should have some hintText', () => {
 		const hintText = () => 'hint text';
 

--- a/packages/overdrive/lib/components/NumberInput/NumberInput.tsx
+++ b/packages/overdrive/lib/components/NumberInput/NumberInput.tsx
@@ -11,7 +11,7 @@ const type = isEdge ? 'text' : 'number';
 export const NumberInput = withEnhancedInput<
 	Partial<Pick<HTMLInputElement, 'min' | 'max' | 'step'>>
 >(
-	({ field, eventHandlers, validation, suffixed, prefixed, ...rest }) => (
+	({ field, eventHandlers, validation, isLoading, suffixed, prefixed, ...rest }) => (
 		<Box
 			is="input"
 			{...eventHandlers}

--- a/packages/overdrive/lib/components/NumberInput/__snapshots__/NumberInput.spec.jsx.snap
+++ b/packages/overdrive/lib/components/NumberInput/__snapshots__/NumberInput.spec.jsx.snap
@@ -132,6 +132,49 @@ exports[`<NumberInput /> should match snapshot when active 1`] = `
 </div>
 `;
 
+exports[`<NumberInput /> should match snapshot when loading 1`] = `
+<div
+  class="block width_full"
+>
+  <div
+    class="block none_mobile_base none_mobile_base none_mobile_base none_mobile_base width_full position_relative root_base"
+  >
+    <div
+      class="block width_full height_full"
+    >
+      <input
+        autocomplete="off"
+        class="trimmedBlockElement appearance input trimmedBlockElement appearance input display_flex width_full position_relative input_itself_root_base"
+        id="id"
+        type="number"
+        value=""
+      />
+    </div>
+    <div
+      class="block display_flex width_full height_full position_absolute textAlign_left pointerEvents_none borderVisualDefaults_base borders_root_default"
+    >
+      <div
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
+      />
+      <div
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
+        style="width: 0px;"
+      >
+        <label
+          class="inlineText none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base display_inline position_absolute pointerEvents_none placeholder_default_base root_base block colours_neutral_base noWrap sizes_4_base placeholder_mutedLabelStyles_base placeholderPlacement_default_base"
+          for="id"
+        >
+          placeholder something
+        </label>
+      </div>
+      <div
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<NumberInput /> should match snapshot when touched 1`] = `
 <div
   class="block width_full input-class"

--- a/packages/overdrive/lib/components/NumberInput/stories.tsx
+++ b/packages/overdrive/lib/components/NumberInput/stories.tsx
@@ -90,3 +90,17 @@ export const withIcon = () => (
 export const disabled = () => (
 	<NumberInput disabled name="abc" placeholder="How many?" />
 );
+
+export const loading = () => (
+	<NumberInput isLoading name="abc" placeholder="How many?" />
+);
+
+export const loadingWithIcon = () => (
+	<NumberInput
+		isLoading
+		prefixIcon={PlusIcon}
+		suffixIcon={StarIcon}
+		name="abc"
+		placeholder="How many?"
+	/>
+);

--- a/packages/overdrive/lib/components/Pagination/__snapshots__/Pagination.spec.jsx.snap
+++ b/packages/overdrive/lib/components/Pagination/__snapshots__/Pagination.spec.jsx.snap
@@ -21,6 +21,7 @@ exports[`<Pagination /> should match snapshot for loading phase 1`] = `
           fill="currentColor"
           focusable="false"
           viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
         >
           <path
             d="M15.414 16.584l-4.586-4.586 4.586-4.586-1.415-1.414-6 6 6 6 1.415-1.414z"
@@ -67,6 +68,7 @@ exports[`<Pagination /> should match snapshot for loading phase 1`] = `
           fill="currentColor"
           focusable="false"
           viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
         >
           <path
             d="M8.585 16.584l4.586-4.586-4.586-4.586L10 5.998l6 6-6 6-1.414-1.414z"

--- a/packages/overdrive/lib/components/SelectInput/SelectInput.tsx
+++ b/packages/overdrive/lib/components/SelectInput/SelectInput.tsx
@@ -15,7 +15,15 @@ export const SelectInput = withEnhancedInput<
 	},
 	HTMLSelectElement
 >(
-	({ field, eventHandlers, suffixed, prefixed, validation, ...rest }) => {
+	({
+		field,
+		eventHandlers,
+		suffixed,
+		prefixed,
+		validation,
+		isLoading,
+		...rest
+	}) => {
 		const styles = useStyles(styleRefs);
 		return (
 			<Box
@@ -37,17 +45,19 @@ export const SelectInput = withEnhancedInput<
 					]}
 					autoComplete="off"
 				/>
-				<Box
-					className={styles.arrow}
-					display="flex"
-					alignItems="center"
-					height="full"
-					marginRight="4"
-					flexShrink={0}
-					pointerEvents="none"
-					position="absolute">
-					<Icon size="medium" icon={ChevronDownIcon} />
-				</Box>
+				{isLoading ? null : (
+					<Box
+						className={styles.arrow}
+						display="flex"
+						alignItems="center"
+						height="full"
+						marginRight="4"
+						flexShrink={0}
+						pointerEvents="none"
+						position="absolute">
+						<Icon size="medium" icon={ChevronDownIcon} />
+					</Box>
+				)}
 			</Box>
 		);
 	},

--- a/packages/overdrive/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
+++ b/packages/overdrive/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
@@ -45,6 +45,7 @@ exports[`<SelectInput /> should have some hintText 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
@@ -128,6 +129,7 @@ exports[`<SelectInput /> should match snapshot 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
@@ -206,6 +208,7 @@ exports[`<SelectInput /> should match snapshot when active 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
@@ -284,6 +287,7 @@ exports[`<SelectInput /> should match snapshot when touched 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
@@ -362,6 +366,7 @@ exports[`<SelectInput /> should match snapshot when touched and invalid 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
@@ -440,6 +445,7 @@ exports[`<SelectInput /> should match snapshot when touched and valid 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
@@ -516,6 +522,7 @@ exports[`<SelectInput /> should match snapshot with prefix icon 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"

--- a/packages/overdrive/lib/components/SelectInput/stories.tsx
+++ b/packages/overdrive/lib/components/SelectInput/stories.tsx
@@ -103,3 +103,22 @@ export const disabled = () => (
 		<option value="Option 2">Option 2</option>
 	</SelectInput>
 );
+
+export const loading = () => (
+	<SelectInput isLoading name="abc" placeholder="Select one" value="Option 2">
+		<option disabled />
+		<option value="Option 2">Option 2</option>
+	</SelectInput>
+);
+
+export const loadingWithIcon = () => (
+	<SelectInput
+		isLoading
+		prefixIcon={AccountEditIcon}
+		name="abc"
+		placeholder="Select one"
+		value="Option 2">
+		<option disabled />
+		<option value="Option 2">Option 2</option>
+	</SelectInput>
+);

--- a/packages/overdrive/lib/components/SimplePagination/__snapshots__/SimplePagination.spec.jsx.snap
+++ b/packages/overdrive/lib/components/SimplePagination/__snapshots__/SimplePagination.spec.jsx.snap
@@ -25,6 +25,7 @@ exports[`<SimplePagination /> should match snapshot for hasNext 1`] = `
             fill="currentColor"
             focusable="false"
             viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
               d="M15.414 16.584l-4.586-4.586 4.586-4.586-1.415-1.414-6 6 6 6 1.415-1.414z"
@@ -54,6 +55,7 @@ exports[`<SimplePagination /> should match snapshot for hasNext 1`] = `
             fill="currentColor"
             focusable="false"
             viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
               d="M8.585 16.584l4.586-4.586-4.586-4.586L10 5.998l6 6-6 6-1.414-1.414z"
@@ -90,6 +92,7 @@ exports[`<SimplePagination /> should match snapshot for hasNext and hasPrevious 
             fill="currentColor"
             focusable="false"
             viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
               d="M15.414 16.584l-4.586-4.586 4.586-4.586-1.415-1.414-6 6 6 6 1.415-1.414z"
@@ -119,6 +122,7 @@ exports[`<SimplePagination /> should match snapshot for hasNext and hasPrevious 
             fill="currentColor"
             focusable="false"
             viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
               d="M8.585 16.584l4.586-4.586-4.586-4.586L10 5.998l6 6-6 6-1.414-1.414z"
@@ -155,6 +159,7 @@ exports[`<SimplePagination /> should match snapshot for hasPrevious 1`] = `
             fill="currentColor"
             focusable="false"
             viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
               d="M15.414 16.584l-4.586-4.586 4.586-4.586-1.415-1.414-6 6 6 6 1.415-1.414z"
@@ -185,6 +190,7 @@ exports[`<SimplePagination /> should match snapshot for hasPrevious 1`] = `
             fill="currentColor"
             focusable="false"
             viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
               d="M8.585 16.584l4.586-4.586-4.586-4.586L10 5.998l6 6-6 6-1.414-1.414z"

--- a/packages/overdrive/lib/components/StandardModal/__snapshots__/StandardModal.spec.jsx.snap
+++ b/packages/overdrive/lib/components/StandardModal/__snapshots__/StandardModal.spec.jsx.snap
@@ -67,6 +67,7 @@ exports[`<StandardModal /> should match snapshot with title and body 1`] = `
                     fill="currentColor"
                     focusable="false"
                     viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
                       d="M13.458 12L19 17.543V19h-1.457L12 13.457 6.458 19H5v-1.456L10.544 12 5 6.458V5h1.457L12 10.543 17.544 5H19v1.458L13.458 12z"
@@ -160,6 +161,7 @@ exports[`<StandardModal /> should match snapshot without title and body 1`] = `
                     fill="currentColor"
                     focusable="false"
                     viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
                       d="M13.458 12L19 17.543V19h-1.457L12 13.457 6.458 19H5v-1.456L10.544 12 5 6.458V5h1.457L12 10.543 17.544 5H19v1.458L13.458 12z"

--- a/packages/overdrive/lib/components/Stepper/__snapshots__/Stepper.spec.jsx.snap
+++ b/packages/overdrive/lib/components/Stepper/__snapshots__/Stepper.spec.jsx.snap
@@ -29,6 +29,7 @@ exports[`<Stepper /> should match snapshot with label formatter 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M19 12.998H5V11l14-.002v2z"
@@ -71,6 +72,7 @@ exports[`<Stepper /> should match snapshot with label formatter 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6v2z"
@@ -113,6 +115,7 @@ exports[`<Stepper /> should match snapshot with props 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M19 12.998H5V11l14-.002v2z"
@@ -155,6 +158,7 @@ exports[`<Stepper /> should match snapshot with props 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6v2z"
@@ -198,6 +202,7 @@ exports[`<Stepper /> should match snapshot without props 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M19 12.998H5V11l14-.002v2z"
@@ -241,6 +246,7 @@ exports[`<Stepper /> should match snapshot without props 1`] = `
               fill="currentColor"
               focusable="false"
               viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6v2z"

--- a/packages/overdrive/lib/components/Table/__snapshots__/Table.spec.js.snap
+++ b/packages/overdrive/lib/components/Table/__snapshots__/Table.spec.js.snap
@@ -65,6 +65,7 @@ exports[`<Table /> when implemented should match snapshot 1`] = `
                   fill="currentColor"
                   focusable="false"
                   viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
                     d="M277.333 426.667h-42.666v-256L117.333 288 87.04 257.707 256 88.747l168.96 168.96L394.667 288 277.333 170.667v256z"

--- a/packages/overdrive/lib/components/TextAreaInput/TextAreaInput.spec.jsx
+++ b/packages/overdrive/lib/components/TextAreaInput/TextAreaInput.spec.jsx
@@ -12,6 +12,14 @@ describe('<TextAreaInput />', () => {
 		).toMatchSnapshot();
 	});
 
+	it('should match snapshot when loading', () => {
+		expect(
+			render(
+				<TextAreaInput isLoading placeholder="placeholder something" id="id" />,
+			).container.firstChild,
+		).toMatchSnapshot();
+	});
+
 	it('should have some hintText', () => {
 		const hintText = () => 'hint text';
 

--- a/packages/overdrive/lib/components/TextAreaInput/TextAreaInput.tsx
+++ b/packages/overdrive/lib/components/TextAreaInput/TextAreaInput.tsx
@@ -4,7 +4,7 @@ import { Box } from '../Box';
 import { withEnhancedInput } from '../private/InputBase';
 
 export const TextAreaInput = withEnhancedInput<{}, HTMLTextAreaElement>(
-	({ field, eventHandlers, validation, suffixed, prefixed, ...rest }) => (
+	({ field, eventHandlers, validation, isLoading, suffixed, prefixed, ...rest }) => (
 		<Box
 			is="textarea"
 			{...eventHandlers}

--- a/packages/overdrive/lib/components/TextAreaInput/__snapshots__/TextAreaInput.spec.jsx.snap
+++ b/packages/overdrive/lib/components/TextAreaInput/__snapshots__/TextAreaInput.spec.jsx.snap
@@ -128,6 +128,65 @@ exports[`<TextAreaInput /> should match snapshot when active 1`] = `
 </div>
 `;
 
+exports[`<TextAreaInput /> should match snapshot when loading 1`] = `
+<div
+  class="block width_full"
+>
+  <div
+    class="block none_mobile_base none_mobile_base none_mobile_base none_mobile_base width_full position_relative root_base"
+  >
+    <div
+      class="block width_full height_full"
+    >
+      <div
+        class="block size_medium_circular_base colours_primary_base block position_absolute pointerEvents_none iconRoot_base icon_suffix styleNode_base"
+      >
+        <svg
+          class="display_block overflow_hidden circular"
+          viewBox="25 25 50 50"
+        >
+          <circle
+            class="path_base size_medium_path_base"
+            cx="50"
+            cy="50"
+            fill="none"
+            r="20"
+            stroke-miterlimit="10"
+          />
+        </svg>
+      </div>
+      <textarea
+        aria-busy="true"
+        autocomplete="off"
+        class="trimmedBlockElement appearance input trimmedBlockElement appearance input display_flex width_full position_relative types_textarea_base input_itself_root_base input_itself_suffixed_base"
+        id="id"
+      />
+    </div>
+    <div
+      class="block display_flex width_full height_full position_absolute textAlign_left pointerEvents_none borderVisualDefaults_base borders_root_default"
+    >
+      <div
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
+      />
+      <div
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
+        style="width: 0px;"
+      >
+        <label
+          class="inlineText none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base display_inline position_absolute pointerEvents_none placeholder_default_base root_base block colours_neutral_base noWrap sizes_4_base placeholder_mutedLabelStyles_base placeholderPlacement_default_base"
+          for="id"
+        >
+          placeholder something
+        </label>
+      </div>
+      <div
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<TextAreaInput /> should match snapshot when touched 1`] = `
 <div
   class="block width_full input-class"

--- a/packages/overdrive/lib/components/TextAreaInput/stories.tsx
+++ b/packages/overdrive/lib/components/TextAreaInput/stories.tsx
@@ -36,4 +36,12 @@ export const disabled = () => (
 		value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vitae pulvinar odio. Duis laoreet lacus vel consequat congue. Ut euismod enim non eros lacinia mollis. Vestibulum libero quam, aliquet non justo laoreet, egestas molestie ante. Quisque urna leo, consectetur id dui aliquet, placerat iaculis augue. Pellentesque sed vestibulum augue, quis porta lectus."
 	/>
 );
+export const loading = () => (
+	<TextAreaInput
+		isLoading
+		name="abc"
+		placeholder="Tell us about your car."
+		value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vitae pulvinar odio. Duis laoreet lacus vel consequat congue. Ut euismod enim non eros lacinia mollis. Vestibulum libero quam, aliquet non justo laoreet, egestas molestie ante. Quisque urna leo, consectetur id dui aliquet, placerat iaculis augue. Pellentesque sed vestibulum augue, quis porta lectus."
+	/>
+);
 // TODO: A test here to limit the value to 100 chars

--- a/packages/overdrive/lib/components/TextInput/TextInput.spec.jsx
+++ b/packages/overdrive/lib/components/TextInput/TextInput.spec.jsx
@@ -17,6 +17,13 @@ describe('<TextInput />', () => {
 		).toMatchSnapshot();
 	});
 
+	it('should match snapshot when loading', () => {
+		expect(
+			render(<TextInput isLoading placeholder="placeholder something" id="id" />)
+				.container.firstChild,
+		).toMatchSnapshot();
+	});
+
 	it('should have some hintText', () => {
 		const hintText = () => 'hint text';
 

--- a/packages/overdrive/lib/components/TextInput/TextInput.tsx
+++ b/packages/overdrive/lib/components/TextInput/TextInput.tsx
@@ -6,7 +6,15 @@ import { withEnhancedInput } from '../private/InputBase';
 export const TextInput = withEnhancedInput<
 	Partial<Pick<HTMLInputElement, 'type'>>
 >(
-	({ field, eventHandlers, validation, suffixed, prefixed, ...rest }) => (
+	({
+		field,
+		eventHandlers,
+		validation,
+		suffixed,
+		prefixed,
+		isLoading,
+		...rest
+	}) => (
 		<Box
 			is="input"
 			{...eventHandlers}

--- a/packages/overdrive/lib/components/TextInput/__snapshots__/TextInput.spec.jsx.snap
+++ b/packages/overdrive/lib/components/TextInput/__snapshots__/TextInput.spec.jsx.snap
@@ -132,6 +132,67 @@ exports[`<TextInput /> should match snapshot when active 1`] = `
 </div>
 `;
 
+exports[`<TextInput /> should match snapshot when loading 1`] = `
+<div
+  class="block width_full"
+>
+  <div
+    class="block none_mobile_base none_mobile_base none_mobile_base none_mobile_base width_full position_relative root_base"
+  >
+    <div
+      class="block width_full height_full"
+    >
+      <div
+        class="block size_medium_circular_base colours_primary_base block position_absolute pointerEvents_none iconRoot_base icon_suffix styleNode_base"
+      >
+        <svg
+          class="display_block overflow_hidden circular"
+          viewBox="25 25 50 50"
+        >
+          <circle
+            class="path_base size_medium_path_base"
+            cx="50"
+            cy="50"
+            fill="none"
+            r="20"
+            stroke-miterlimit="10"
+          />
+        </svg>
+      </div>
+      <input
+        aria-busy="true"
+        autocomplete="off"
+        class="trimmedBlockElement appearance input trimmedBlockElement appearance input display_flex width_full position_relative input_itself_root_base input_itself_suffixed_base"
+        id="id"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="block display_flex width_full height_full position_absolute textAlign_left pointerEvents_none borderVisualDefaults_base borders_root_default"
+    >
+      <div
+        class="borderRegionDefaults_base borders_leading_base styleNode_base"
+      />
+      <div
+        class="borderRegionDefaults_base borders_middle_base styleNode_base"
+        style="width: 0px;"
+      >
+        <label
+          class="inlineText none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base none_mobile_base display_inline position_absolute pointerEvents_none placeholder_default_base root_base block colours_neutral_base noWrap sizes_4_base placeholder_mutedLabelStyles_base placeholderPlacement_default_base"
+          for="id"
+        >
+          placeholder something
+        </label>
+      </div>
+      <div
+        class="borderRegionDefaults_base borders_trailing_base styleNode_base"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<TextInput /> should match snapshot when touched 1`] = `
 <div
   class="block width_full input-class"

--- a/packages/overdrive/lib/components/TextInput/stories.tsx
+++ b/packages/overdrive/lib/components/TextInput/stories.tsx
@@ -126,3 +126,24 @@ export const disabledWithValue = () => (
 		hintText="Cannot be Bob The Builder."
 	/>
 );
+
+export const loading = () => (
+	<TextInput
+		isLoading
+		placeholder="What is your first name?"
+		value="Bob The Builder"
+		name="abc"
+		hintText="Cannot be Bob The Builder."
+	/>
+);
+
+export const loadingWithIcon = () => (
+	<TextInput
+		isLoading
+		prefixIcon={AccountEditIcon}
+		placeholder="What is your first name?"
+		value="Bob The Builder"
+		name="abc"
+		hintText="Cannot be Bob The Builder."
+	/>
+);

--- a/packages/overdrive/lib/components/private/InputBase/withEnhancedInput.tsx
+++ b/packages/overdrive/lib/components/private/InputBase/withEnhancedInput.tsx
@@ -238,9 +238,9 @@ export const withEnhancedInput = <
 				},
 				prefixed: Boolean(prefixIcon),
 				suffixed: Boolean(suffixIcon),
-				isLoading: isLoading,
+				isLoading,
+				'aria-busy': isLoading || void 0,
 				...(rest as IncomingProps),
-				'aria-label': isLoading ? 'Loading' : rest['aria-label'],
 			};
 
 			const onMouseOver = useCallback(() => {

--- a/packages/overdrive/lib/components/private/InputBase/withEnhancedInput.tsx
+++ b/packages/overdrive/lib/components/private/InputBase/withEnhancedInput.tsx
@@ -1,4 +1,5 @@
 import { IconType } from '@autoguru/icons';
+import { ProgressSpinner } from '../../ProgressSpinner';
 import { invariant, wrapEvent } from '@autoguru/utilities';
 import clsx from 'clsx';
 import * as React from 'react';
@@ -54,6 +55,7 @@ export interface EnhanceInputPrimitiveProps extends AriaAttributes {
 	prefixIcon?: IconType;
 	suffixIcon?: IconType;
 	wrapperRef?: Ref<HTMLDivElement>;
+	isLoading?: boolean;
 }
 
 export interface ValidationProps {
@@ -79,6 +81,7 @@ export type WrappedComponentProps<IncomingProps, PrimitiveElementType> = {
 	};
 	prefixed: boolean;
 	suffixed: boolean;
+	isLoading: boolean;
 } & IncomingProps;
 
 interface EnhancedInputConfigs {
@@ -115,6 +118,7 @@ export const withEnhancedInput = <
 				className,
 				isTouched,
 				isValid,
+				isLoading = false,
 				notch = true,
 				reserveHintSpace = false,
 
@@ -179,7 +183,9 @@ export const withEnhancedInput = <
 				styles.input.itself.root,
 				{
 					[styles.input.itself.prefixed]: Boolean(prefixIcon),
-					[styles.input.itself.suffixed]: Boolean(suffixIcon),
+					[styles.input.itself.suffixed]: Boolean(
+						suffixIcon || isLoading,
+					),
 				},
 			);
 
@@ -232,7 +238,9 @@ export const withEnhancedInput = <
 				},
 				prefixed: Boolean(prefixIcon),
 				suffixed: Boolean(suffixIcon),
+				isLoading: isLoading,
 				...(rest as IncomingProps),
+				'aria-label': isLoading ? 'Loading' : rest['aria-label'],
 			};
 
 			const onMouseOver = useCallback(() => {
@@ -277,7 +285,16 @@ export const withEnhancedInput = <
 									)}
 								/>
 							) : null}
-							{suffixIcon ? (
+							{isLoading ? (
+								<ProgressSpinner
+									className={clsx(
+										iconStyles,
+										styles.icon.suffix,
+										derivedColours.colour,
+									)}
+								/>
+							) : null}
+							{suffixIcon && !isLoading ? (
 								<Icon
 									icon={suffixIcon}
 									size="medium"

--- a/packages/overdrive/package.json
+++ b/packages/overdrive/package.json
@@ -22,8 +22,8 @@
 	],
 	"main": "./index.ts",
 	"dependencies": {
-		"@autoguru/icons": "^1.5.0",
-		"@autoguru/utilities": "^1.0.97",
+		"@autoguru/icons": "^1.7.4",
+		"@autoguru/utilities": "^1.0.98",
 		"@popperjs/core": "^2.7.0",
 		"clsx": "^1.1.1",
 		"csstype": "^3.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,12 +66,12 @@
     eslint-plugin-react-hooks "^4.2.0"
     eslint-plugin-unicorn "^28.0.2"
 
-"@autoguru/icons@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@autoguru/icons/-/icons-1.5.0.tgz#be316eacbbdfeb04f7b89883b84de26e4f779af9"
-  integrity sha512-MivFdTFttiRHFN3nrvpdgyt5GDdbnwy128cV0vfjrh8HUCQ+Ja4ylKmhbc/I5OsGRnst3UqoZTUmEHH4rUwApA==
+"@autoguru/icons@^1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@autoguru/icons/-/icons-1.7.4.tgz#91833425a2d5750237442ca7f4df45b2e55fbe34"
+  integrity sha512-ZzG22m1Sl43h1ym2Cy+VIxaQowm3ks+3qtEHQt/znyy+TVWDM7URPkM7lE4BkTiBcpATn/6pazjsaKLvjB2RmQ==
   dependencies:
-    tslib "^1.10.0"
+    tslib "^2.1.0"
 
 "@autoguru/jest-preset@1.0.98":
   version "1.0.98"
@@ -89,7 +89,7 @@
   resolved "https://registry.yarnpkg.com/@autoguru/tsconfig/-/tsconfig-1.0.79.tgz#b7b92930e6c369e467cd2870293ec5203d08fb7b"
   integrity sha512-22mjKCPODiy/hYJJdi6Rk6dsDSwVVcHxxPQgt3se2cPJrgicG8h5pFhTiWUrZtajT1O+TpqA+0f2dnMAgKlXFQ==
 
-"@autoguru/utilities@^1.0.97":
+"@autoguru/utilities@^1.0.98":
   version "1.0.98"
   resolved "https://registry.yarnpkg.com/@autoguru/utilities/-/utilities-1.0.98.tgz#4efc60604a927a2856f5b024fafe61f23819e931"
   integrity sha512-Dd5mog9mm9nicXi4BTXKafc0h3PTv/jbIO774h6+TKiip6+Wj3RYjfntxbU/t3Uu7ejzOWE1DXY/lXsa8ALDsQ==
@@ -15086,6 +15086,11 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsutils@^3.17.1:
   version "3.20.0"


### PR DESCRIPTION
Inputs including Autosuggest do not currently support an easy way to show a loading state. A use case for this is when a user is typing into a search box and we might want to display the fact that communication with blackened is in progress. 

This PR removes any existing suffix icon and places a LoadingSpinner in place while `isLoading` flag is on.