### PR TITLE
Add ci test script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
               run: yarn lint
 
             - name: Test
-              run: yarn test --run --coverage
+              run: yarn test:ci
 
             - uses: codecov/codecov-action@v5
               with:

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"storybook": "storybook dev -p 6006",
 		"storybook:build": "storybook build",
 		"test": "vitest",
+		"test:ci": "vitest run --coverage",
 		"typeEmit": "tsc -d --declarationDir dist --emitDeclarationOnly",
 		"watch": "tsc --watch"
 	},


### PR DESCRIPTION
This pull request adds the new script test:ci for use in workflows so that the CLI flags are specific to the repo.