### PR TITLE
feat: Adds id and test id props to text and headings

### DIFF
--- a/.changeset/chilly-bees-grin.md
+++ b/.changeset/chilly-bees-grin.md
@@ -1,0 +1,6 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Added id and testId props to Text component. Added testId props to Heading
+component.

--- a/lib/components/Heading/Heading.tsx
+++ b/lib/components/Heading/Heading.tsx
@@ -13,6 +13,8 @@ export interface Props
 	children?: ReactNode;
 	is?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 	colour?: Exclude<keyof Tokens['typography']['colour'], 'muted'>;
+	id?: string;
+	testId?: string;
 }
 
 const sizeScaleDefaults = {
@@ -26,19 +28,21 @@ const sizeScaleDefaults = {
 
 export const Heading: FunctionComponent<Props> = ({
 	is = 'h1',
+	id,
+	testId,
 	align,
 	fontWeight = 'bold',
 	noWrap,
 	transform,
 	colour = 'dark',
 	size = sizeScaleDefaults[is],
-	id,
 	breakWord,
 	className = '',
 	children,
 }) => (
 	<Box
 		id={id}
+		data-test-id={testId}
 		is={is}
 		className={[
 			useTextStyles({

--- a/lib/components/Text/Text.tsx
+++ b/lib/components/Text/Text.tsx
@@ -10,6 +10,8 @@ import { TextStyleProps, useTextStyles } from './useTextStyles';
 export interface Props extends TextStyleProps {
 	className?: string;
 	is?: 'p' | 'span';
+	id?: string;
+	testId?: string;
 	strong?: boolean;
 	children?: ReactNode;
 	display?: Extract<
@@ -25,6 +27,8 @@ export const Text = forwardRef<HTMLElement, Props>(
 			children,
 			className = '',
 			is: Component = 'span',
+			id,
+			testId,
 			align = 'left',
 			colour,
 			display,
@@ -40,6 +44,8 @@ export const Text = forwardRef<HTMLElement, Props>(
 	) => (
 		<Box
 			is={Component}
+			id={id}
+			data-test-id={testId}
 			ref={ref}
 			display={display}
 			textAlign={align}


### PR DESCRIPTION
This pull request introduces new `id` and `testId` props to the `Text` and `Heading` components to improve their testability and identification. Below are the most important changes:

### Additions to Props:

* Added `id` and `testId` props to the `Text` component in `lib/components/Text/Text.tsx`. [[1]](diffhunk://#diff-72cccd06911d8e3be548ce966954bdc790ddc9eba76f89eb07124d2b5cadb7daR13-R14) [[2]](diffhunk://#diff-72cccd06911d8e3be548ce966954bdc790ddc9eba76f89eb07124d2b5cadb7daR30-R31) [[3]](diffhunk://#diff-72cccd06911d8e3be548ce966954bdc790ddc9eba76f89eb07124d2b5cadb7daR47-R48)
* Added `id` and `testId` props to the `Heading` component in `lib/components/Heading/Heading.tsx`. [[1]](diffhunk://#diff-7cd45168261448f3423b0b0921f941f726bf9954928382635e8bfbce59a1c71eR16-R17) [[2]](diffhunk://#diff-7cd45168261448f3423b0b0921f941f726bf9954928382635e8bfbce59a1c71eR31-R45)

### Documentation:

* Updated `.changeset/chilly-bees-grin.md` to reflect the new props added to the `Text` and `Heading` components.