### PR TITLE
Change publish CI behaviour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: push
+on:
+    push:
+        branches-ignore:
+            - 'changeset-release/**'
 
 jobs:
     test:


### PR DESCRIPTION
`ci` workflow will ignore the `changeset-release` branches to avoid Chromatic hang