### PR TITLE
Reorganise navigation

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -182,10 +182,17 @@ const preview = {
 				order: [
 					'Overdrive',
 					'Foundation',
+					['Palette', 'Theme Colours', 'Borders', 'Space'],
 					'Primatives',
 					'Layout',
 					'Forms & Input Fields',
 					'Components',
+					[
+						'*',
+						'Modal',
+						'Modal: Minimal',
+						'Modal: Standard with Title',
+					],
 				],
 			},
 		},

--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -179,7 +179,14 @@ const preview = {
 		},
 		options: {
 			storySort: {
-				order: ['Overdrive', 'Foundation'],
+				order: [
+					'Overdrive',
+					'Foundation',
+					'Primatives',
+					'Layout',
+					'Forms & Input Fields',
+					'Components',
+				],
 			},
 		},
 	},

--- a/lib/components/Anchor/Anchor.stories.tsx
+++ b/lib/components/Anchor/Anchor.stories.tsx
@@ -33,7 +33,7 @@ const iconOptions = {
 };
 
 export default {
-	title: 'Foundation/Typography/Anchor',
+	title: 'Primatives/Anchor',
 	component: Anchor,
 	decorators: [],
 	argTypes: {
@@ -66,19 +66,19 @@ const standardProps: ComponentProps<typeof Anchor> = {
 	children: '07 5612 5347',
 };
 
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const withIconProps: typeof standardProps = {
 	...standardProps,
 	icon: PhoneIcon,
 };
-export const withIcon = Template.bind(withIconProps);
-withIcon.args = withIconProps;
+export const WithIcon = Template.bind(withIconProps);
+WithIcon.args = withIconProps;
 
 const withButtonProps: ComponentProps<typeof Anchor> = {
 	...withIconProps,
 	is: Button,
 };
-export const withButton = Template.bind(withButtonProps);
-withButton.args = withButtonProps;
+export const WithButton = Template.bind(withButtonProps);
+WithButton.args = withButtonProps;

--- a/lib/components/AutoSuggest/AutoSuggest.stories.tsx
+++ b/lib/components/AutoSuggest/AutoSuggest.stories.tsx
@@ -64,7 +64,7 @@ const attachOptions: Record<
 };
 
 export default {
-	title: 'Components/Inputs/AutoSuggest',
+	title: 'Forms & Input Fields/Auto Suggest',
 	component: AutoSuggest,
 	decorators: [
 		(story) => (
@@ -213,51 +213,51 @@ const standardProps: Omit<ComponentProps<typeof AutoSuggest>, 'children'> = {
 	onBlur: (thing) => action('onBlur')(thing),
 };
 
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const withValueProps: typeof standardProps = {
 	...standardProps,
 	value: mockSuggestions[3],
 };
 
-export const withValue = Template.bind(withValueProps);
-withValue.args = withValueProps;
+export const WithValue = Template.bind(withValueProps);
+WithValue.args = withValueProps;
 
 const withoutNotchProps: typeof withValueProps = {
 	...withValueProps,
 	notch: false,
 };
-export const withoutNotch = Template.bind(withoutNotchProps);
-withoutNotch.args = withoutNotchProps;
+export const WithoutNotch = Template.bind(withoutNotchProps);
+WithoutNotch.args = withoutNotchProps;
 
 const withNoItemsProps: typeof standardProps = {
 	...standardProps,
 	suggestions: [],
 };
-export const withNoItems = Template.bind(withNoItemsProps);
-withNoItems.args = withNoItemsProps;
+export const WithNoItems = Template.bind(withNoItemsProps);
+WithNoItems.args = withNoItemsProps;
 
 const withIconProps: typeof withValueProps = {
 	...withValueProps,
 	prefixIcon: CarIcon,
 };
-export const withIcon = Template.bind(withIconProps);
-withIcon.args = withIconProps;
+export const WithIcon = Template.bind(withIconProps);
+WithIcon.args = withIconProps;
 
 const disabledProps: typeof withIconProps = {
 	...withIconProps,
 	disabled: true,
 };
-export const disabled = Template.bind(disabledProps);
-disabled.args = disabledProps;
+export const Disabled = Template.bind(disabledProps);
+Disabled.args = disabledProps;
 
 const withHintTextProps: typeof withIconProps = {
 	...withIconProps,
 	hintText: 'Choose a sports car make',
 };
-export const withHintText = Template.bind(withHintTextProps);
-withHintText.args = withHintTextProps;
+export const WithHintText = Template.bind(withHintTextProps);
+WithHintText.args = withHintTextProps;
 
 const validProps: typeof withHintTextProps = {
 	...withHintTextProps,
@@ -265,8 +265,8 @@ const validProps: typeof withHintTextProps = {
 	isTouched: true,
 	isValid: true,
 };
-export const valid = Template.bind(validProps);
-valid.args = validProps;
+export const Valid = Template.bind(validProps);
+Valid.args = validProps;
 
 const invalidProps: typeof withHintTextProps = {
 	...withHintTextProps,
@@ -274,8 +274,8 @@ const invalidProps: typeof withHintTextProps = {
 	isTouched: true,
 	isValid: false,
 };
-export const invalid = Template.bind(invalidProps);
-invalid.args = invalidProps;
+export const Invalid = Template.bind(invalidProps);
+Invalid.args = invalidProps;
 
 const withIconSmallProps: typeof withValueProps = {
 	...withValueProps,
@@ -287,8 +287,8 @@ const smallProps: typeof standardProps = {
 	...standardProps,
 	size: 'small',
 };
-export const small = Template.bind(smallProps);
-small.args = smallProps;
+export const Small = Template.bind(smallProps);
+Small.args = smallProps;
 
 const withValueSmallProps: typeof standardProps = {
 	...standardProps,
@@ -296,16 +296,16 @@ const withValueSmallProps: typeof standardProps = {
 	size: 'small',
 };
 
-export const withValueSmall = Template.bind(withValueSmallProps);
-withValueSmall.args = withValueSmallProps;
+export const WithValueSmall = Template.bind(withValueSmallProps);
+WithValueSmall.args = withValueSmallProps;
 
-export const withIconSmall = Template.bind(withIconSmallProps);
-withIconSmall.args = withIconSmallProps;
+export const WithIconSmall = Template.bind(withIconSmallProps);
+WithIconSmall.args = withIconSmallProps;
 
 const loadingSmallProps: typeof withValueSmallProps = {
 	...withValueSmallProps,
 	isLoading: true,
 	size: 'small',
 };
-export const loadingSmall = Template.bind(loadingSmallProps);
-loadingSmall.args = loadingSmallProps;
+export const LoadingSmall = Template.bind(loadingSmallProps);
+LoadingSmall.args = loadingSmallProps;

--- a/lib/components/Box/Box.stories.tsx
+++ b/lib/components/Box/Box.stories.tsx
@@ -7,7 +7,7 @@ import { boxArgTypes } from './argTypes';
 import { Box } from '.';
 
 export default {
-	title: 'Foundation/Box',
+	title: 'Primatives/Box',
 	component: Box,
 	decorators: [
 		(story) => (

--- a/lib/components/BulletList/Bullet.stories.tsx
+++ b/lib/components/BulletList/Bullet.stories.tsx
@@ -7,7 +7,7 @@ import { Text } from '../Text';
 import { Bullet, BulletList } from '.';
 
 export default {
-	title: 'Foundation/List/BulletList',
+	title: 'Primatives/Bullet List',
 	component: BulletList,
 	decorators: [
 		(story) => (
@@ -92,8 +92,8 @@ const NestedBulletListTemplate: StoryFn<typeof BulletList> = (args) => (
 
 const standardProps: ComponentProps<typeof BulletList> = {};
 
-export const standard = StandardBulletListTemplate.bind(standardProps);
-standard.args = {};
+export const Standard = StandardBulletListTemplate.bind(standardProps);
+Standard.args = {};
 
-export const nested = NestedBulletListTemplate.bind(standardProps);
-nested.args = {};
+export const Nested = NestedBulletListTemplate.bind(standardProps);
+Nested.args = {};

--- a/lib/components/BulletText/BulletText.stories.tsx
+++ b/lib/components/BulletText/BulletText.stories.tsx
@@ -8,7 +8,7 @@ import { Icon } from '../Icon';
 import { BulletText } from '.';
 
 export default {
-	title: 'Components/BulletText',
+	title: 'Components/Bullet Text',
 	component: BulletText,
 	argTypes: {
 		variant: {

--- a/lib/components/Button/Button.stories.tsx
+++ b/lib/components/Button/Button.stories.tsx
@@ -11,7 +11,7 @@ import { Button } from '.';
 
 const onClick = action('onClick');
 export default {
-	title: 'Components/Buttons',
+	title: 'Primatives/Buttons',
 	component: Button,
 	decorators: [
 		(story) => (

--- a/lib/components/CheckBox/CheckBox.stories.tsx
+++ b/lib/components/CheckBox/CheckBox.stories.tsx
@@ -10,7 +10,7 @@ import { Text } from '../Text';
 import { CheckBox } from '.';
 
 export default {
-	title: 'Components/Inputs/CheckBox',
+	title: 'Forms & Input Fields/CheckBox',
 	component: CheckBox,
 	decorators: [
 		(story) => (
@@ -168,30 +168,30 @@ const withMultiLineComponentProps: ComponentProps<typeof CheckBox> = {
 	value: '1',
 };
 
-export const unchecked = Template.bind(uncheckedProps);
-unchecked.args = uncheckedProps;
+export const Unchecked = Template.bind(uncheckedProps);
+Unchecked.args = uncheckedProps;
 
-export const checked = Template.bind(checkedProps);
-checked.args = checkedProps;
+export const Checked = Template.bind(checkedProps);
+Checked.args = checkedProps;
 
-export const disabled = Template.bind(disabledProps);
-disabled.args = disabledProps;
+export const Disabled = Template.bind(disabledProps);
+Disabled.args = disabledProps;
 
-export const disabledChecked = Template.bind(disabledCheckedProps);
-disabledChecked.args = disabledCheckedProps;
+export const DisabledChecked = Template.bind(disabledCheckedProps);
+DisabledChecked.args = disabledCheckedProps;
 
-export const multipleLines = Template.bind(multipleLinesProps);
-multipleLines.args = multipleLinesProps;
+export const MultipleLines = Template.bind(multipleLinesProps);
+MultipleLines.args = multipleLinesProps;
 
-export const withNoChildren = Template.bind(emptyProps);
-withNoChildren.args = emptyProps;
+export const WithNoChildren = Template.bind(emptyProps);
+WithNoChildren.args = emptyProps;
 
-export const withComponent = Template.bind(withComponentProps);
-withComponent.args = withComponentProps;
-withComponent.argTypes = { children: { control: { disable: true } } };
+export const WithComponent = Template.bind(withComponentProps);
+WithComponent.args = withComponentProps;
+WithComponent.argTypes = { children: { control: { disable: true } } };
 
-export const withMultiLineComponent = Template.bind(
+export const WithMultiLineComponent = Template.bind(
 	withMultiLineComponentProps,
 );
-withMultiLineComponent.args = withMultiLineComponentProps;
-withMultiLineComponent.argTypes = { children: { control: { disable: true } } };
+WithMultiLineComponent.args = withMultiLineComponentProps;
+WithMultiLineComponent.argTypes = { children: { control: { disable: true } } };

--- a/lib/components/ColourInput/ColourInput.stories.tsx
+++ b/lib/components/ColourInput/ColourInput.stories.tsx
@@ -19,7 +19,7 @@ import { DateInput } from '../DateInput';
 import { ColourInput } from '.';
 
 export default {
-	title: 'Components/Inputs/Colour',
+	title: 'Forms & Input Fields/Colour Input',
 	component: ColourInput,
 	parameters: { chromatic: {} },
 } satisfies Meta<typeof ColourInput>;
@@ -143,62 +143,62 @@ const loadingProps: ComponentProps<typeof ColourInput> = {
 	...sharedProps,
 	isLoading: true,
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
-standard.argTypes = argTypes;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
+Standard.argTypes = argTypes;
 
-export const withAValue = Template.bind(withAValueProps);
-withAValue.args = withAValueProps;
-withAValue.argTypes = argTypes;
+export const WithAValue = Template.bind(withAValueProps);
+WithAValue.args = withAValueProps;
+WithAValue.argTypes = argTypes;
 
-export const withHintText = Template.bind(withHintTextProps);
-withHintText.args = withHintTextProps;
-withHintText.argTypes = argTypes;
+export const WithHintText = Template.bind(withHintTextProps);
+WithHintText.args = withHintTextProps;
+WithHintText.argTypes = argTypes;
 
-export const notchDisabled = Template.bind(noNotchProps);
-notchDisabled.args = noNotchProps;
-notchDisabled.argTypes = argTypes;
+export const NotchDisabled = Template.bind(noNotchProps);
+NotchDisabled.args = noNotchProps;
+NotchDisabled.argTypes = argTypes;
 
-export const notchDisabledWithValue = Template.bind(noNotchWithValueProps);
-notchDisabledWithValue.args = noNotchWithValueProps;
-notchDisabledWithValue.argTypes = argTypes;
+export const NotchDisabledWithValue = Template.bind(noNotchWithValueProps);
+NotchDisabledWithValue.args = noNotchWithValueProps;
+NotchDisabledWithValue.argTypes = argTypes;
 
-export const withIcon = Template.bind(withIconProps);
-withIcon.args = withIconProps;
-withIcon.argTypes = argTypes;
+export const WithIcon = Template.bind(withIconProps);
+WithIcon.args = withIconProps;
+WithIcon.argTypes = argTypes;
 
-export const disabled = Template.bind(disabledProps);
-disabled.args = disabledProps;
-disabled.argTypes = argTypes;
+export const Disabled = Template.bind(disabledProps);
+Disabled.args = disabledProps;
+Disabled.argTypes = argTypes;
 
-export const valid = Template.bind(validProps);
-valid.args = validProps;
-valid.argTypes = argTypes;
+export const Valid = Template.bind(validProps);
+Valid.args = validProps;
+Valid.argTypes = argTypes;
 
-export const invalid = Template.bind(invalidProps);
-invalid.args = invalidProps;
-invalid.argTypes = argTypes;
+export const Invalid = Template.bind(invalidProps);
+Invalid.args = invalidProps;
+Invalid.argTypes = argTypes;
 
-export const loading = Template.bind(loadingProps);
-loading.args = loadingProps;
-loading.argTypes = argTypes;
+export const Loading = Template.bind(loadingProps);
+Loading.args = loadingProps;
+Loading.argTypes = argTypes;
 
 const smallProps: typeof standardProps = {
 	...standardProps,
 	size: 'small',
 };
-export const small = Template.bind(smallProps);
-small.args = smallProps;
-small.argTypes = argTypes;
+export const Small = Template.bind(smallProps);
+Small.args = smallProps;
+Small.argTypes = argTypes;
 
 const withValueSmallProps: typeof withAValueProps = {
 	...withAValueProps,
 	size: 'small',
 };
 
-export const withValueSmall = Template.bind(withValueSmallProps);
-withValueSmall.args = withValueSmallProps;
-withValueSmall.argTypes = argTypes;
+export const WithValueSmall = Template.bind(withValueSmallProps);
+WithValueSmall.args = withValueSmallProps;
+WithValueSmall.argTypes = argTypes;
 
 const withIconSmallProps: typeof withAValueProps = {
 	...withAValueProps,
@@ -206,15 +206,15 @@ const withIconSmallProps: typeof withAValueProps = {
 	size: 'small',
 };
 
-export const withIconSmall = Template.bind(withIconSmallProps);
-withIconSmall.args = withIconSmallProps;
-withIconSmall.argTypes = argTypes;
+export const WithIconSmall = Template.bind(withIconSmallProps);
+WithIconSmall.args = withIconSmallProps;
+WithIconSmall.argTypes = argTypes;
 
 const loadingSmallProps: typeof withAValueProps = {
 	...withAValueProps,
 	isLoading: true,
 	size: 'small',
 };
-export const loadingSmall = Template.bind(loadingSmallProps);
-loadingSmall.args = loadingSmallProps;
-loadingSmall.argTypes = argTypes;
+export const LoadingSmall = Template.bind(loadingSmallProps);
+LoadingSmall.args = loadingSmallProps;
+LoadingSmall.argTypes = argTypes;

--- a/lib/components/Columns/Columns.stories.tsx
+++ b/lib/components/Columns/Columns.stories.tsx
@@ -8,7 +8,7 @@ import { boxArgTypes, scaleOptions } from '../Box/argTypes';
 import { Column, Columns } from '.';
 
 export default {
-	title: 'Foundation/Layout/Columns',
+	title: 'Layout/Columns',
 	component: Columns,
 	decorators: [
 		(story) => (
@@ -167,17 +167,17 @@ const standardProps: ComponentProps<typeof Columns> = {
 	noWrap: false,
 };
 
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const standardColumnProps: Omit<ComponentProps<typeof Column>, 'children'> = {
 	width: ['full', '1/3', '1/5'],
 	is: 'section',
 };
 
-export const standardColumn = TemplateColumn.bind(standardColumnProps);
-standardColumn.args = standardColumnProps;
-standardColumn.argTypes = {
+export const StandardColumn = TemplateColumn.bind(standardColumnProps);
+StandardColumn.args = standardColumnProps;
+StandardColumn.argTypes = {
 	alignSelf: {
 		options: {
 			stretch: 'stretch',

--- a/lib/components/DateInput/DateInput.stories.tsx
+++ b/lib/components/DateInput/DateInput.stories.tsx
@@ -29,7 +29,7 @@ const todayStr: string = formatDate(
 );
 
 export default {
-	title: 'Components/Inputs/Date',
+	title: 'Forms & Input Fields/Date Input',
 	component: DateInput,
 	parameters: { chromatic: {} },
 } satisfies Meta<typeof DateInput>;
@@ -148,62 +148,62 @@ const loadingProps: ComponentProps<typeof DateInput> = {
 	...sharedProps,
 	isLoading: true,
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
-standard.argTypes = argTypes;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
+Standard.argTypes = argTypes;
 
-export const withAValue = Template.bind(withAValueProps);
-withAValue.args = withAValueProps;
-withAValue.argTypes = argTypes;
+export const WithAValue = Template.bind(withAValueProps);
+WithAValue.args = withAValueProps;
+WithAValue.argTypes = argTypes;
 
-export const withHintText = Template.bind(withHintTextProps);
-withHintText.args = withHintTextProps;
-withHintText.argTypes = argTypes;
+export const WithHintText = Template.bind(withHintTextProps);
+WithHintText.args = withHintTextProps;
+WithHintText.argTypes = argTypes;
 
-export const notchDisabled = Template.bind(noNotchProps);
-notchDisabled.args = noNotchProps;
-notchDisabled.argTypes = argTypes;
+export const NotchDisabled = Template.bind(noNotchProps);
+NotchDisabled.args = noNotchProps;
+NotchDisabled.argTypes = argTypes;
 
-export const notchDisabledWithValue = Template.bind(noNotchWithValueProps);
-notchDisabledWithValue.args = noNotchWithValueProps;
-notchDisabledWithValue.argTypes = argTypes;
+export const NotchDisabledWithValue = Template.bind(noNotchWithValueProps);
+NotchDisabledWithValue.args = noNotchWithValueProps;
+NotchDisabledWithValue.argTypes = argTypes;
 
-export const withPrefixIcon = Template.bind(withIconProps);
-withPrefixIcon.args = withIconProps;
-withPrefixIcon.argTypes = argTypes;
+export const WithPrefixIcon = Template.bind(withIconProps);
+WithPrefixIcon.args = withIconProps;
+WithPrefixIcon.argTypes = argTypes;
 
-export const disabled = Template.bind(disabledProps);
-disabled.args = disabledProps;
-disabled.argTypes = argTypes;
+export const Disabled = Template.bind(disabledProps);
+Disabled.args = disabledProps;
+Disabled.argTypes = argTypes;
 
-export const valid = Template.bind(validProps);
-valid.args = validProps;
-valid.argTypes = argTypes;
+export const Valid = Template.bind(validProps);
+Valid.args = validProps;
+Valid.argTypes = argTypes;
 
-export const invalid = Template.bind(invalidProps);
-invalid.args = invalidProps;
-invalid.argTypes = argTypes;
+export const Invalid = Template.bind(invalidProps);
+Invalid.args = invalidProps;
+Invalid.argTypes = argTypes;
 
-export const loading = Template.bind(loadingProps);
-loading.args = loadingProps;
-loading.argTypes = argTypes;
+export const Loading = Template.bind(loadingProps);
+Loading.args = loadingProps;
+Loading.argTypes = argTypes;
 
 const smallProps: typeof standardProps = {
 	...standardProps,
 	size: 'small',
 };
-export const small = Template.bind(smallProps);
-small.args = smallProps;
-small.argTypes = argTypes;
+export const Small = Template.bind(smallProps);
+Small.args = smallProps;
+Small.argTypes = argTypes;
 
 const withValueSmallProps: typeof withAValueProps = {
 	...withAValueProps,
 	size: 'small',
 };
 
-export const withValueSmall = Template.bind(withValueSmallProps);
-withValueSmall.args = withValueSmallProps;
-withValueSmall.argTypes = argTypes;
+export const WithValueSmall = Template.bind(withValueSmallProps);
+WithValueSmall.args = withValueSmallProps;
+WithValueSmall.argTypes = argTypes;
 
 const withIconSmallProps: typeof withAValueProps = {
 	...withAValueProps,
@@ -211,15 +211,15 @@ const withIconSmallProps: typeof withAValueProps = {
 	size: 'small',
 };
 
-export const withIconSmall = Template.bind(withIconSmallProps);
-withIconSmall.args = withIconSmallProps;
-withIconSmall.argTypes = argTypes;
+export const WithIconSmall = Template.bind(withIconSmallProps);
+WithIconSmall.args = withIconSmallProps;
+WithIconSmall.argTypes = argTypes;
 
 const loadingSmallProps: typeof withAValueProps = {
 	...withAValueProps,
 	isLoading: true,
 	size: 'small',
 };
-export const loadingSmall = Template.bind(loadingSmallProps);
-loadingSmall.args = loadingSmallProps;
-loadingSmall.argTypes = argTypes;
+export const LoadingSmall = Template.bind(loadingSmallProps);
+LoadingSmall.args = loadingSmallProps;
+LoadingSmall.argTypes = argTypes;

--- a/lib/components/DatePicker/DatePicker.stories.tsx
+++ b/lib/components/DatePicker/DatePicker.stories.tsx
@@ -32,7 +32,7 @@ const iconOptions = {
 };
 
 export default {
-	title: 'Components/DatePicker',
+	title: 'Components/Date Picker',
 	component: DatePicker,
 	decorators: [],
 	argTypes: {
@@ -64,8 +64,8 @@ const standardProps: ComponentProps<typeof DatePicker> = {
 	disabled: false,
 };
 
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const smallProps: ComponentProps<typeof DatePicker> = {
 	size: 'small',
@@ -73,16 +73,16 @@ const smallProps: ComponentProps<typeof DatePicker> = {
 	disabled: false,
 };
 
-export const small = Template.bind(smallProps);
-small.args = smallProps;
+export const Small = Template.bind(smallProps);
+Small.args = smallProps;
 
 const smallWithLabelProps: ComponentProps<typeof DatePicker> = {
 	...smallProps,
 	valueLabel: 'Today',
 };
 
-export const smallWithLabel = Template.bind(smallWithLabelProps);
-smallWithLabel.args = smallWithLabelProps;
+export const SmallWithLabel = Template.bind(smallWithLabelProps);
+SmallWithLabel.args = smallWithLabelProps;
 
 const mediumProps: ComponentProps<typeof DatePicker> = {
 	size: 'medium',
@@ -90,16 +90,16 @@ const mediumProps: ComponentProps<typeof DatePicker> = {
 	disabled: false,
 };
 
-export const medium = Template.bind(mediumProps);
-medium.args = mediumProps;
+export const Medium = Template.bind(mediumProps);
+Medium.args = mediumProps;
 
 const mediumWithLabelProps: ComponentProps<typeof DatePicker> = {
 	...mediumProps,
 	valueLabel: 'Today',
 };
 
-export const mediumWithLabel = Template.bind(mediumWithLabelProps);
-mediumWithLabel.args = mediumWithLabelProps;
+export const MediumWithLabel = Template.bind(mediumWithLabelProps);
+MediumWithLabel.args = mediumWithLabelProps;
 
 const largeProps: ComponentProps<typeof DatePicker> = {
 	size: 'large',
@@ -107,13 +107,13 @@ const largeProps: ComponentProps<typeof DatePicker> = {
 	disabled: false,
 };
 
-export const large = Template.bind(largeProps);
-large.args = largeProps;
+export const Large = Template.bind(largeProps);
+Large.args = largeProps;
 
 const largeWithLabelProps: ComponentProps<typeof DatePicker> = {
 	...largeProps,
 	valueLabel: 'Today',
 };
 
-export const largeWithLabel = Template.bind(largeWithLabelProps);
-largeWithLabel.args = largeWithLabelProps;
+export const LargeWithLabel = Template.bind(largeWithLabelProps);
+LargeWithLabel.args = largeWithLabelProps;

--- a/lib/components/DividerLine/DividerLine.stories.tsx
+++ b/lib/components/DividerLine/DividerLine.stories.tsx
@@ -37,7 +37,7 @@ const colours: ReadonlyArray<ComponentProps<typeof DividerLine>['colour']> = [
 ] as const;
 
 export default {
-	title: 'Components/DividerLine',
+	title: 'Primatives/Divider Line',
 	component: DividerLine,
 	argTypes: {
 		space: {
@@ -127,16 +127,16 @@ const standardProps: ComponentProps<typeof DividerLine> = {
 	colour: 'primary',
 };
 
-export const standard = template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = template.bind(standardProps);
+Standard.args = standardProps;
 
 const verticalProps: ComponentProps<typeof DividerLine> = {
 	...standardProps,
 	isVertical: true,
 };
 
-export const vertical = verticalTemplate.bind(verticalProps);
-vertical.args = verticalProps;
+export const Vertical = verticalTemplate.bind(verticalProps);
+Vertical.args = verticalProps;
 
-export const standardAllColours = templateAllColours.bind(standardProps);
-standardAllColours.args = standardProps;
+export const StandardAllColours = templateAllColours.bind(standardProps);
+StandardAllColours.args = standardProps;

--- a/lib/components/DropDown/DropDown.stories.tsx
+++ b/lib/components/DropDown/DropDown.stories.tsx
@@ -16,7 +16,7 @@ import { DropDown, DropDownOption } from '.';
 
 const onClick = action('onClick');
 export default {
-	title: 'Components/DropDown',
+	title: 'Components/Drop Down',
 	component: DropDown,
 	decorators: [
 		(story) => (
@@ -93,24 +93,24 @@ const standardProps: ComponentProps<typeof DropDown> = {
 	onClick,
 };
 
-export const primary = Template.bind(standardProps);
-primary.args = standardProps;
+export const Primary = Template.bind(standardProps);
+Primary.args = standardProps;
 
 const withOpenMenuProps: ComponentProps<typeof DropDown> = {
 	...standardProps,
 	isOpen: true,
 };
 
-export const withOpenMenu = Template.bind(withOpenMenuProps);
-withOpenMenu.args = withOpenMenuProps;
+export const WithOpenMenu = Template.bind(withOpenMenuProps);
+WithOpenMenu.args = withOpenMenuProps;
 
 const secondaryProps: ComponentProps<typeof DropDown> = {
 	...standardProps,
 	variant: 'secondary',
 };
 
-export const secondary = Template.bind(secondaryProps);
-secondary.args = secondaryProps;
+export const Secondary = Template.bind(secondaryProps);
+Secondary.args = secondaryProps;
 
 const minimalPrimaryProps: ComponentProps<typeof DropDown> = {
 	...standardProps,
@@ -118,8 +118,8 @@ const minimalPrimaryProps: ComponentProps<typeof DropDown> = {
 	minimal: true,
 };
 
-export const minimalPrimary = Template.bind(minimalPrimaryProps);
-minimalPrimary.args = minimalPrimaryProps;
+export const MinimalPrimary = Template.bind(minimalPrimaryProps);
+MinimalPrimary.args = minimalPrimaryProps;
 
 const roundedSecondaryProps: ComponentProps<typeof DropDown> = {
 	...standardProps,
@@ -127,8 +127,8 @@ const roundedSecondaryProps: ComponentProps<typeof DropDown> = {
 	rounded: true,
 };
 
-export const roundedSecondary = Template.bind(roundedSecondaryProps);
-roundedSecondary.args = roundedSecondaryProps;
+export const RoundedSecondary = Template.bind(roundedSecondaryProps);
+RoundedSecondary.args = roundedSecondaryProps;
 
 const withCustomIconProps: ComponentProps<typeof DropDown> = {
 	...standardProps,
@@ -137,8 +137,8 @@ const withCustomIconProps: ComponentProps<typeof DropDown> = {
 	isOpen: true,
 };
 
-export const withCustomIcon = Template.bind(withCustomIconProps);
-withCustomIcon.args = withCustomIconProps;
+export const WithCustomIcon = Template.bind(withCustomIconProps);
+WithCustomIcon.args = withCustomIconProps;
 
 const withManyOptionsProps: ComponentProps<typeof DropDown> = {
 	...standardProps,
@@ -154,5 +154,5 @@ const withManyOptionsProps: ComponentProps<typeof DropDown> = {
 	),
 };
 
-export const withManyOptions = Template.bind(withManyOptionsProps);
-withManyOptions.args = withManyOptionsProps;
+export const WithManyOptions = Template.bind(withManyOptionsProps);
+WithManyOptions.args = withManyOptionsProps;

--- a/lib/components/EditableText/EditableText.stories.tsx
+++ b/lib/components/EditableText/EditableText.stories.tsx
@@ -6,7 +6,7 @@ import { ChangeEvent, ComponentProps, useState } from 'react';
 import { EditableText } from '.';
 
 export default {
-	title: 'Components/Inputs/EditableText',
+	title: 'Forms & Input Fields/Editable Text',
 	component: EditableText,
 	argTypes: {
 		colour: {
@@ -78,14 +78,14 @@ const customSizeProps: ComponentProps<typeof EditableText> = {
 	size: '6',
 };
 
-export const text = template.bind(textProps);
-export const number = template.bind(numberProps);
-export const date = template.bind(dateProps);
-export const narrowCharacters = template.bind(narrowCharactersProps);
-export const customSize = template.bind(customSizeProps);
+export const Text = template.bind(textProps);
+export const Number = template.bind(numberProps);
+export const DateWithPicker = template.bind(dateProps);
+export const NarrowCharacters = template.bind(narrowCharactersProps);
+export const CustomSize = template.bind(customSizeProps);
 
-text.args = textProps;
-number.args = numberProps;
-date.args = dateProps;
-narrowCharacters.args = narrowCharactersProps;
-customSize.args = customSizeProps;
+Text.args = textProps;
+Number.args = numberProps;
+DateWithPicker.args = dateProps;
+NarrowCharacters.args = narrowCharactersProps;
+CustomSize.args = customSizeProps;

--- a/lib/components/FillHeightBox/FillHeightBox.stories.tsx
+++ b/lib/components/FillHeightBox/FillHeightBox.stories.tsx
@@ -9,7 +9,7 @@ import { Text } from '../Text';
 import { FillHeightBox } from './FillHeightBox';
 
 export default {
-	title: 'Foundation/Layout/FillHeightBox',
+	title: 'Layout/Fill Height Box',
 	component: StickyBox,
 } satisfies Meta<typeof StickyBox>;
 
@@ -41,5 +41,5 @@ const Template: StoryFn<typeof StickyBox> = (args) => (
 const standardProps: Props = {
 	top: 'none',
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;

--- a/lib/components/Heading/Heading.stories.tsx
+++ b/lib/components/Heading/Heading.stories.tsx
@@ -64,7 +64,7 @@ const colourOptions: Array<ComponentProps<typeof Heading>['colour']> = [
 ];
 
 export default {
-	title: 'Foundation/Typography/Heading',
+	title: 'Primatives/Heading',
 	// component: Heading, Breaks the docs when enabled!
 	argTypes: {
 		noWrap: {
@@ -162,11 +162,11 @@ const standardProps: ComponentProps<typeof Heading> = {
 const allTypesProps: ComponentProps<typeof Heading> = {
 	children: 'I am a heading',
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
-export const allTypes = AllTypesTemplate.bind(allTypesProps);
-allTypes.args = allTypesProps;
+export const AllTypes = AllTypesTemplate.bind(allTypesProps);
+AllTypes.args = allTypesProps;
 
-export const allColours = AllColoursTemplate.bind(allTypesProps);
-allColours.args = allTypesProps;
+export const AllColours = AllColoursTemplate.bind(allTypesProps);
+AllColours.args = allTypesProps;

--- a/lib/components/HorizontalAutoScroller/HorizontalAutoScroller.stories.tsx
+++ b/lib/components/HorizontalAutoScroller/HorizontalAutoScroller.stories.tsx
@@ -9,7 +9,7 @@ import { boxArgTypes, scaleOptions } from '../Box/argTypes';
 import { HorizontalAutoScroller } from '.';
 
 export default {
-	title: 'Components/HorizontalAutoScroller',
+	title: 'Components/Horizontal Auto Scroller',
 	component: HorizontalAutoScroller,
 	argTypes: {
 		sliderProgressColour: boxArgTypes.backgroundColour,

--- a/lib/components/Icon/Icon.stories.tsx
+++ b/lib/components/Icon/Icon.stories.tsx
@@ -31,7 +31,7 @@ const iconOptions = {
 };
 
 export default {
-	title: 'Foundation/Icon',
+	title: 'Primatives/Icon',
 	component: Icon,
 	decorators: [],
 	argTypes: {
@@ -55,26 +55,26 @@ const template: StoryFn<typeof Icon> = (args) => <Icon {...args} />;
 const standardProps: ComponentProps<typeof Icon> = {
 	icon: CalendarIcon,
 };
-export const standard = template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = template.bind(standardProps);
+Standard.args = standardProps;
 
 const responsiveProps: ComponentProps<typeof Icon> = {
 	...standardProps,
 	size: ['small', 'medium', 'large'],
 };
-export const responsive = template.bind(responsiveProps);
-responsive.args = responsiveProps;
+export const Responsive = template.bind(responsiveProps);
+Responsive.args = responsiveProps;
 
 const mediumProps: ComponentProps<typeof Icon> = {
 	...standardProps,
 	size: 'medium',
 };
-export const medium = template.bind(mediumProps);
-medium.args = mediumProps;
+export const Medium = template.bind(mediumProps);
+Medium.args = mediumProps;
 
 const largeProps: ComponentProps<typeof Icon> = {
 	...standardProps,
 	size: 'large',
 };
-export const large = template.bind(largeProps);
-large.args = largeProps;
+export const Large = template.bind(largeProps);
+Large.args = largeProps;

--- a/lib/components/Image/Image.stories.tsx
+++ b/lib/components/Image/Image.stories.tsx
@@ -34,7 +34,7 @@ const sizeOptions: Array<ComponentProps<typeof Image>['imageWidth']> =
 const qualityOptions: Array<ComponentProps<typeof Image>['quality']> =
 	isChromatic() ? ['70'] : [1, 20, 40, 60, 80, 100];
 export default {
-	title: 'Foundation/Image',
+	title: 'Primatives/Image',
 	component: Image,
 	args: {
 		imageWidth: 8,
@@ -88,8 +88,8 @@ const SimpleTemplate: StoryFn<typeof Image> = (args) => (
 const standardProps: ComponentProps<typeof Image> = {
 	src: 'https://cdn.autoguru.com.au/images/autoguru-og.jpg',
 };
-export const standard = SimpleTemplate.bind(standardProps);
-standard.args = standardProps;
+export const Standard = SimpleTemplate.bind(standardProps);
+Standard.args = standardProps;
 
 const srcUrlMapper = ({ src, width, quality }) =>
 	`https://images.autoguru.com.au/?url=${src}&w=${width}&q=${quality}`;
@@ -105,10 +105,10 @@ const withImageServerUnoptimisedProps: ComponentProps<typeof Image> = {
 	src: 'https://cdn.autoguru.com.au/images/autoguru-test-highres-image.jpg',
 	unoptimised: true,
 };
-export const withImageServerUnoptimised = WidthProviderTemplate.bind(
+export const WithImageServerUnoptimised = WidthProviderTemplate.bind(
 	withImageServerUnoptimisedProps,
 );
-withImageServerUnoptimised.args = withImageServerUnoptimisedProps;
+WithImageServerUnoptimised.args = withImageServerUnoptimisedProps;
 
 const withImageServerProps: ComponentProps<typeof Image> = {
 	src: 'https://cdn.autoguru.com.au/images/autoguru-test-highres-image.jpg',
@@ -116,8 +116,8 @@ const withImageServerProps: ComponentProps<typeof Image> = {
 	imageWidth: 8,
 	sizes: ['100vh', , '60vh', '40vh'],
 };
-export const withImageServer = WidthProviderTemplate.bind(withImageServerProps);
-withImageServer.args = withImageServerProps;
+export const WithImageServer = WidthProviderTemplate.bind(withImageServerProps);
+WithImageServer.args = withImageServerProps;
 
 const withResponsiveImageWidthProps: ComponentProps<typeof Image> = {
 	src: 'https://cdn.autoguru.com.au/images/autoguru-test-highres-image.jpg',
@@ -125,20 +125,20 @@ const withResponsiveImageWidthProps: ComponentProps<typeof Image> = {
 	sizes: ['100vw', '70vw', '50vw', '40vw'],
 	imageWidth: [5, 8, , 12],
 };
-export const withResponsiveImageWidth = WidthProviderTemplate.bind(
+export const WithResponsiveImageWidth = WidthProviderTemplate.bind(
 	withResponsiveImageWidthProps,
 );
-withResponsiveImageWidth.args = withResponsiveImageWidthProps;
+WithResponsiveImageWidth.args = withResponsiveImageWidthProps;
 
 const withResponsiveSizesProps: ComponentProps<typeof Image> = {
 	src: 'https://cdn.autoguru.com.au/images/autoguru-test-highres-image.jpg',
 	width: 'full',
 	sizes: ['100vw', '70vw', '50vw', '40vw'],
 };
-export const withResponsiveSizes = WidthProviderTemplate.bind(
+export const WithResponsiveSizes = WidthProviderTemplate.bind(
 	withResponsiveSizesProps,
 );
-withResponsiveSizes.args = withResponsiveSizesProps;
+WithResponsiveSizes.args = withResponsiveSizesProps;
 
 const AllQualityTemplate: StoryFn<typeof Image> = (args) => (
 	<ImageServerProvider srcUrlMapper={srcUrlMapper}>
@@ -163,9 +163,9 @@ const AllQualityTemplate: StoryFn<typeof Image> = (args) => (
 	</ImageServerProvider>
 );
 
-export const withImageServerQualities =
+export const WithImageServerQualities =
 	AllQualityTemplate.bind(withImageServerProps);
-withImageServerQualities.args = withImageServerProps;
+WithImageServerQualities.args = withImageServerProps;
 
 const AllSizeTemplate: StoryFn<typeof Image> = (args) => (
 	<ImageServerProvider srcUrlMapper={srcUrlMapper}>
@@ -200,7 +200,7 @@ const withImageServerResizingProps: ComponentProps<typeof Image> = {
 	sizes: ['100vh', , '60vh', '40vh'],
 };
 
-export const withImageServerResizing = AllSizeTemplate.bind(
+export const WithImageServerResizing = AllSizeTemplate.bind(
 	withImageServerResizingProps,
 );
-withImageServerResizing.args = withImageServerResizingProps;
+WithImageServerResizing.args = withImageServerResizingProps;

--- a/lib/components/Inline/Inline.stories.tsx
+++ b/lib/components/Inline/Inline.stories.tsx
@@ -10,7 +10,7 @@ import { Text } from '../Text';
 import { Inline } from '.';
 
 export default {
-	title: 'Foundation/Layout/Inline',
+	title: 'Layout/Inline',
 	component: Inline,
 	argTypes: {
 		alignY: {
@@ -75,14 +75,14 @@ const DiffSizeTemplate: StoryFn<typeof Inline> = (args) => (
 );
 
 const standardProps: ComponentProps<typeof Inline> = {};
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const dividersProps: ComponentProps<typeof Inline> = {
 	dividers: true,
 };
-export const dividers = Template.bind(dividersProps);
-dividers.args = dividersProps;
+export const Dividers = Template.bind(dividersProps);
+Dividers.args = dividersProps;
 
 const customDividersProps: ComponentProps<typeof Inline> = {
 	dividers: (
@@ -95,20 +95,20 @@ const customDividersProps: ComponentProps<typeof Inline> = {
 		/>
 	),
 };
-export const customDividers = Template.bind(customDividersProps);
-customDividers.args = customDividersProps;
+export const CustomDividers = Template.bind(customDividersProps);
+CustomDividers.args = customDividersProps;
 
 const differentSizeItemsProps: ComponentProps<typeof Inline> = {
 	dividers: true,
 };
-export const differentSizeItems = DiffSizeTemplate.bind(
+export const DifferentSizeItems = DiffSizeTemplate.bind(
 	differentSizeItemsProps,
 );
-differentSizeItems.args = differentSizeItemsProps;
+DifferentSizeItems.args = differentSizeItemsProps;
 
 const withFullWidthProps: ComponentProps<typeof Inline> = {
 	width: 'full',
 	alignX: 'spaceBetween',
 };
-export const withFullWidth = DiffSizeTemplate.bind(withFullWidthProps);
-withFullWidth.args = withFullWidthProps;
+export const WithFullWidth = DiffSizeTemplate.bind(withFullWidthProps);
+WithFullWidth.args = withFullWidthProps;

--- a/lib/components/IntentStripe/IntentStripe.stories.tsx
+++ b/lib/components/IntentStripe/IntentStripe.stories.tsx
@@ -8,7 +8,7 @@ import { IntentStripe } from '.';
 
 type Intent = ComponentProps<typeof IntentStripe>['intent'];
 export default {
-	title: 'Components/IntentStripe',
+	title: 'Components/Intent Stripe',
 	component: IntentStripe,
 	argTypes: {
 		intent: {

--- a/lib/components/LoadingBox/LoadingBox.stories.tsx
+++ b/lib/components/LoadingBox/LoadingBox.stories.tsx
@@ -7,7 +7,7 @@ import { boxArgTypes } from '../Box/argTypes';
 import { LoadingBox } from '.';
 
 export default {
-	title: 'Components/Loading/Box',
+	title: 'Components/Loading Box',
 	component: LoadingBox,
 	decorators: [
 		(story) => (
@@ -23,17 +23,17 @@ export default {
 const Template: StoryFn<typeof LoadingBox> = (args) => <LoadingBox {...args} />;
 
 const standardProps: ComponentProps<typeof LoadingBox> = {};
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const blinkingOffProps: ComponentProps<typeof LoadingBox> = {
 	blinking: false,
 };
-export const blinkingOff = Template.bind(blinkingOffProps);
-blinkingOff.args = blinkingOffProps;
+export const BlinkingOff = Template.bind(blinkingOffProps);
+BlinkingOff.args = blinkingOffProps;
 
 const randomWidthProps: ComponentProps<typeof LoadingBox> = {
 	randomWidth: true,
 };
-export const randomWidth = Template.bind(randomWidthProps);
-randomWidth.args = randomWidthProps;
+export const RandomWidth = Template.bind(randomWidthProps);
+RandomWidth.args = randomWidthProps;

--- a/lib/components/MinimalModal/MinimalModal.stories.tsx
+++ b/lib/components/MinimalModal/MinimalModal.stories.tsx
@@ -18,7 +18,7 @@ const argTypes: ArgTypes = {
 };
 
 export default {
-	title: 'Components/MinimalModal',
+	title: 'Components/Modal: Minimal',
 	component: MinimalModal,
 	parameters: {
 		chromatic: { disable: true },

--- a/lib/components/Modal/Modal.stories.tsx
+++ b/lib/components/Modal/Modal.stories.tsx
@@ -8,7 +8,7 @@ import { Text } from '../Text';
 import { Modal } from '.';
 
 export default {
-	title: 'Utility/Modal',
+	title: 'Components/Modal',
 	component: Modal,
 	parameters: {
 		chromatic: { disable: true },
@@ -97,5 +97,5 @@ const standardProps = {
 	onRequestClose: action('onRequestClose'),
 };
 
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;

--- a/lib/components/NumberBubble/NumberBubble.stories.tsx
+++ b/lib/components/NumberBubble/NumberBubble.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentProps } from 'react';
 import { NumberBubble } from '.';
 
 export default {
-	title: 'Foundation/Typography/NumberBubble',
+	title: 'Components/Number Bubble',
 	component: NumberBubble,
 } satisfies Meta<typeof NumberBubble>;
 
@@ -16,11 +16,11 @@ const template: StoryFn<typeof NumberBubble> = (args) => (
 const standardProps: Omit<ComponentProps<typeof NumberBubble>, 'children'> = {
 	value: 0,
 };
-export const standard = template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = template.bind(standardProps);
+Standard.args = standardProps;
 
 const bigNumberProps: Omit<ComponentProps<typeof NumberBubble>, 'children'> = {
 	value: 2345,
 };
-export const bigNumber = template.bind(bigNumberProps);
-bigNumber.args = bigNumberProps;
+export const BigNumber = template.bind(bigNumberProps);
+BigNumber.args = bigNumberProps;

--- a/lib/components/NumberInput/NumberInput.stories.tsx
+++ b/lib/components/NumberInput/NumberInput.stories.tsx
@@ -20,7 +20,7 @@ import { DateInput } from '../DateInput';
 import { NumberInput } from '.';
 
 const meta: Meta<typeof NumberInput> = {
-	title: 'Components/Inputs/Number',
+	title: 'Forms & Input Fields/Number Input',
 	component: NumberInput,
 	parameters: {
 		chromatic: {},
@@ -188,70 +188,70 @@ const loadingProps: ComponentProps<typeof NumberInput> = {
 	isLoading: true,
 };
 
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
-standard.argTypes = argTypes;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
+Standard.argTypes = argTypes;
 
-export const withAValue = Template.bind(withAValueProps);
-withAValue.args = withAValueProps;
-withAValue.argTypes = argTypes;
+export const WithAValue = Template.bind(withAValueProps);
+WithAValue.args = withAValueProps;
+WithAValue.argTypes = argTypes;
 
-export const withHintText = Template.bind(withHintTextProps);
-withHintText.args = withHintTextProps;
-withHintText.argTypes = argTypes;
+export const WithHintText = Template.bind(withHintTextProps);
+WithHintText.args = withHintTextProps;
+WithHintText.argTypes = argTypes;
 
-export const notchDisabled = Template.bind(noNotchProps);
-notchDisabled.args = noNotchProps;
-notchDisabled.argTypes = argTypes;
+export const NotchDisabled = Template.bind(noNotchProps);
+NotchDisabled.args = noNotchProps;
+NotchDisabled.argTypes = argTypes;
 
-export const notchDisabledWithValue = Template.bind(noNotchWithValueProps);
-notchDisabledWithValue.args = noNotchWithValueProps;
-notchDisabledWithValue.argTypes = argTypes;
+export const NotchDisabledWithValue = Template.bind(noNotchWithValueProps);
+NotchDisabledWithValue.args = noNotchWithValueProps;
+NotchDisabledWithValue.argTypes = argTypes;
 
-export const withPrefixIcon = Template.bind(withPrefixIconProps);
-withPrefixIcon.args = withPrefixIconProps;
-withPrefixIcon.argTypes = argTypes;
+export const WithPrefixIcon = Template.bind(withPrefixIconProps);
+WithPrefixIcon.args = withPrefixIconProps;
+WithPrefixIcon.argTypes = argTypes;
 
-export const withSuffixIcon = Template.bind(withSuffixIconProps);
-withSuffixIcon.args = withSuffixIconProps;
-withSuffixIcon.argTypes = argTypes;
+export const WithSuffixIcon = Template.bind(withSuffixIconProps);
+WithSuffixIcon.args = withSuffixIconProps;
+WithSuffixIcon.argTypes = argTypes;
 
-export const withBothIcons = Template.bind(withBothIconsProps);
-withBothIcons.args = withBothIconsProps;
-withBothIcons.argTypes = argTypes;
+export const WithBothIcons = Template.bind(withBothIconsProps);
+WithBothIcons.args = withBothIconsProps;
+WithBothIcons.argTypes = argTypes;
 
-export const disabled = Template.bind(disabledProps);
-disabled.args = disabledProps;
-disabled.argTypes = argTypes;
+export const Disabled = Template.bind(disabledProps);
+Disabled.args = disabledProps;
+Disabled.argTypes = argTypes;
 
-export const valid = Template.bind(validProps);
-valid.args = validProps;
-valid.argTypes = argTypes;
+export const Valid = Template.bind(validProps);
+Valid.args = validProps;
+Valid.argTypes = argTypes;
 
-export const invalid = Template.bind(invalidProps);
-invalid.args = invalidProps;
-invalid.argTypes = argTypes;
+export const Invalid = Template.bind(invalidProps);
+Invalid.args = invalidProps;
+Invalid.argTypes = argTypes;
 
-export const loading = Template.bind(loadingProps);
-loading.args = loadingProps;
-loading.argTypes = argTypes;
+export const Loading = Template.bind(loadingProps);
+Loading.args = loadingProps;
+Loading.argTypes = argTypes;
 
 const smallProps: typeof standardProps = {
 	...standardProps,
 	size: 'small',
 };
-export const small = Template.bind(smallProps);
-small.args = smallProps;
-small.argTypes = argTypes;
+export const Small = Template.bind(smallProps);
+Small.args = smallProps;
+Small.argTypes = argTypes;
 
 const withValueSmallProps: typeof withAValueProps = {
 	...withAValueProps,
 	size: 'small',
 };
 
-export const withValueSmall = Template.bind(withValueSmallProps);
-withValueSmall.args = withValueSmallProps;
-withValueSmall.argTypes = argTypes;
+export const WithValueSmall = Template.bind(withValueSmallProps);
+WithValueSmall.args = withValueSmallProps;
+WithValueSmall.argTypes = argTypes;
 
 const withIconSmallProps: typeof withAValueProps = {
 	...withAValueProps,
@@ -259,15 +259,15 @@ const withIconSmallProps: typeof withAValueProps = {
 	size: 'small',
 };
 
-export const withIconSmall = Template.bind(withIconSmallProps);
-withIconSmall.args = withIconSmallProps;
-withIconSmall.argTypes = argTypes;
+export const WithIconSmall = Template.bind(withIconSmallProps);
+WithIconSmall.args = withIconSmallProps;
+WithIconSmall.argTypes = argTypes;
 
 const loadingSmallProps: typeof withAValueProps = {
 	...withAValueProps,
 	isLoading: true,
 	size: 'small',
 };
-export const loadingSmall = Template.bind(loadingSmallProps);
-loadingSmall.args = loadingSmallProps;
-loadingSmall.argTypes = argTypes;
+export const LoadingSmall = Template.bind(loadingSmallProps);
+LoadingSmall.args = loadingSmallProps;
+LoadingSmall.argTypes = argTypes;

--- a/lib/components/OptionGrid/OptionGrid.stories.tsx
+++ b/lib/components/OptionGrid/OptionGrid.stories.tsx
@@ -97,7 +97,7 @@ const alphaOptions: OptionItem[] = [
 ];
 
 const meta: Meta<typeof OptionGrid> = {
-	title: 'Components/Option Grid',
+	title: 'Forms & Input Fields/Option Grid',
 	component: OptionGrid,
 	args: {
 		label: 'Select car servicing options',

--- a/lib/components/OptionList/OptionList.stories.tsx
+++ b/lib/components/OptionList/OptionList.stories.tsx
@@ -12,7 +12,7 @@ const itemData = [
 ];
 
 const meta: Meta<typeof OptionList> = {
-	title: 'Components/Option List',
+	title: 'Forms & Input Fields/Option List',
 	component: OptionList,
 	args: {
 		label: 'Commonly requested extras',

--- a/lib/components/OrderedList/OrderedList.stories.tsx
+++ b/lib/components/OrderedList/OrderedList.stories.tsx
@@ -6,7 +6,7 @@ import { Text } from '../Text';
 import { OrderedList } from '.';
 
 export default {
-	title: 'Foundation/List/OrderedList',
+	title: 'Primatives/Ordered List',
 	component: OrderedList,
 } satisfies Meta<typeof OrderedList>;
 
@@ -46,6 +46,6 @@ const Template: StoryFn<typeof OrderedList> = (args) => (
 	</OrderedList>
 );
 
-export const standard = {
+export const Standard = {
 	render: Template,
 };

--- a/lib/components/Pagination/Pagination.stories.tsx
+++ b/lib/components/Pagination/Pagination.stories.tsx
@@ -7,7 +7,7 @@ import { Box } from '../Box';
 import { Pagination } from '.';
 
 export default {
-	title: 'Components/Pagination/Numbered',
+	title: 'Components/Pagination',
 	component: Pagination,
 } satisfies Meta<typeof Pagination>;
 
@@ -34,16 +34,16 @@ const standardProps = {
 	loading: false,
 	onChange: action('onChange'),
 };
-export const standard: StoryFn<typeof Pagination> =
+export const Standard: StoryFn<typeof Pagination> =
 	Template.bind(standardProps);
-standard.args = standardProps;
+Standard.args = standardProps;
 
 const loadingProps = {
 	...standardProps,
 	loading: true,
 };
-export const loading: StoryFn<typeof Pagination> = Template.bind(loadingProps);
-loading.args = loadingProps;
+export const Loading: StoryFn<typeof Pagination> = Template.bind(loadingProps);
+Loading.args = loadingProps;
 
 const lessThanMaxPagesProps = {
 	...standardProps,
@@ -52,10 +52,10 @@ const lessThanMaxPagesProps = {
 	pageSize: 10,
 	numPagesDisplayed: 5,
 };
-export const lessThanMaxPages: StoryFn<typeof Pagination> = Template.bind(
+export const LessThanMaxPages: StoryFn<typeof Pagination> = Template.bind(
 	lessThanMaxPagesProps,
 );
-lessThanMaxPages.args = lessThanMaxPagesProps;
+LessThanMaxPages.args = lessThanMaxPagesProps;
 
 const allPagesFitProps = {
 	...standardProps,
@@ -64,9 +64,9 @@ const allPagesFitProps = {
 	pageSize: 10,
 	numPagesDisplayed: 5,
 };
-export const allPagesFit: StoryFn<typeof Pagination> =
+export const AllPagesFit: StoryFn<typeof Pagination> =
 	Template.bind(allPagesFitProps);
-allPagesFit.args = allPagesFitProps;
+AllPagesFit.args = allPagesFitProps;
 
 const jumpForwardStartProps = {
 	...standardProps,
@@ -75,10 +75,10 @@ const jumpForwardStartProps = {
 	pageSize: 10,
 	numPagesDisplayed: 5,
 };
-export const jumpForwardStart: StoryFn<typeof Pagination> = Template.bind(
+export const JumpForwardStart: StoryFn<typeof Pagination> = Template.bind(
 	jumpForwardStartProps,
 );
-jumpForwardStart.args = jumpForwardStartProps;
+JumpForwardStart.args = jumpForwardStartProps;
 
 const jumpForwardMiddleProps = {
 	...standardProps,
@@ -87,10 +87,10 @@ const jumpForwardMiddleProps = {
 	pageSize: 10,
 	numPagesDisplayed: 5,
 };
-export const jumpForwardMiddle: StoryFn<typeof Pagination> = Template.bind(
+export const JumpForwardMiddle: StoryFn<typeof Pagination> = Template.bind(
 	jumpForwardMiddleProps,
 );
-jumpForwardMiddle.args = jumpForwardMiddleProps;
+JumpForwardMiddle.args = jumpForwardMiddleProps;
 
 const lastChunkStartProps = {
 	...standardProps,
@@ -99,9 +99,9 @@ const lastChunkStartProps = {
 	pageSize: 10,
 	numPagesDisplayed: 5,
 };
-export const lastChunkStart: StoryFn<typeof Pagination> =
+export const LastChunkStart: StoryFn<typeof Pagination> =
 	Template.bind(lastChunkStartProps);
-lastChunkStart.args = lastChunkStartProps;
+LastChunkStart.args = lastChunkStartProps;
 
 const lastChunkMiddleProps = {
 	...standardProps,
@@ -110,9 +110,9 @@ const lastChunkMiddleProps = {
 	pageSize: 10,
 	numPagesDisplayed: 5,
 };
-export const lastChunkMiddle: StoryFn<typeof Pagination> =
+export const LastChunkMiddle: StoryFn<typeof Pagination> =
 	Template.bind(lastChunkMiddleProps);
-lastChunkMiddle.args = lastChunkMiddleProps;
+LastChunkMiddle.args = lastChunkMiddleProps;
 
 const jumpBackStartProps = {
 	...standardProps,
@@ -121,9 +121,9 @@ const jumpBackStartProps = {
 	pageSize: 10,
 	numPagesDisplayed: 5,
 };
-export const jumpBackStart: StoryFn<typeof Pagination> =
+export const JumpBackStart: StoryFn<typeof Pagination> =
 	Template.bind(jumpBackStartProps);
-jumpBackStart.args = lastChunkMiddleProps;
+JumpBackStart.args = lastChunkMiddleProps;
 
 const jumpBackMiddleProps = {
 	...standardProps,
@@ -132,9 +132,9 @@ const jumpBackMiddleProps = {
 	pageSize: 10,
 	numPagesDisplayed: 5,
 };
-export const jumpBackMiddle: StoryFn<typeof Pagination> =
+export const JumpBackMiddle: StoryFn<typeof Pagination> =
 	Template.bind(jumpBackMiddleProps);
-jumpBackMiddle.args = jumpBackMiddleProps;
+JumpBackMiddle.args = jumpBackMiddleProps;
 
 const jumpBackEndProps = {
 	...standardProps,
@@ -143,6 +143,6 @@ const jumpBackEndProps = {
 	pageSize: 10,
 	numPagesDisplayed: 5,
 };
-export const jumpBackEnd: StoryFn<typeof Pagination> =
+export const JumpBackEnd: StoryFn<typeof Pagination> =
 	Template.bind(jumpBackEndProps);
-jumpBackEnd.args = jumpBackEndProps;
+JumpBackEnd.args = jumpBackEndProps;

--- a/lib/components/Positioner/Positioner.stories.tsx
+++ b/lib/components/Positioner/Positioner.stories.tsx
@@ -12,7 +12,7 @@ import { EAlignment } from './alignment';
 import { Positioner } from '.';
 
 export default {
-	title: 'Utility/Positioner',
+	title: 'Layout/Positioner',
 	component: Positioner,
 	parameters: { chromatic: {} },
 	argTypes: {
@@ -113,25 +113,25 @@ const standardProps = {
 	triggerOffset: 12,
 };
 
-export const closed: StoryFn<typeof Positioner> = Template.bind(standardProps);
-closed.args = standardProps;
+export const Closed: StoryFn<typeof Positioner> = Template.bind(standardProps);
+Closed.args = standardProps;
 
 const openProps = {
 	...standardProps,
 	isOpen: true,
 };
 
-export const open: StoryFn<typeof Positioner> = Template.bind(openProps);
-open.args = openProps;
+export const Open: StoryFn<typeof Positioner> = Template.bind(openProps);
+Open.args = openProps;
 
 const illustrateAScrollProps = {
 	...standardProps,
 	isOpen: true,
 };
 
-export const illustrateAScroll: StoryFn<typeof Positioner> =
+export const IllustrateAScroll: StoryFn<typeof Positioner> =
 	WithScrollTemplate.bind(illustrateAScrollProps);
-illustrateAScroll.args = openProps;
-illustrateAScroll.parameters = {
+IllustrateAScroll.args = openProps;
+IllustrateAScroll.parameters = {
 	chromatic: { disableSnapshot: true },
 };

--- a/lib/components/ProgressBar/ProgressBar.stories.tsx
+++ b/lib/components/ProgressBar/ProgressBar.stories.tsx
@@ -7,7 +7,7 @@ import { Stack } from '../Stack';
 import { ProgressBar } from '.';
 
 export default {
-	title: 'Components/Progress/ProgressBar',
+	title: 'Components/Progress/Progress Bar',
 	component: ProgressBar,
 } satisfies Meta<typeof ProgressBar>;
 
@@ -32,8 +32,8 @@ standard.args = standardProps;
 const withValueProps: ComponentProps<typeof ProgressBar> = {
 	value: 0.3,
 };
-export const withValue = Template.bind(withValueProps);
-withValue.args = withValueProps;
+export const WithValue = Template.bind(withValueProps);
+WithValue.args = withValueProps;
 
-export const allColours = AllColoursTemplate.bind(standardProps);
-allColours.args = standardProps;
+export const AllColours = AllColoursTemplate.bind(standardProps);
+AllColours.args = standardProps;

--- a/lib/components/ProgressBarGroup/ProgressBarGroup.stories.tsx
+++ b/lib/components/ProgressBarGroup/ProgressBarGroup.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentProps } from 'react';
 import { ProgressBarGroup } from '.';
 
 export default {
-	title: 'Components/Progress/ProgressBarGroup',
+	title: 'Components/Progress Bar Group',
 	component: ProgressBarGroup,
 } satisfies Meta<typeof ProgressBarGroup>;
 
@@ -18,5 +18,5 @@ const standardProps: ComponentProps<typeof ProgressBarGroup> = {
 	prefixLabels: ['5 star', '4 star', '3 star', '2 star', '1 star'],
 	suffixLabels: values.map((item) => item.toString()),
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;

--- a/lib/components/ProgressSpinner/ProgressSpinner.stories.tsx
+++ b/lib/components/ProgressSpinner/ProgressSpinner.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentProps } from 'react';
 import { ProgressSpinner } from '.';
 
 export default {
-	title: 'Components/Progress/Spinner',
+	title: 'Primatives/Progress Spinner',
 	component: ProgressSpinner,
 	decorators: [
 		(story) => (
@@ -26,13 +26,11 @@ export default {
 	parameters: { chromatic: { disable: true } },
 } satisfies Meta<typeof ProgressSpinner>;
 
-export const Standard = () => (
-	<ProgressSpinner colour="primary" size="medium" />
-);
-
 const Template: StoryFn<typeof ProgressSpinner> = (args) => (
 	<ProgressSpinner {...args} />
 );
+
 const standardProps: ComponentProps<typeof ProgressSpinner> = {};
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;

--- a/lib/components/Radio/Radio.stories.tsx
+++ b/lib/components/Radio/Radio.stories.tsx
@@ -10,7 +10,7 @@ import { Text } from '../Text';
 import { Radio, RadioGroup } from '.';
 
 export default {
-	title: 'Components/Inputs/Radio',
+	title: 'Forms & Input Fields/Radio',
 	component: Radio,
 	decorators: [
 		(story) => (
@@ -58,7 +58,7 @@ const argTypes: ArgTypes = {
 	},
 };
 
-export const list: StoryObj<typeof Radio> = {
+export const List: StoryObj<typeof Radio> = {
 	render: ({ value, children, ...args }) => (
 		<RadioGroup value={value} name="favourite fruit">
 			{listData.map((item: { label: string; value: string }) => {
@@ -94,7 +94,7 @@ const uncheckedProps: ComponentProps<typeof Radio> = {
 	value: 'berry',
 };
 const checkedProps: ComponentProps<typeof Radio> = {
-	// @ts-ignore
+	// @ts-expect-error type error for `checked`
 	checked: true,
 	disabled: false,
 	children: 'check me!',
@@ -111,7 +111,7 @@ const emptyProps: ComponentProps<typeof Radio> = {
 	value: 'berry',
 };
 const disabledCheckedProps: ComponentProps<typeof Radio> = {
-	// @ts-ignore
+	// @ts-expect-error type error for `checked`
 	checked: true,
 	disabled: true,
 	children: 'check me!',
@@ -172,41 +172,41 @@ const withMultiLineComponentProps: ComponentProps<typeof Radio> = {
 	value: '1',
 };
 
-export const unchecked = Template.bind(uncheckedProps);
-unchecked.args = uncheckedProps;
-unchecked.argTypes = argTypes;
+export const Unchecked = Template.bind(uncheckedProps);
+Unchecked.args = uncheckedProps;
+Unchecked.argTypes = argTypes;
 
-export const checked = Template.bind(checkedProps);
-checked.args = checkedProps;
-checked.argTypes = argTypes;
+export const Checked = Template.bind(checkedProps);
+Checked.args = checkedProps;
+Checked.argTypes = argTypes;
 
-export const disabled = Template.bind(disabledProps);
-disabled.args = disabledProps;
-disabled.argTypes = argTypes;
+export const Disabled = Template.bind(disabledProps);
+Disabled.args = disabledProps;
+Disabled.argTypes = argTypes;
 
-export const disabledChecked = Template.bind(disabledCheckedProps);
-disabledChecked.args = disabledCheckedProps;
-disabledChecked.argTypes = argTypes;
+export const DisabledChecked = Template.bind(disabledCheckedProps);
+DisabledChecked.args = disabledCheckedProps;
+DisabledChecked.argTypes = argTypes;
 
-export const withNoChildren = Template.bind(emptyProps);
-withNoChildren.args = emptyProps;
+export const WithNoChildren = Template.bind(emptyProps);
+WithNoChildren.args = emptyProps;
 
-export const multipleLines = Template.bind(multipleLinesProps);
-multipleLines.args = multipleLinesProps;
-multipleLines.argTypes = argTypes;
+export const MultipleLines = Template.bind(multipleLinesProps);
+MultipleLines.args = multipleLinesProps;
+MultipleLines.argTypes = argTypes;
 
-export const withComponent = Template.bind(withComponentProps);
-withComponent.args = withComponentProps;
-withComponent.argTypes = {
+export const WithComponent = Template.bind(withComponentProps);
+WithComponent.args = withComponentProps;
+WithComponent.argTypes = {
 	...argTypes,
 	children: { control: { disable: true } },
 };
 
-export const withMultiLineComponent = Template.bind(
+export const WithMultiLineComponent = Template.bind(
 	withMultiLineComponentProps,
 );
-withMultiLineComponent.args = withMultiLineComponentProps;
-withMultiLineComponent.argTypes = {
+WithMultiLineComponent.args = withMultiLineComponentProps;
+WithMultiLineComponent.argTypes = {
 	...argTypes,
 	children: { control: { disable: true } },
 };

--- a/lib/components/ScrollPane/ScrollPane.stories.tsx
+++ b/lib/components/ScrollPane/ScrollPane.stories.tsx
@@ -10,7 +10,7 @@ import { Text } from '../Text';
 import { ScrollPane } from '.';
 
 export default {
-	title: 'Foundation/Layout/ScrollPane',
+	title: 'Layout/Scroll Pane',
 	component: ScrollPane,
 } satisfies Meta<typeof ScrollPane>;
 
@@ -42,5 +42,5 @@ const Template: StoryFn<typeof ScrollPane> = (args) => (
 );
 
 const standardProps: Props = {};
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;

--- a/lib/components/Section/Section.stories.tsx
+++ b/lib/components/Section/Section.stories.tsx
@@ -8,7 +8,7 @@ import { boxArgTypes } from '../Box/argTypes';
 import { Section } from '.';
 
 export default {
-	title: 'Foundation/Section',
+	title: 'Layout/Section',
 	component: Section,
 	argTypes: {
 		paddingX: boxArgTypes.paddingX,
@@ -39,5 +39,5 @@ const standardProps: Omit<ComponentProps<typeof Section>, 'children'> = {
 	width: 'small',
 	paddingX: ['none', '3', '5'],
 };
-export const standard = template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = template.bind(standardProps);
+Standard.args = standardProps;

--- a/lib/components/SelectInput/SelectInput.stories.tsx
+++ b/lib/components/SelectInput/SelectInput.stories.tsx
@@ -52,7 +52,7 @@ const iconOptions = {
 };
 
 export default {
-	title: 'Components/Inputs/Select',
+	title: 'Forms & Input Fields/Select',
 	component: SelectInput,
 	parameters: { chromatic: {} },
 	args: {
@@ -104,84 +104,84 @@ const Template: StoryFn<typeof SelectInput> = (args) => (
 	</SelectInput>
 );
 
-export const standard = Template.bind({});
+export const Standard = Template.bind({});
 
-export const withAValue = Template.bind({});
-withAValue.args = { value: defaultValue, placeholder: defaultPlaceholder };
+export const WithAValue = Template.bind({});
+WithAValue.args = { value: defaultValue, placeholder: defaultPlaceholder };
 
-export const withHintText = Template.bind({});
-withHintText.args = {
+export const WithHintText = Template.bind({});
+WithHintText.args = {
 	hintText: 'Hint Text',
 	placeholder: defaultPlaceholder,
 };
 
-export const notchDisabled = Template.bind({});
-notchDisabled.args = {
+export const NotchDisabled = Template.bind({});
+NotchDisabled.args = {
 	placeholder: defaultPlaceholder,
 	notch: false,
 };
 
-export const notchDisabledWithValue = Template.bind({});
-notchDisabledWithValue.args = {
+export const NotchDisabledWithValue = Template.bind({});
+NotchDisabledWithValue.args = {
 	value: defaultValue,
 	placeholder: defaultPlaceholder,
 	notch: false,
 };
 
-export const withPrefixIcon = Template.bind({});
-withPrefixIcon.args = {
+export const WithPrefixIcon = Template.bind({});
+WithPrefixIcon.args = {
 	prefixIcon: CarIcon,
 };
 
-export const disabled = Template.bind({});
-disabled.args = {
+export const Disabled = Template.bind({});
+Disabled.args = {
 	value: defaultValue,
 	placeholder: defaultPlaceholder,
 	disabled: true,
 };
 
-export const valid = Template.bind({});
-valid.args = {
+export const Valid = Template.bind({});
+Valid.args = {
 	value: defaultValue,
 	placeholder: defaultPlaceholder,
 	isTouched: true,
 	isValid: true,
 };
 
-export const invalid = Template.bind({});
-invalid.args = {
+export const Invalid = Template.bind({});
+Invalid.args = {
 	placeholder: defaultPlaceholder,
 	isTouched: true,
 	isValid: false,
 	hintText: 'Vehicle make is mandatory',
 };
 
-export const loading = Template.bind({});
-loading.args = {
+export const Loading = Template.bind({});
+Loading.args = {
 	isLoading: true,
 };
 
-export const small = Template.bind({});
-small.args = {
+export const Small = Template.bind({});
+Small.args = {
 	size: 'small',
 };
 
-export const withValueSmall = Template.bind({});
-withValueSmall.args = {
-	...withAValue.args,
+export const WithValueSmall = Template.bind({});
+WithValueSmall.args = {
+	...WithAValue.args,
 	size: 'small',
 };
 
-export const withIconSmall = Template.bind({});
-withIconSmall.args = {
-	...withAValue.args,
+export const WithIconSmall = Template.bind({});
+WithIconSmall.args = {
+	...WithAValue.args,
 	prefixIcon: CarIcon,
 	size: 'small',
 };
 
-export const loadingSmall = Template.bind({});
-loadingSmall.args = {
-	...withAValue.args,
+export const LoadingSmall = Template.bind({});
+LoadingSmall.args = {
+	...WithAValue.args,
 	isLoading: true,
 	size: 'small',
 };

--- a/lib/components/SimplePagination/SimplePagination.stories.tsx
+++ b/lib/components/SimplePagination/SimplePagination.stories.tsx
@@ -7,7 +7,7 @@ import { Box } from '../Box';
 import { SimplePagination } from '.';
 
 export default {
-	title: 'Components/Pagination/Simple',
+	title: 'Primatives/Simple Pagination',
 	component: SimplePagination,
 } satisfies Meta<typeof SimplePagination>;
 

--- a/lib/components/SliderProgress/SliderProgress.stories.tsx
+++ b/lib/components/SliderProgress/SliderProgress.stories.tsx
@@ -9,7 +9,7 @@ import { boxArgTypes } from '../Box/argTypes';
 import { SliderProgress } from '.';
 
 export default {
-	title: 'Components/Progress/SliderProgress',
+	title: 'Components/Progress/Slider Progress',
 	component: SliderProgress,
 	argTypes: {
 		backgroundColour: boxArgTypes.backgroundColour,

--- a/lib/components/Stack/Stack.stories.tsx
+++ b/lib/components/Stack/Stack.stories.tsx
@@ -21,7 +21,7 @@ const spacingOptions: Record<string, ComponentProps<typeof Stack>['space']> = {
 };
 
 export default {
-	title: 'Foundation/Layout/Stack',
+	title: 'Layout/Stack',
 	component: Stack,
 	argTypes: {
 		space: {
@@ -50,15 +50,15 @@ const standardProps: Omit<ComponentProps<typeof Stack>, 'children'> = {
 	width: void 0,
 	is: 'div',
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const asSectionProps: Omit<ComponentProps<typeof Stack>, 'children'> = {
 	...standardProps,
 	is: 'section',
 };
-export const asSection = Template.bind(asSectionProps);
-asSection.args = asSectionProps;
+export const AsSection = Template.bind(asSectionProps);
+AsSection.args = asSectionProps;
 
 const withDividersProps: Omit<ComponentProps<typeof Stack>, 'children'> = {
 	...standardProps,
@@ -66,8 +66,8 @@ const withDividersProps: Omit<ComponentProps<typeof Stack>, 'children'> = {
 	dividers: true,
 	space: '3',
 };
-export const withDividers = Template.bind(withDividersProps);
-withDividers.args = withDividersProps;
+export const WithDividers = Template.bind(withDividersProps);
+WithDividers.args = withDividersProps;
 
 const withAlignmentProps: Omit<ComponentProps<typeof Stack>, 'children'> = {
 	...standardProps,
@@ -76,5 +76,5 @@ const withAlignmentProps: Omit<ComponentProps<typeof Stack>, 'children'> = {
 	space: '3',
 	alignItems: 'center',
 };
-export const withAlignment = Template.bind(withAlignmentProps);
-withAlignment.args = withAlignmentProps;
+export const WithAlignment = Template.bind(withAlignmentProps);
+WithAlignment.args = withAlignmentProps;

--- a/lib/components/StandardModal/StandardModal.stories.tsx
+++ b/lib/components/StandardModal/StandardModal.stories.tsx
@@ -9,7 +9,7 @@ import { Text } from '../Text';
 import { StandardModal } from '.';
 
 export default {
-	title: 'Components/StandardModal',
+	title: 'Components/Modal: Standard with Title',
 	component: StandardModal,
 	parameters: {
 		chromatic: { disable: true },

--- a/lib/components/StarRating/StarRating.stories.tsx
+++ b/lib/components/StarRating/StarRating.stories.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { EStarRatingSize, StarRating } from '.';
 
 export default {
-	title: 'Components/StarRating',
+	title: 'Components/Star Rating',
 	component: StarRating,
 	argTypes: {
 		size: {
@@ -31,21 +31,21 @@ const standardProps = {
 	size: EStarRatingSize.Medium,
 	label: '',
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const smallSizeProps = {
 	rating: 3.2,
 	size: EStarRatingSize.Small,
 	label: '',
 };
-export const smallSize = Template.bind(smallSizeProps);
-smallSize.args = smallSizeProps;
+export const SmallSize = Template.bind(smallSizeProps);
+SmallSize.args = smallSizeProps;
 
 const withLabelProps = {
 	rating: 3.9,
 	size: EStarRatingSize.Medium,
 	label: 'product rating',
 };
-export const withLabel = Template.bind(withLabelProps);
-withLabel.args = withLabelProps;
+export const WithLabel = Template.bind(withLabelProps);
+WithLabel.args = withLabelProps;

--- a/lib/components/Stepper/Stepper.stories.tsx
+++ b/lib/components/Stepper/Stepper.stories.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { Stepper } from '.';
 
 export default {
-	title: 'Components/Inputs/Stepper',
+	title: 'Forms & Input Fields/Stepper',
 	component: Stepper,
 } satisfies Meta<typeof Stepper>;
 
@@ -36,15 +36,15 @@ const standardProps = {
 	disabled: false,
 	onChange: action('onChange'),
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const fullWidthPropsProps = {
 	...standardProps,
 	isFullWidth: true,
 };
-export const fullWidth = Template.bind(fullWidthPropsProps);
-fullWidth.args = fullWidthPropsProps;
+export const FullWidth = Template.bind(fullWidthPropsProps);
+FullWidth.args = fullWidthPropsProps;
 
 const formatter = new Intl.NumberFormat('en-AU', {
 	style: 'currency',
@@ -59,5 +59,5 @@ const withFormattingProps = {
 	format: formatter.format,
 	onChange: action('onChange'),
 };
-export const withFormatting = Template.bind(withFormattingProps);
-withFormatting.args = withFormattingProps;
+export const WithFormatting = Template.bind(withFormattingProps);
+WithFormatting.args = withFormattingProps;

--- a/lib/components/StickyBox/StickyBox.stories.tsx
+++ b/lib/components/StickyBox/StickyBox.stories.tsx
@@ -10,7 +10,7 @@ import { Text } from '../Text';
 import { StickyBox } from '.';
 
 export default {
-	title: 'Foundation/Layout/StickyBox',
+	title: 'Layout/StickyBox',
 	component: StickyBox,
 } satisfies Meta<typeof StickyBox>;
 
@@ -55,12 +55,12 @@ const Template: StoryFn<typeof StickyBox> = (args) => (
 const standardProps: Props = {
 	top: 'none',
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const withNoPopShadowProps: Props = {
 	top: 'none',
 	noPopShadow: true,
 };
-export const withNoPopShadow = Template.bind(withNoPopShadowProps);
-withNoPopShadow.args = withNoPopShadowProps;
+export const WithNoPopShadow = Template.bind(withNoPopShadowProps);
+WithNoPopShadow.args = withNoPopShadowProps;

--- a/lib/components/Switch/Switch.stories.tsx
+++ b/lib/components/Switch/Switch.stories.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { Switch } from '.';
 
 export default {
-	title: 'Components/Switch',
+	title: 'Primatives/Switch',
 	component: Switch,
 } satisfies Meta<typeof Switch>;
 
@@ -18,26 +18,26 @@ const standardProps = {
 	className: 'toggleButton-class',
 };
 
-export const untoggled: StoryFn<typeof Switch> = Template.bind(standardProps);
-untoggled.args = standardProps;
+export const Untoggled: StoryFn<typeof Switch> = Template.bind(standardProps);
+Untoggled.args = standardProps;
 
 const untoggledDisabledProps = {
 	...standardProps,
 	isDisabled: true,
 };
 
-export const untoggledDisabled: StoryFn<typeof Switch> = Template.bind(
+export const UntoggledDisabled: StoryFn<typeof Switch> = Template.bind(
 	untoggledDisabledProps,
 );
-untoggledDisabled.args = untoggledDisabledProps;
+UntoggledDisabled.args = untoggledDisabledProps;
 
 const toggledProps = {
 	...standardProps,
 	isSelected: true,
 };
 
-export const toggled: StoryFn<typeof Switch> = Template.bind(toggledProps);
-toggled.args = toggledProps;
+export const Toggled: StoryFn<typeof Switch> = Template.bind(toggledProps);
+Toggled.args = toggledProps;
 
 const toggledDisabledProps = {
 	...standardProps,
@@ -45,6 +45,6 @@ const toggledDisabledProps = {
 	isDisabled: true,
 };
 
-export const toggledDisabled: StoryFn<typeof Switch> =
+export const ToggledDisabled: StoryFn<typeof Switch> =
 	Template.bind(toggledDisabledProps);
-toggledDisabled.args = toggledDisabledProps;
+ToggledDisabled.args = toggledDisabledProps;

--- a/lib/components/Text/Text.stories.tsx
+++ b/lib/components/Text/Text.stories.tsx
@@ -55,7 +55,7 @@ const colourOptions: Array<ComponentProps<typeof Text>['colour']> = [
 ];
 
 export default {
-	title: 'Foundation/Typography/Text',
+	title: 'Primatives/Text',
 	//component: Text, Breaks the docs when enabled!
 	decorators: [],
 } satisfies Meta<typeof Text>;
@@ -171,21 +171,21 @@ const allTypesProps: ComponentProps<typeof Text> = {
 		'To avoid you coming to a halt in the middle of the road, because of a banging, crash of pistons and valves fighting with each other, let investigate what the timing belt is, what it does, and why it costs so much to replace or repair.',
 };
 
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
-standard.argTypes = argTypes;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
+Standard.argTypes = argTypes;
 
-export const allTypes = AllTypesTemplate.bind(allTypesProps);
-allTypes.args = allTypesProps;
-allTypes.argTypes = { ...sharedArgTypes, ...colourArgTypes };
+export const AllTypes = AllTypesTemplate.bind(allTypesProps);
+AllTypes.args = allTypesProps;
+AllTypes.argTypes = { ...sharedArgTypes, ...colourArgTypes };
 
-export const allSizes = AllSizesTemplate.bind(allTypesProps);
-allSizes.args = allTypesProps;
-allSizes.argTypes = argTypes;
+export const AllSizes = AllSizesTemplate.bind(allTypesProps);
+AllSizes.args = allTypesProps;
+AllSizes.argTypes = argTypes;
 
-export const allColours = AllColoursTemplate.bind(allTypesProps);
-allColours.args = allTypesProps;
-allColours.argTypes = argTypes;
+export const AllColours = AllColoursTemplate.bind(allTypesProps);
+AllColours.args = allTypesProps;
+AllColours.argTypes = argTypes;
 
 const withLongUnspacedTextProps: ComponentProps<typeof Text> = {
 	breakWord: true,
@@ -193,6 +193,6 @@ const withLongUnspacedTextProps: ComponentProps<typeof Text> = {
 		'Toavoidyoucomingtoahaltinthemiddleoftheroad,becauseofabanging,crashofpistonsandvalvesfightingwitheachother,letinvestigatewhatthetiming belt is, what it does, and why it costs so much to replace or repair.',
 };
 
-export const withLongUnspacedText = Template.bind(withLongUnspacedTextProps);
-withLongUnspacedText.args = withLongUnspacedTextProps;
-withLongUnspacedText.argTypes = argTypes;
+export const WithLongUnspacedText = Template.bind(withLongUnspacedTextProps);
+WithLongUnspacedText.args = withLongUnspacedTextProps;
+WithLongUnspacedText.argTypes = argTypes;

--- a/lib/components/TextAreaInput/TextAreaInput.stories.tsx
+++ b/lib/components/TextAreaInput/TextAreaInput.stories.tsx
@@ -6,7 +6,7 @@ import { ComponentProps } from 'react';
 import { TextAreaInput } from '.';
 
 export default {
-	title: 'Components/Inputs/Textarea',
+	title: 'Forms & Input Fields/Text Area Input',
 	component: TextAreaInput,
 	parameters: { chromatic: {} },
 } satisfies Meta<typeof TextAreaInput>;
@@ -93,64 +93,64 @@ const loadingProps: ComponentProps<typeof TextAreaInput> = {
 	...sharedProps,
 	isLoading: true,
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
-standard.argTypes = argTypes;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
+Standard.argTypes = argTypes;
 
-export const withAValue = Template.bind(withAValueProps);
-withAValue.args = withAValueProps;
-withAValue.argTypes = argTypes;
+export const WithAValue = Template.bind(withAValueProps);
+WithAValue.args = withAValueProps;
+WithAValue.argTypes = argTypes;
 
-export const withHintText = Template.bind(withHintTextProps);
-withHintText.args = withHintTextProps;
-withHintText.argTypes = argTypes;
+export const WithHintText = Template.bind(withHintTextProps);
+WithHintText.args = withHintTextProps;
+WithHintText.argTypes = argTypes;
 
-export const notchDisabled = Template.bind(noNotchProps);
-notchDisabled.args = noNotchProps;
-notchDisabled.argTypes = argTypes;
+export const NotchDisabled = Template.bind(noNotchProps);
+NotchDisabled.args = noNotchProps;
+NotchDisabled.argTypes = argTypes;
 
-export const notchDisabledWithValue = Template.bind(noNotchWithValueProps);
-notchDisabledWithValue.args = noNotchWithValueProps;
-notchDisabledWithValue.argTypes = argTypes;
+export const NotchDisabledWithValue = Template.bind(noNotchWithValueProps);
+NotchDisabledWithValue.args = noNotchWithValueProps;
+NotchDisabledWithValue.argTypes = argTypes;
 
-export const disabled = Template.bind(disabledProps);
-disabled.args = disabledProps;
-disabled.argTypes = argTypes;
+export const Disabled = Template.bind(disabledProps);
+Disabled.args = disabledProps;
+Disabled.argTypes = argTypes;
 
-export const valid = Template.bind(validProps);
-valid.args = validProps;
-valid.argTypes = argTypes;
+export const Valid = Template.bind(validProps);
+Valid.args = validProps;
+Valid.argTypes = argTypes;
 
-export const invalid = Template.bind(invalidProps);
-invalid.args = invalidProps;
-invalid.argTypes = argTypes;
+export const Invalid = Template.bind(invalidProps);
+Invalid.args = invalidProps;
+Invalid.argTypes = argTypes;
 
-export const loading = Template.bind(loadingProps);
-loading.args = loadingProps;
-loading.argTypes = argTypes;
+export const Loading = Template.bind(loadingProps);
+Loading.args = loadingProps;
+Loading.argTypes = argTypes;
 
 const smallProps: typeof standardProps = {
 	...standardProps,
 	size: 'small',
 };
-export const small = Template.bind(smallProps);
-small.args = smallProps;
-small.argTypes = argTypes;
+export const Small = Template.bind(smallProps);
+Small.args = smallProps;
+Small.argTypes = argTypes;
 
 const withValueSmallProps: typeof withAValueProps = {
 	...withAValueProps,
 	size: 'small',
 };
 
-export const withValueSmall = Template.bind(withValueSmallProps);
-withValueSmall.args = withValueSmallProps;
-withValueSmall.argTypes = argTypes;
+export const WithValueSmall = Template.bind(withValueSmallProps);
+WithValueSmall.args = withValueSmallProps;
+WithValueSmall.argTypes = argTypes;
 
 const loadingSmallProps: typeof withAValueProps = {
 	...withAValueProps,
 	isLoading: true,
 	size: 'small',
 };
-export const loadingSmall = Template.bind(loadingSmallProps);
-loadingSmall.args = loadingSmallProps;
-loadingSmall.argTypes = argTypes;
+export const LoadingSmall = Template.bind(loadingSmallProps);
+LoadingSmall.args = loadingSmallProps;
+LoadingSmall.argTypes = argTypes;

--- a/lib/components/TextBubble/TextBubble.stories.tsx
+++ b/lib/components/TextBubble/TextBubble.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentProps } from 'react';
 import { TextBubble } from '.';
 
 export default {
-	title: 'Foundation/Typography/TextBubble',
+	title: 'Components/Text Bubble',
 	component: TextBubble,
 } satisfies Meta<typeof TextBubble>;
 
@@ -14,16 +14,16 @@ const template: StoryFn<typeof TextBubble> = (args) => <TextBubble {...args} />;
 const standardProps: Omit<ComponentProps<typeof TextBubble>, 'children'> = {
 	label: 'OK',
 };
-export const standard = template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = template.bind(standardProps);
+Standard.args = standardProps;
 
 const longLabelProps: Omit<ComponentProps<typeof TextBubble>, 'children'> = {
 	label: 'Error',
 	textColour: 'danger',
 	backgroundColour: 'gray900',
 };
-export const longLabel = template.bind(longLabelProps);
-longLabel.args = longLabelProps;
+export const LongLabel = template.bind(longLabelProps);
+LongLabel.args = longLabelProps;
 
 const veryLongLabelProps: Omit<
 	ComponentProps<typeof TextBubble>,
@@ -31,5 +31,5 @@ const veryLongLabelProps: Omit<
 > = {
 	label: 'Too Long',
 };
-export const veryLongLabel = template.bind(veryLongLabelProps);
-veryLongLabel.args = veryLongLabelProps;
+export const VeryLongLabel = template.bind(veryLongLabelProps);
+VeryLongLabel.args = veryLongLabelProps;

--- a/lib/components/TextContainer/TextContainer.stories.tsx
+++ b/lib/components/TextContainer/TextContainer.stories.tsx
@@ -9,7 +9,7 @@ import { Text } from '../Text';
 import { TextContainer } from '.';
 
 export default {
-	title: 'Components/TextContainer',
+	title: 'Components/Text Container',
 	component: TextContainer,
 	decorators: [(story) => <div style={{ maxWidth: 512 }}>{story()}</div>],
 	argTypes: {
@@ -43,8 +43,8 @@ const standardProps: ComponentProps<typeof TextContainer> = {
 		</Text>
 	),
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
 
 const withALotOfBodyProps: ComponentProps<typeof TextContainer> = {
 	heading: <Heading>Reviews</Heading>,
@@ -52,13 +52,13 @@ const withALotOfBodyProps: ComponentProps<typeof TextContainer> = {
 		<Text colour="muted" is="p">
 			To avoid you coming to a halt in the middle of the road, because of
 			a banging, crash of pistons and valves fighting with each other,
-			let's investigate what the timing belt is, what it does, and why it
-			costs so much to replace or repair.
+			let&apos;s investigate what the timing belt is, what it does, and
+			why it costs so much to replace or repair.
 		</Text>
 	),
 };
-export const withALotOfBody = Template.bind(withALotOfBodyProps);
-withALotOfBody.args = withALotOfBodyProps;
+export const WithALotOfBody = Template.bind(withALotOfBodyProps);
+WithALotOfBody.args = withALotOfBodyProps;
 
 const withInteractionProps: ComponentProps<typeof TextContainer> = {
 	heading: <Heading>Reviews</Heading>,
@@ -66,8 +66,8 @@ const withInteractionProps: ComponentProps<typeof TextContainer> = {
 		<Text colour="muted" is="p">
 			To avoid you coming to a halt in the middle of the road, because of
 			a banging, crash of pistons and valves fighting with each other,
-			let's investigate what the timing belt is, what it does, and why it
-			costs so much to replace or repair.
+			let&apos;s investigate what the timing belt is, what it does, and
+			why it costs so much to replace or repair.
 		</Text>
 	),
 	action: (
@@ -76,8 +76,8 @@ const withInteractionProps: ComponentProps<typeof TextContainer> = {
 		</Button>
 	),
 };
-export const withInteraction = Template.bind(withInteractionProps);
-withInteraction.args = withInteractionProps;
+export const WithInteraction = Template.bind(withInteractionProps);
+WithInteraction.args = withInteractionProps;
 
 const withInteractionOnlyProps: ComponentProps<typeof TextContainer> = {
 	heading: void 0,
@@ -85,8 +85,8 @@ const withInteractionOnlyProps: ComponentProps<typeof TextContainer> = {
 		<Text colour="muted" is="p">
 			To avoid you coming to a halt in the middle of the road, because of
 			a banging, crash of pistons and valves fighting with each other,
-			let's investigate what the timing belt is, what it does, and why it
-			costs so much to replace or repair.
+			let&apos;s investigate what the timing belt is, what it does, and
+			why it costs so much to replace or repair.
 		</Text>
 	),
 	action: (
@@ -95,8 +95,8 @@ const withInteractionOnlyProps: ComponentProps<typeof TextContainer> = {
 		</Button>
 	),
 };
-export const withInteractionOnly = Template.bind(withInteractionOnlyProps);
-withInteractionOnly.args = withInteractionOnlyProps;
+export const WithInteractionOnly = Template.bind(withInteractionOnlyProps);
+WithInteractionOnly.args = withInteractionOnlyProps;
 
 const withLongTitleProps: ComponentProps<typeof TextContainer> = {
 	heading: <Heading>Setup your personal settings</Heading>,
@@ -104,8 +104,8 @@ const withLongTitleProps: ComponentProps<typeof TextContainer> = {
 		<Text colour="muted" is="p">
 			To avoid you coming to a halt in the middle of the road, because of
 			a banging, crash of pistons and valves fighting with each other,
-			let's investigate what the timing belt is, what it does, and why it
-			costs so much to replace or repair.
+			let&apos;s investigate what the timing belt is, what it does, and
+			why it costs so much to replace or repair.
 		</Text>
 	),
 	action: (
@@ -114,14 +114,14 @@ const withLongTitleProps: ComponentProps<typeof TextContainer> = {
 		</Button>
 	),
 };
-export const withLongTitle = Template.bind(withLongTitleProps);
-withLongTitle.args = withLongTitleProps;
+export const WithLongTitle = Template.bind(withLongTitleProps);
+WithLongTitle.args = withLongTitleProps;
 
 const withNoBodyTextProps: ComponentProps<typeof TextContainer> = {
 	children: <Heading>Choose a credit pack</Heading>,
 };
-export const withNoBodyText = Template.bind(withNoBodyTextProps);
-withNoBodyText.args = withNoBodyTextProps;
+export const WithNoBodyText = Template.bind(withNoBodyTextProps);
+WithNoBodyText.args = withNoBodyTextProps;
 
 const withNoTitleTextProps: ComponentProps<typeof TextContainer> = {
 	children: (
@@ -130,5 +130,5 @@ const withNoTitleTextProps: ComponentProps<typeof TextContainer> = {
 		</Text>
 	),
 };
-export const withNoTitleText = Template.bind(withNoTitleTextProps);
-withNoTitleText.args = withNoTitleTextProps;
+export const WithNoTitleText = Template.bind(withNoTitleTextProps);
+WithNoTitleText.args = withNoTitleTextProps;

--- a/lib/components/TextInput/TextInput.stories.tsx
+++ b/lib/components/TextInput/TextInput.stories.tsx
@@ -20,7 +20,7 @@ import { DateInput } from '../DateInput';
 import { TextInput } from '.';
 
 export default {
-	title: 'Components/Inputs/Text',
+	title: 'Forms & Input Fields/Text Input',
 	component: TextInput,
 	parameters: { chromatic: {} },
 } satisfies Meta<typeof TextInput>;
@@ -204,110 +204,110 @@ const loadingProps: ComponentProps<typeof TextInput> = {
 	...sharedProps,
 	isLoading: true,
 };
-export const standard = Template.bind(standardProps);
-standard.args = standardProps;
-standard.argTypes = argTypes;
+export const Standard = Template.bind(standardProps);
+Standard.args = standardProps;
+Standard.argTypes = argTypes;
 
-export const withAValue = Template.bind(withAValueProps);
-withAValue.args = withAValueProps;
-withAValue.argTypes = argTypes;
+export const WithAValue = Template.bind(withAValueProps);
+WithAValue.args = withAValueProps;
+WithAValue.argTypes = argTypes;
 
-export const withHintText = Template.bind(withHintTextProps);
-withHintText.args = withHintTextProps;
-withHintText.argTypes = argTypes;
+export const WithHintText = Template.bind(withHintTextProps);
+WithHintText.args = withHintTextProps;
+WithHintText.argTypes = argTypes;
 
-export const notchDisabled = Template.bind(noNotchProps);
-notchDisabled.args = noNotchProps;
-notchDisabled.argTypes = argTypes;
+export const NotchDisabled = Template.bind(noNotchProps);
+NotchDisabled.args = noNotchProps;
+NotchDisabled.argTypes = argTypes;
 
-export const notchDisabledWithValue = Template.bind(noNotchWithValueProps);
-notchDisabledWithValue.args = noNotchWithValueProps;
-notchDisabledWithValue.argTypes = argTypes;
+export const NotchDisabledWithValue = Template.bind(noNotchWithValueProps);
+NotchDisabledWithValue.args = noNotchWithValueProps;
+NotchDisabledWithValue.argTypes = argTypes;
 
-export const withPrefixIcon = Template.bind(withPrefixIconProps);
-withPrefixIcon.args = withPrefixIconProps;
-withPrefixIcon.argTypes = argTypes;
+export const WithPrefixIcon = Template.bind(withPrefixIconProps);
+WithPrefixIcon.args = withPrefixIconProps;
+WithPrefixIcon.argTypes = argTypes;
 
-export const withSuffixIcon = Template.bind(withSuffixIconProps);
-withSuffixIcon.args = withSuffixIconProps;
-withSuffixIcon.argTypes = argTypes;
+export const WithSuffixIcon = Template.bind(withSuffixIconProps);
+WithSuffixIcon.args = withSuffixIconProps;
+WithSuffixIcon.argTypes = argTypes;
 
-export const withBothIcons = Template.bind(withBothIconsProps);
-withBothIcons.args = withBothIconsProps;
-withBothIcons.argTypes = argTypes;
+export const WithBothIcons = Template.bind(withBothIconsProps);
+WithBothIcons.args = withBothIconsProps;
+WithBothIcons.argTypes = argTypes;
 
-export const attachedLeft = Template.bind(attachedLeftProps);
-attachedLeft.args = attachedLeftProps;
-attachedLeft.argTypes = argTypes;
+export const AttachedLeft = Template.bind(attachedLeftProps);
+AttachedLeft.args = attachedLeftProps;
+AttachedLeft.argTypes = argTypes;
 
-export const attachedTop = Template.bind(attachedTopProps);
-attachedTop.args = attachedTopProps;
-attachedTop.argTypes = argTypes;
+export const AttachedTop = Template.bind(attachedTopProps);
+AttachedTop.args = attachedTopProps;
+AttachedTop.argTypes = argTypes;
 
-export const attachedRight = Template.bind(attachedRightProps);
-attachedRight.args = attachedRightProps;
-attachedRight.argTypes = argTypes;
+export const AttachedRight = Template.bind(attachedRightProps);
+AttachedRight.args = attachedRightProps;
+AttachedRight.argTypes = argTypes;
 
-export const attachedBottom = Template.bind(attachedBottomProps);
-attachedBottom.args = attachedBottomProps;
-attachedBottom.argTypes = argTypes;
+export const AttachedBottom = Template.bind(attachedBottomProps);
+AttachedBottom.args = attachedBottomProps;
+AttachedBottom.argTypes = argTypes;
 
-export const attachedAll = Template.bind(attachedAllProps);
-attachedAll.args = attachedAllProps;
-attachedAll.argTypes = argTypes;
+export const AttachedAll = Template.bind(attachedAllProps);
+AttachedAll.args = attachedAllProps;
+AttachedAll.argTypes = argTypes;
 
-export const mergedLeft = Template.bind(mergedLeftProps);
-mergedLeft.args = mergedLeftProps;
-mergedLeft.argTypes = argTypes;
+export const MergedLeft = Template.bind(mergedLeftProps);
+MergedLeft.args = mergedLeftProps;
+MergedLeft.argTypes = argTypes;
 
-export const mergedTop = Template.bind(mergedTopProps);
-mergedTop.args = mergedTopProps;
-mergedTop.argTypes = argTypes;
+export const MergedTop = Template.bind(mergedTopProps);
+MergedTop.args = mergedTopProps;
+MergedTop.argTypes = argTypes;
 
-export const mergedRight = Template.bind(mergedRightProps);
-mergedRight.args = mergedRightProps;
-mergedRight.argTypes = argTypes;
+export const MergedRight = Template.bind(mergedRightProps);
+MergedRight.args = mergedRightProps;
+MergedRight.argTypes = argTypes;
 
-export const mergedBottom = Template.bind(mergedBottomProps);
-mergedBottom.args = mergedBottomProps;
-mergedBottom.argTypes = argTypes;
+export const MergedBottom = Template.bind(mergedBottomProps);
+MergedBottom.args = mergedBottomProps;
+MergedBottom.argTypes = argTypes;
 
-export const mergedAll = Template.bind(mergedAllProps);
-mergedAll.args = mergedAllProps;
-mergedAll.argTypes = argTypes;
+export const MergedAll = Template.bind(mergedAllProps);
+MergedAll.args = mergedAllProps;
+MergedAll.argTypes = argTypes;
 
-export const disabled = Template.bind(disabledProps);
-disabled.args = disabledProps;
-disabled.argTypes = argTypes;
+export const Disabled = Template.bind(disabledProps);
+Disabled.args = disabledProps;
+Disabled.argTypes = argTypes;
 
-export const valid = Template.bind(validProps);
-valid.args = validProps;
-valid.argTypes = argTypes;
+export const Valid = Template.bind(validProps);
+Valid.args = validProps;
+Valid.argTypes = argTypes;
 
-export const invalid = Template.bind(invalidProps);
-invalid.args = invalidProps;
-invalid.argTypes = argTypes;
+export const Invalid = Template.bind(invalidProps);
+Invalid.args = invalidProps;
+Invalid.argTypes = argTypes;
 
-export const loading = Template.bind(loadingProps);
-loading.args = loadingProps;
-loading.argTypes = argTypes;
+export const Loading = Template.bind(loadingProps);
+Loading.args = loadingProps;
+Loading.argTypes = argTypes;
 
 const smallProps: typeof standardProps = {
 	...standardProps,
 	size: 'small',
 };
-export const small = Template.bind(smallProps);
-small.args = smallProps;
-small.argTypes = argTypes;
+export const Small = Template.bind(smallProps);
+Small.args = smallProps;
+Small.argTypes = argTypes;
 
 const withValueSmallProps: typeof withAValueProps = {
 	...withAValueProps,
 	size: 'small',
 };
 
-export const withValueSmall = Template.bind(withValueSmallProps);
-withValueSmall.args = withValueSmallProps;
-withValueSmall.argTypes = argTypes;
+export const WithValueSmall = Template.bind(withValueSmallProps);
+WithValueSmall.args = withValueSmallProps;
+WithValueSmall.argTypes = argTypes;
 
 const withIconSmallProps: typeof withAValueProps = {
 	...withAValueProps,
@@ -315,15 +315,15 @@ const withIconSmallProps: typeof withAValueProps = {
 	size: 'small',
 };
 
-export const withIconSmall = Template.bind(withIconSmallProps);
-withIconSmall.args = withIconSmallProps;
-withIconSmall.argTypes = argTypes;
+export const WithIconSmall = Template.bind(withIconSmallProps);
+WithIconSmall.args = withIconSmallProps;
+WithIconSmall.argTypes = argTypes;
 
 const loadingSmallProps: typeof withAValueProps = {
 	...withAValueProps,
 	isLoading: true,
 	size: 'small',
 };
-export const loadingSmall = Template.bind(loadingSmallProps);
-loadingSmall.args = loadingSmallProps;
-loadingSmall.argTypes = argTypes;
+export const LoadingSmall = Template.bind(loadingSmallProps);
+LoadingSmall.args = loadingSmallProps;
+LoadingSmall.argTypes = argTypes;

--- a/lib/components/TextLink/TextLink.stories.tsx
+++ b/lib/components/TextLink/TextLink.stories.tsx
@@ -27,7 +27,7 @@ const transformOptions: Array<ComponentProps<typeof Text>['transform']> = [
 ];
 
 export default {
-	title: 'Foundation/Typography/TextLink',
+	title: 'Primatives/Text Link',
 	decorators: [
 		(story) => (
 			<div
@@ -116,21 +116,21 @@ const standardProps: Omit<ComponentProps<typeof TextLink>, 'children'> = {
 	fontWeight: 'semiBold',
 };
 
-export const standard: StoryFn<typeof TextLink> = Template.bind(standardProps);
-standard.args = standardProps;
+export const Standard: StoryFn<typeof TextLink> = Template.bind(standardProps);
+Standard.args = standardProps;
 
-export const insideParagraph: StoryFn<typeof TextLink> =
+export const InsideParagraph: StoryFn<typeof TextLink> =
 	InsideParagraphTemplate.bind(standardProps);
-insideParagraph.args = standardProps;
+InsideParagraph.args = standardProps;
 
 const withIconProps: typeof standardProps = {
 	...standardProps,
 	icon: ArrowRightIcon,
 };
 
-export const withIcon = Template.bind(withIconProps);
-withIcon.args = withIconProps;
+export const WithIcon = Template.bind(withIconProps);
+WithIcon.args = withIconProps;
 
-export const withIconInsideParagraph =
+export const WithIconInsideParagraph =
 	InsideParagraphTemplate.bind(withIconProps);
-withIconInsideParagraph.args = withIconProps;
+WithIconInsideParagraph.args = withIconProps;

--- a/lib/components/Toaster/Toast.stories.tsx
+++ b/lib/components/Toaster/Toast.stories.tsx
@@ -8,7 +8,7 @@ import { Text } from '../Text';
 import { ToastProvider, useToast } from '.';
 
 export default {
-	title: 'Utility/Toaster',
+	title: 'Components/Toaster',
 	decorators: [
 		(Story) => (
 			<ToastProvider>

--- a/lib/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/lib/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -6,7 +6,7 @@ import { Text } from '../Text';
 import { VisuallyHidden } from '.';
 
 export default {
-	title: 'Utility/VisuallyHidden',
+	title: 'Layout/Visually Hidden',
 	component: VisuallyHidden,
 	args: {
 		as: 'div',

--- a/lib/hooks/useAttachedBoxes/useAttachedBoxes.stories.tsx
+++ b/lib/hooks/useAttachedBoxes/useAttachedBoxes.stories.tsx
@@ -6,7 +6,7 @@ import { Text } from '../../components/Text/Text';
 import { useAttachedBoxes } from '.';
 
 export default {
-	title: 'Foundation/Layout/Attached Boxes',
+	title: 'Layout/Attached Boxes [Hook]',
 };
 
 const columnCount = [2, 3, 4, 5];


### PR DESCRIPTION
This is a proposal to flatten the storybook sidebar nav in order to make it easier for discoverability and finding components.
It introduces new groupings:
- Primatives
- Layout
- Forms & Input Fields