### PR TITLE
Fix/1077 icon renders inside div

### DIFF
--- a/.changeset/pretty-files-drop.md
+++ b/.changeset/pretty-files-drop.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Fix for Icon rendering as `div` by default, defaults to `span` instead.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,74 @@
+import '../lib/reset/globalFonts.css';
+import '../lib/reset/globalReset.css';
+import * as themes from '../lib/themes';
+
+import { withThemeProvider } from './withThemeProvider';
+
+export const globalTypes = {
+	theme: {
+		name: 'theme',
+		description: 'Global theme for components',
+		defaultValue: themes.baseTheme.name,
+		title: 'theme',
+		toolbar: {
+			icon: 'mirror',
+			// eslint-disable-next-line import/namespace
+			items: Object.keys(themes).map((theme) => themes[theme].name),
+			showName: true,
+			dynamicTitle: true,
+		},
+	},
+	themeColours: {
+		name: 'Set dynamic colours',
+		description: 'Global primary background colour',
+		defaultValue: 'defaults',
+		toolbar: {
+			icon: 'paintbrush',
+			items: ['defaults', 'bright', 'dark'],
+			showName: true,
+			dynamicTitle: true,
+			control: 'color',
+		},
+	},
+};
+
+/** @type { import('@storybook/react').Preview } */
+const preview = {
+	decorators: [withThemeProvider],
+
+	parameters: {
+		controls: {
+			matchers: {
+				color: /(background|color)$/i,
+				date: /Date$/i,
+			},
+		},
+		chromatic: {
+			// Mobile and large table and up
+			viewports: [320, 1024],
+		},
+		options: {
+			storySort: {
+				order: [
+					'Overdrive',
+					'Foundation',
+					['Palette', 'Theme Colours', 'Borders', 'Space'],
+					'Primatives',
+					'Layout',
+					'Forms & Input Fields',
+					'Components',
+					[
+						'*',
+						'Modal',
+						'Modal: Minimal',
+						'Modal: Standard with Title',
+					],
+				],
+			},
+		},
+	},
+
+	tags: ['autodocs'],
+};
+
+export default preview;

--- a/.storybook/withThemeProvider.tsx
+++ b/.storybook/withThemeProvider.tsx
@@ -1,9 +1,7 @@
+/* eslint-disable import/namespace */
+import isChromatic from 'chromatic/isChromatic';
 import React, { useEffect, useRef } from 'react';
 
-import '../lib/reset/globalFonts.css';
-import '../lib/reset/globalReset.css';
-import * as themes from '../lib/themes';
-import isChromatic from 'chromatic/isChromatic';
 import { Box } from '../lib/components/Box';
 import { Heading } from '../lib/components/Heading';
 import { OverdriveProvider } from '../lib/components/OverdriveProvider';
@@ -12,9 +10,10 @@ import {
 	ThemeOverrideProvider,
 	useThemeOverrides,
 } from '../lib/components/ThemeOverrideProvider';
-import { container, themeContractVars } from '../lib/themes/theme.css';
-import { breakpoints } from '../lib/themes/makeTheme';
 import { useDocumentBodyStyles } from '../lib/hooks/useDocumentBodyStyles';
+import * as themes from '../lib/themes';
+import { breakpoints } from '../lib/themes/makeTheme';
+import { container, themeContractVars } from '../lib/themes/theme.css';
 
 const dynamicColours = {
 	bright: {
@@ -28,6 +27,7 @@ const dynamicColours = {
 };
 
 const ThemeProviderComponent = ({ children, context }) => {
+	// @ts-expect-error expecting 0 arguments
 	const { theme, overrideStyles, setThemeValues } = useThemeOverrides({
 		primaryColourBackground:
 			dynamicColours[context.globals.themeColours]
@@ -48,10 +48,11 @@ const ThemeProviderComponent = ({ children, context }) => {
 				...dynamicColours[context.globals.themeColours],
 			});
 		}
-	}, [theme, context.globals.themeColours]);
-	const ref = useRef();
+	}, [theme, context.globals.themeColours, setThemeValues]);
+	const ref = useRef(null);
 	return (
 		<OverdriveProvider
+			// @ts-expect-error Type 'RefObject<null>' is not assignable to type 'MutableRefObject<{ new (): HTMLElement; prototype: HTMLElement; }>'.
 			portalMountPoint={ref}
 			noBodyLevelTheming={false}
 			vars={themeContractVars}
@@ -65,13 +66,14 @@ const ThemeProviderComponent = ({ children, context }) => {
 	);
 };
 
-const withThemeProvider = (Story, context) => {
+export const withThemeProvider = (Story, context) => {
 	const theme = themes[context.globals.theme];
 	const tokens = theme.tokens;
 	const primaryColourBackground = tokens.colours.intent.primary.background;
 	const primaryColourBorder = tokens.colours.intent.primary.border;
 	const primaryColourForeground = tokens.colours.intent.primary.foreground;
 	const overrideColours = dynamicColours[context.globals.themeColours];
+	// eslint-disable-next-line unicorn/no-negated-condition
 	return !isChromatic() ? (
 		<ThemeOverrideProvider
 			primaryColourBackground={
@@ -109,7 +111,7 @@ const withThemeProvider = (Story, context) => {
 				<OverdriveProvider
 					noBodyLevelTheming
 					themeClass={themes[theme].themeRef}
-					tokens={themes[theme].tokens}
+					// tokens={themes[theme].tokens}
 					vars={themes[theme].vars}
 				>
 					<Box width="full" padding="5">
@@ -134,71 +136,3 @@ const withThemeProvider = (Story, context) => {
 		))
 	);
 };
-
-export const globalTypes = {
-	theme: {
-		name: 'theme',
-		description: 'Global theme for components',
-		defaultValue: themes.baseTheme.name,
-		title: 'theme',
-		toolbar: {
-			icon: 'mirror',
-			items: Object.keys(themes).map((theme) => themes[theme].name),
-			showName: true,
-			dynamicTitle: true,
-		},
-	},
-	themeColours: {
-		name: 'Set dynamic colours',
-		description: 'Global primary background colour',
-		defaultValue: 'defaults',
-		toolbar: {
-			icon: 'paintbrush',
-			items: ['defaults', 'bright', 'dark'],
-			showName: true,
-			dynamicTitle: true,
-			control: 'color',
-		},
-	},
-};
-
-/** @type { import('@storybook/react').Preview } */
-const preview = {
-	decorators: [withThemeProvider],
-
-	parameters: {
-		controls: {
-			matchers: {
-				color: /(background|color)$/i,
-				date: /Date$/i,
-			},
-		},
-		chromatic: {
-			// Mobile and large table and up
-			viewports: [320, 1024],
-		},
-		options: {
-			storySort: {
-				order: [
-					'Overdrive',
-					'Foundation',
-					['Palette', 'Theme Colours', 'Borders', 'Space'],
-					'Primatives',
-					'Layout',
-					'Forms & Input Fields',
-					'Components',
-					[
-						'*',
-						'Modal',
-						'Modal: Minimal',
-						'Modal: Standard with Title',
-					],
-				],
-			},
-		},
-	},
-
-	tags: ['autodocs'],
-};
-
-export default preview;

--- a/.storybook/withThemeProvider.tsx
+++ b/.storybook/withThemeProvider.tsx
@@ -111,7 +111,6 @@ export const withThemeProvider = (Story, context) => {
 				<OverdriveProvider
 					noBodyLevelTheming
 					themeClass={themes[theme].themeRef}
-					// tokens={themes[theme].tokens}
 					vars={themes[theme].vars}
 				>
 					<Box width="full" padding="5">

--- a/lib/components/Alert/__snapshots__/Alert.spec.jsx.snap
+++ b/lib/components/Alert/__snapshots__/Alert.spec.jsx.snap
@@ -17,8 +17,8 @@ exports[`<Alert /> > should match the snapshot 1`] = `
       <div
         class="reset_block__1oah0223 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
       >
-        <div
-          class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4k useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l6s useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l7w"
+        <span
+          class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4k useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l6s useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l7w"
         >
           <svg
             aria-hidden="true"
@@ -32,7 +32,7 @@ exports[`<Alert /> > should match the snapshot 1`] = `
               d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm-1 14.502l7-7-1.414-1.414L11 13.674l-3.086-3.086L6.5 12.002l4.5 4.5z"
             />
           </svg>
-        </div>
+        </span>
       </div>
     </div>
     <div
@@ -56,8 +56,8 @@ exports[`<Alert /> > should match the snapshot 1`] = `
           <div
             class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
           >
-            <div
-              class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_muted__1xnpmd7h"
+            <span
+              class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_muted__1xnpmd7h"
             >
               <svg
                 aria-hidden="true"
@@ -71,7 +71,7 @@ exports[`<Alert /> > should match the snapshot 1`] = `
                   d="M13.458 12L19 17.543V19h-1.457L12 13.457 6.458 19H5v-1.456L10.544 12 5 6.458V5h1.457L12 10.543 17.544 5H19v1.458L13.458 12z"
                 />
               </svg>
-            </div>
+            </span>
           </div>
         </button>
       </div>

--- a/lib/components/Anchor/__snapshots__/Anchor.spec.jsx.snap
+++ b/lib/components/Anchor/__snapshots__/Anchor.spec.jsx.snap
@@ -11,8 +11,8 @@ exports[`<Anchor /> > should match snapshot with label, icon and to props 1`] = 
     <div
       class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3g useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_link__1xnpmd7e"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_link__1xnpmd7e"
       >
         <svg
           aria-hidden="true"
@@ -24,7 +24,7 @@ exports[`<Anchor /> > should match snapshot with label, icon and to props 1`] = 
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
     </div>
     <div
       class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3g useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
@@ -63,8 +63,8 @@ exports[`<Anchor /> > when custom component > should match snapshot with label, 
       <div
         class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3g useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
       >
-        <div
-          class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_link__1xnpmd7e"
+        <span
+          class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_link__1xnpmd7e"
         >
           <svg
             aria-hidden="true"
@@ -76,7 +76,7 @@ exports[`<Anchor /> > when custom component > should match snapshot with label, 
               d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
             />
           </svg>
-        </div>
+        </span>
       </div>
       <div
         class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3g useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"

--- a/lib/components/BulletText/__snapshots__/BulletText.spec.jsx.snap
+++ b/lib/components/BulletText/__snapshots__/BulletText.spec.jsx.snap
@@ -11,8 +11,8 @@ exports[`<BulletText /> > should match snapshot for custom bullet text 1`] = `
       class="reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo useBoxStyles_flexShrink_0__3xgq1lhd"
     >
       <span>
-        <div
-          class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx"
+        <span
+          class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx"
         >
           <svg
             aria-hidden="true"
@@ -26,7 +26,7 @@ exports[`<BulletText /> > should match snapshot for custom bullet text 1`] = `
               d="M21 7L9 19l-5.5-5.5 1.414-1.414L9 16.172 19.586 5.586 21 7z"
             />
           </svg>
-        </div>
+        </span>
       </span>
     </div>
   </div>

--- a/lib/components/CheckBox/__snapshots__/CheckBox.spec.jsx.snap
+++ b/lib/components/CheckBox/__snapshots__/CheckBox.spec.jsx.snap
@@ -14,8 +14,8 @@ exports[`<CheckBox /> > should match the snapshot for a checked check 1`] = `
   <div
     class="reset_block__1oah0223 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk CheckableBase_checkable__y94qv4 reset_appearance__1oah0220 reset_cursorPointer__1oah0221 reset_trimmedBlockElement__1oah0225 reset_button__1oah0226"
   >
-    <div
-      class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 CheckBox_icon__1ifzuoz0 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_white__1xnpmd7g reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm"
+    <span
+      class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 CheckBox_icon__1ifzuoz0 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_white__1xnpmd7g reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm"
     >
       <svg
         aria-hidden="true"
@@ -29,7 +29,7 @@ exports[`<CheckBox /> > should match the snapshot for a checked check 1`] = `
           d="M21 7L9 19l-5.5-5.5 1.414-1.414L9 16.172 19.586 5.586 21 7z"
         />
       </svg>
-    </div>
+    </span>
     <div
       class="reset_block__1oah0223 useBoxStyles_border_style__3xgq1l9k useBoxStyles_border_colour_top_gray__3xgq1l9m useBoxStyles_border_colour_right_gray__3xgq1l9y useBoxStyles_border_colour_bottom_gray__3xgq1laa useBoxStyles_border_colour_left_gray__3xgq1lam useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lb1 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lbh useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lbx useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lcd CheckableBase_checkableItem__y94qv5 CheckBox_base_default__1ifzuoz1 CheckBox_base_selected__1ifzuoz2"
     />

--- a/lib/components/ColourInput/__snapshots__/ColourInput.spec.jsx.snap
+++ b/lib/components/ColourInput/__snapshots__/ColourInput.spec.jsx.snap
@@ -471,8 +471,8 @@ exports[`<ColourInput /> > should match snapshot with both icons 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -484,7 +484,7 @@ exports[`<ColourInput /> > should match snapshot with both icons 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <div
         class="reset_block__1oah0223 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexWrap_nowrap__3xgq1lhf useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk"
       >
@@ -547,8 +547,8 @@ exports[`<ColourInput /> > should match snapshot with suffix icon 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -560,7 +560,7 @@ exports[`<ColourInput /> > should match snapshot with suffix icon 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <div
         class="reset_block__1oah0223 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexWrap_nowrap__3xgq1lhf useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk"
       >

--- a/lib/components/DateInput/__snapshots__/DateInput.spec.jsx.snap
+++ b/lib/components/DateInput/__snapshots__/DateInput.spec.jsx.snap
@@ -154,8 +154,8 @@ exports[`<DateInput /> > should match snapshot when loading 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -167,7 +167,7 @@ exports[`<DateInput /> > should match snapshot when loading 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <div
         class="reset_block__1oah0223 ProgressSpinner_size_medium_circular__1kpufmib ProgressSpinner_colours_primary__1kpufmi5 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
@@ -366,8 +366,8 @@ exports[`<DateInput /> > should match snapshot with both icons 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -379,9 +379,9 @@ exports[`<DateInput /> > should match snapshot with both icons 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      </span>
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -393,7 +393,7 @@ exports[`<DateInput /> > should match snapshot with both icons 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <input
         autocomplete="off"
         class="reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_width_full__3xgq1lfj useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lcp useBoxStyles_backgroundColours_transparent__3xgq1lf9 withEnhancedInput_input_itself_root__5jmdy80 withEnhancedInput_inputItselfSize_medium_root_any__5jmdy8a withEnhancedInput_inputItselfSize_medium_prefixed_any__5jmdy8c undefined withEnhancedInput_inputItselfSize_medium_suffixed_any__5jmdy8d"
@@ -439,8 +439,8 @@ exports[`<DateInput /> > should match snapshot with prefix icon 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -452,7 +452,7 @@ exports[`<DateInput /> > should match snapshot with prefix icon 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <input
         autocomplete="off"
         class="reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_width_full__3xgq1lfj useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lcp useBoxStyles_backgroundColours_transparent__3xgq1lf9 withEnhancedInput_input_itself_root__5jmdy80 withEnhancedInput_inputItselfSize_medium_root_any__5jmdy8a withEnhancedInput_inputItselfSize_medium_prefixed_any__5jmdy8c"
@@ -498,8 +498,8 @@ exports[`<DateInput /> > should match snapshot with suffix icon 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -511,7 +511,7 @@ exports[`<DateInput /> > should match snapshot with suffix icon 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <input
         autocomplete="off"
         class="reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_width_full__3xgq1lfj useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lcp useBoxStyles_backgroundColours_transparent__3xgq1lf9 withEnhancedInput_input_itself_root__5jmdy80 withEnhancedInput_inputItselfSize_medium_root_any__5jmdy8a undefined withEnhancedInput_inputItselfSize_medium_suffixed_any__5jmdy8d"

--- a/lib/components/DatePicker/__snapshots__/DatePicker.spec.jsx.snap
+++ b/lib/components/DatePicker/__snapshots__/DatePicker.spec.jsx.snap
@@ -11,8 +11,8 @@ exports[`<DatePicker /> > should match snapshot without label 1`] = `
   <div
     class="reset_block__1oah0223 DatePicker_contents_default__1j3uugj1"
   >
-    <div
-      class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+    <span
+      class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
     >
       <svg
         aria-hidden="true"
@@ -26,7 +26,7 @@ exports[`<DatePicker /> > should match snapshot without label 1`] = `
           d="M19 18.998H5v-11h14m-3-7v2H8v-2H6v2H5a1.99 1.99 0 00-1.99 2l-.01 14a2 2 0 002 2h14c1.102 0 2-.896 2-2v-14a2 2 0 00-2-2h-1v-2m-1 11h-5v5h5v-5z"
         />
       </svg>
-    </div>
+    </span>
   </div>
 </div>
 `;

--- a/lib/components/DropDown/__snapshots__/DropDown.spec.jsx.snap
+++ b/lib/components/DropDown/__snapshots__/DropDown.spec.jsx.snap
@@ -9,8 +9,8 @@ exports[`<DropDown /> > should match the snapshot 1`] = `
     class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
   >
     Attachment
-    <div
-      class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
+    <span
+      class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
     >
       <svg
         aria-hidden="true"
@@ -24,7 +24,7 @@ exports[`<DropDown /> > should match the snapshot 1`] = `
           d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
         />
       </svg>
-    </div>
+    </span>
   </div>
 </button>
 `;
@@ -38,8 +38,8 @@ exports[`<DropDown /> > should match the snapshot as Primary variant 1`] = `
     class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
   >
     Attachment
-    <div
-      class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
+    <span
+      class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
     >
       <svg
         aria-hidden="true"
@@ -53,7 +53,7 @@ exports[`<DropDown /> > should match the snapshot as Primary variant 1`] = `
           d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
         />
       </svg>
-    </div>
+    </span>
   </div>
 </button>
 `;

--- a/lib/components/HorizontalAutoScroller/__snapshots__/HorizontalAutoScroller.spec.jsx.snap
+++ b/lib/components/HorizontalAutoScroller/__snapshots__/HorizontalAutoScroller.spec.jsx.snap
@@ -20,8 +20,8 @@ exports[`<HorizontalAutoScroller /> > should match the snapshot for 8 items 1`] 
           <div
             class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
           >
-            <div
-              class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+            <span
+              class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
             >
               <svg
                 aria-hidden="true"
@@ -35,7 +35,7 @@ exports[`<HorizontalAutoScroller /> > should match the snapshot for 8 items 1`] 
                   d="M15.414 16.584l-4.586-4.586 4.586-4.586-1.415-1.414-6 6 6 6 1.415-1.414z"
                 />
               </svg>
-            </div>
+            </span>
           </div>
         </button>
       </div>
@@ -175,8 +175,8 @@ exports[`<HorizontalAutoScroller /> > should match the snapshot for 8 items 1`] 
           <div
             class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
           >
-            <div
-              class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+            <span
+              class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
             >
               <svg
                 aria-hidden="true"
@@ -190,7 +190,7 @@ exports[`<HorizontalAutoScroller /> > should match the snapshot for 8 items 1`] 
                   d="M8.585 16.584l4.586-4.586-4.586-4.586L10 5.998l6 6-6 6-1.414-1.414z"
                 />
               </svg>
-            </div>
+            </span>
           </div>
         </button>
       </div>
@@ -320,8 +320,8 @@ exports[`<HorizontalAutoScroller /> > should match the snapshot with custom slid
           <div
             class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
           >
-            <div
-              class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+            <span
+              class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
             >
               <svg
                 aria-hidden="true"
@@ -335,7 +335,7 @@ exports[`<HorizontalAutoScroller /> > should match the snapshot with custom slid
                   d="M15.414 16.584l-4.586-4.586 4.586-4.586-1.415-1.414-6 6 6 6 1.415-1.414z"
                 />
               </svg>
-            </div>
+            </span>
           </div>
         </button>
       </div>
@@ -423,8 +423,8 @@ exports[`<HorizontalAutoScroller /> > should match the snapshot with custom slid
           <div
             class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
           >
-            <div
-              class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+            <span
+              class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
             >
               <svg
                 aria-hidden="true"
@@ -438,7 +438,7 @@ exports[`<HorizontalAutoScroller /> > should match the snapshot with custom slid
                   d="M8.585 16.584l4.586-4.586-4.586-4.586L10 5.998l6 6-6 6-1.414-1.414z"
                 />
               </svg>
-            </div>
+            </span>
           </div>
         </button>
       </div>

--- a/lib/components/Icon/Icon.spec.jsx
+++ b/lib/components/Icon/Icon.spec.jsx
@@ -29,7 +29,9 @@ describe('<Icon />', () => {
 
 	it('should nest the provided svg inside the div tag', () => {
 		expect(
-			render(<Icon icon={TestIcon} />).container.querySelector('div>svg'),
+			render(<Icon icon={TestIcon} />).container.querySelector(
+				'span>svg',
+			),
 		).toBeInTheDocument();
 	});
 });

--- a/lib/components/Icon/Icon.tsx
+++ b/lib/components/Icon/Icon.tsx
@@ -27,26 +27,25 @@ export const Icon: FunctionComponent<Props> = ({
 	display = 'block',
 }) => {
 	useNullCheck(icon, 'Icon component received an empty icon prop.');
+
+	const iconElement = cloneElement(icon, {
+		className: useBoxStyles({
+			as: 'svg',
+			display: 'block',
+			width: 'full',
+			height: 'full',
+		}),
+		'aria-label': icon.props['aria-label'] ?? undefined,
+		'aria-hidden': icon.props['aria-label'] ? undefined : true,
+	});
+
 	return (
 		<Box
-			as="div"
+			as="span"
 			display={display}
 			className={[resolveResponsiveStyle(size, styles.size), className]}
 		>
-			{icon
-				? cloneElement(icon, {
-						className: useBoxStyles({
-							as: 'svg',
-							display: 'block',
-							width: 'full',
-							height: 'full',
-						}),
-						'aria-label': icon.props['aria-label'] ?? undefined,
-						'aria-hidden': icon.props['aria-label']
-							? undefined
-							: true,
-					})
-				: '⬤'}
+			{icon ? iconElement : '⬤'}
 		</Box>
 	);
 };

--- a/lib/components/Icon/__snapshots__/Icon.spec.jsx.snap
+++ b/lib/components/Icon/__snapshots__/Icon.spec.jsx.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<Icon /> > should match snapshot for same icon 1`] = `
-<div
-  class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
+<span
+  class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
 >
   <svg
     aria-hidden="true"
@@ -14,5 +14,5 @@ exports[`<Icon /> > should match snapshot for same icon 1`] = `
       d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
     />
   </svg>
-</div>
+</span>
 `;

--- a/lib/components/Meta/__snapshots__/Meta.spec.jsx.snap
+++ b/lib/components/Meta/__snapshots__/Meta.spec.jsx.snap
@@ -7,8 +7,8 @@ exports[`<Meta /> > should match snapshot with label, icon for Primary variant 1
   <div
     class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3g useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
   >
-    <div
-      class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 Meta_variant_primary__5jk44p0"
+    <span
+      class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 Meta_variant_primary__5jk44p0"
     >
       <svg
         aria-hidden="true"
@@ -20,7 +20,7 @@ exports[`<Meta /> > should match snapshot with label, icon for Primary variant 1
           d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
         />
       </svg>
-    </div>
+    </span>
   </div>
   <div
     class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3g useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
@@ -41,8 +41,8 @@ exports[`<Meta /> > should match snapshot with label, icon for Secondary variant
   <div
     class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3g useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
   >
-    <div
-      class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 Meta_variant_secondary__5jk44p1"
+    <span
+      class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 Meta_variant_secondary__5jk44p1"
     >
       <svg
         aria-hidden="true"
@@ -54,7 +54,7 @@ exports[`<Meta /> > should match snapshot with label, icon for Secondary variant
           d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
         />
       </svg>
-    </div>
+    </span>
   </div>
   <div
     class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3g useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"

--- a/lib/components/NumberInput/__snapshots__/NumberInput.spec.jsx.snap
+++ b/lib/components/NumberInput/__snapshots__/NumberInput.spec.jsx.snap
@@ -343,8 +343,8 @@ exports[`<NumberInput /> > should match snapshot with both icons 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -356,9 +356,9 @@ exports[`<NumberInput /> > should match snapshot with both icons 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      </span>
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -370,7 +370,7 @@ exports[`<NumberInput /> > should match snapshot with both icons 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <input
         autocomplete="off"
         class="reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_width_full__3xgq1lfj useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lcp useBoxStyles_backgroundColours_transparent__3xgq1lf9 withEnhancedInput_input_itself_root__5jmdy80 withEnhancedInput_inputItselfSize_medium_root_any__5jmdy8a withEnhancedInput_inputItselfSize_medium_prefixed_any__5jmdy8c undefined withEnhancedInput_inputItselfSize_medium_suffixed_any__5jmdy8d"
@@ -417,8 +417,8 @@ exports[`<NumberInput /> > should match snapshot with prefix icon 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -430,7 +430,7 @@ exports[`<NumberInput /> > should match snapshot with prefix icon 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <input
         autocomplete="off"
         class="reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_width_full__3xgq1lfj useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lcp useBoxStyles_backgroundColours_transparent__3xgq1lf9 withEnhancedInput_input_itself_root__5jmdy80 withEnhancedInput_inputItselfSize_medium_root_any__5jmdy8a withEnhancedInput_inputItselfSize_medium_prefixed_any__5jmdy8c"
@@ -477,8 +477,8 @@ exports[`<NumberInput /> > should match snapshot with suffix icon 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -490,7 +490,7 @@ exports[`<NumberInput /> > should match snapshot with suffix icon 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <input
         autocomplete="off"
         class="reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_width_full__3xgq1lfj useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lcp useBoxStyles_backgroundColours_transparent__3xgq1lf9 withEnhancedInput_input_itself_root__5jmdy80 withEnhancedInput_inputItselfSize_medium_root_any__5jmdy8a undefined withEnhancedInput_inputItselfSize_medium_suffixed_any__5jmdy8d"

--- a/lib/components/Pagination/__snapshots__/Pagination.spec.jsx.snap
+++ b/lib/components/Pagination/__snapshots__/Pagination.spec.jsx.snap
@@ -12,8 +12,8 @@ exports[`<Pagination /> > should match snapshot for loading phase 1`] = `
       aria-label=""
       class="reset_appearance__1oah0220 reset_cursorPointer__1oah0221 reset_trimmedBlockElement__1oah0225 reset_button__1oah0226 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l18 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l2c useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3g useBoxStyles_display_flex__3xgq1lfy useBoxStyles_overflow_hidden__3xgq1lfs useBoxStyles_userSelect_none__3xgq1lg6 useBoxStyles_textAlign_center__3xgq1lfq useBoxStyles_pointerEvents_none__3xgq1li0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1ld9 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_light__1xnpmd7j Pagination_disabled__9nf7kx0"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
       >
         <svg
           aria-hidden="true"
@@ -27,7 +27,7 @@ exports[`<Pagination /> > should match snapshot for loading phase 1`] = `
             d="M15.414 16.584l-4.586-4.586 4.586-4.586-1.415-1.414-6 6 6 6 1.415-1.414z"
           />
         </svg>
-      </div>
+      </span>
     </button>
   </div>
   <div
@@ -59,8 +59,8 @@ exports[`<Pagination /> > should match snapshot for loading phase 1`] = `
       aria-label=""
       class="reset_appearance__1oah0220 reset_cursorPointer__1oah0221 reset_trimmedBlockElement__1oah0225 reset_button__1oah0226 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l18 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l2c useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3g useBoxStyles_display_flex__3xgq1lfy useBoxStyles_overflow_hidden__3xgq1lfs useBoxStyles_userSelect_none__3xgq1lg6 useBoxStyles_textAlign_center__3xgq1lfq useBoxStyles_pointerEvents_none__3xgq1li0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1ld9 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_light__1xnpmd7j Pagination_disabled__9nf7kx0"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
       >
         <svg
           aria-hidden="true"
@@ -74,7 +74,7 @@ exports[`<Pagination /> > should match snapshot for loading phase 1`] = `
             d="M8.585 16.584l4.586-4.586-4.586-4.586L10 5.998l6 6-6 6-1.414-1.414z"
           />
         </svg>
-      </div>
+      </span>
     </button>
   </div>
 </span>

--- a/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
+++ b/lib/components/SelectInput/__snapshots__/SelectInput.spec.jsx.snap
@@ -36,8 +36,8 @@ exports[`<SelectInput /> > should have some hintText 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l5w useBoxStyles_display_flex__3xgq1lfy useBoxStyles_height_full__3xgq1lfl useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexShrink_0__3xgq1lhd SelectInput_arrow__1gqjkbj2"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
           >
             <svg
               aria-hidden="true"
@@ -51,7 +51,7 @@ exports[`<SelectInput /> > should have some hintText 1`] = `
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -124,8 +124,8 @@ exports[`<SelectInput /> > should match snapshot 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l5w useBoxStyles_display_flex__3xgq1lfy useBoxStyles_height_full__3xgq1lfl useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexShrink_0__3xgq1lhd SelectInput_arrow__1gqjkbj2"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
           >
             <svg
               aria-hidden="true"
@@ -139,7 +139,7 @@ exports[`<SelectInput /> > should match snapshot 1`] = `
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -207,8 +207,8 @@ exports[`<SelectInput /> > should match snapshot when active 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l5w useBoxStyles_display_flex__3xgq1lfy useBoxStyles_height_full__3xgq1lfl useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexShrink_0__3xgq1lhd SelectInput_arrow__1gqjkbj2"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
           >
             <svg
               aria-hidden="true"
@@ -222,7 +222,7 @@ exports[`<SelectInput /> > should match snapshot when active 1`] = `
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -290,8 +290,8 @@ exports[`<SelectInput /> > should match snapshot when touched 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l5w useBoxStyles_display_flex__3xgq1lfy useBoxStyles_height_full__3xgq1lfl useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexShrink_0__3xgq1lhd SelectInput_arrow__1gqjkbj2"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
           >
             <svg
               aria-hidden="true"
@@ -305,7 +305,7 @@ exports[`<SelectInput /> > should match snapshot when touched 1`] = `
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -373,8 +373,8 @@ exports[`<SelectInput /> > should match snapshot when touched and invalid 1`] = 
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l5w useBoxStyles_display_flex__3xgq1lfy useBoxStyles_height_full__3xgq1lfl useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexShrink_0__3xgq1lhd SelectInput_arrow__1gqjkbj2"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
           >
             <svg
               aria-hidden="true"
@@ -388,7 +388,7 @@ exports[`<SelectInput /> > should match snapshot when touched and invalid 1`] = 
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -456,8 +456,8 @@ exports[`<SelectInput /> > should match snapshot when touched and valid 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l5w useBoxStyles_display_flex__3xgq1lfy useBoxStyles_height_full__3xgq1lfl useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexShrink_0__3xgq1lhd SelectInput_arrow__1gqjkbj2"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
           >
             <svg
               aria-hidden="true"
@@ -471,7 +471,7 @@ exports[`<SelectInput /> > should match snapshot when touched and valid 1`] = `
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -523,8 +523,8 @@ exports[`<SelectInput /> > should match snapshot with custom icon 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l5w useBoxStyles_display_flex__3xgq1lfy useBoxStyles_height_full__3xgq1lfl useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexShrink_0__3xgq1lhd SelectInput_arrow__1gqjkbj2"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
           >
             <svg
               aria-hidden="true"
@@ -536,7 +536,7 @@ exports[`<SelectInput /> > should match snapshot with custom icon 1`] = `
                 d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -578,8 +578,8 @@ exports[`<SelectInput /> > should match snapshot with prefix icon 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -591,7 +591,7 @@ exports[`<SelectInput /> > should match snapshot with prefix icon 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <div
         class="reset_block__1oah0223 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexWrap_nowrap__3xgq1lhf useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk"
       >
@@ -602,8 +602,8 @@ exports[`<SelectInput /> > should match snapshot with prefix icon 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l5w useBoxStyles_display_flex__3xgq1lfy useBoxStyles_height_full__3xgq1lfl useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_flexShrink_0__3xgq1lhd SelectInput_arrow__1gqjkbj2"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
           >
             <svg
               aria-hidden="true"
@@ -617,7 +617,7 @@ exports[`<SelectInput /> > should match snapshot with prefix icon 1`] = `
                 d="M7.413 8.584L12 13.17l4.586-4.586L18 9.998l-6 6-6-6 1.413-1.414z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>

--- a/lib/components/SimplePagination/__snapshots__/SimplePagination.spec.jsx.snap
+++ b/lib/components/SimplePagination/__snapshots__/SimplePagination.spec.jsx.snap
@@ -17,8 +17,8 @@ exports[`<SimplePagination /> > should match snapshot for hasNext 1`] = `
       <div
         class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
       >
-        <div
-          class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+        <span
+          class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
         >
           <svg
             aria-hidden="true"
@@ -32,7 +32,7 @@ exports[`<SimplePagination /> > should match snapshot for hasNext 1`] = `
               d="M15.414 16.584l-4.586-4.586 4.586-4.586-1.415-1.414-6 6 6 6 1.415-1.414z"
             />
           </svg>
-        </div>
+        </span>
       </div>
     </button>
   </div>
@@ -47,8 +47,8 @@ exports[`<SimplePagination /> > should match snapshot for hasNext 1`] = `
       <div
         class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
       >
-        <div
-          class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+        <span
+          class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
         >
           <svg
             aria-hidden="true"
@@ -62,7 +62,7 @@ exports[`<SimplePagination /> > should match snapshot for hasNext 1`] = `
               d="M8.585 16.584l4.586-4.586-4.586-4.586L10 5.998l6 6-6 6-1.414-1.414z"
             />
           </svg>
-        </div>
+        </span>
       </div>
     </button>
   </div>
@@ -84,8 +84,8 @@ exports[`<SimplePagination /> > should match snapshot for hasNext and hasPreviou
       <div
         class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
       >
-        <div
-          class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+        <span
+          class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
         >
           <svg
             aria-hidden="true"
@@ -99,7 +99,7 @@ exports[`<SimplePagination /> > should match snapshot for hasNext and hasPreviou
               d="M15.414 16.584l-4.586-4.586 4.586-4.586-1.415-1.414-6 6 6 6 1.415-1.414z"
             />
           </svg>
-        </div>
+        </span>
       </div>
     </button>
   </div>
@@ -114,8 +114,8 @@ exports[`<SimplePagination /> > should match snapshot for hasNext and hasPreviou
       <div
         class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
       >
-        <div
-          class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+        <span
+          class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
         >
           <svg
             aria-hidden="true"
@@ -129,7 +129,7 @@ exports[`<SimplePagination /> > should match snapshot for hasNext and hasPreviou
               d="M8.585 16.584l4.586-4.586-4.586-4.586L10 5.998l6 6-6 6-1.414-1.414z"
             />
           </svg>
-        </div>
+        </span>
       </div>
     </button>
   </div>
@@ -151,8 +151,8 @@ exports[`<SimplePagination /> > should match snapshot for hasPrevious 1`] = `
       <div
         class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
       >
-        <div
-          class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+        <span
+          class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
         >
           <svg
             aria-hidden="true"
@@ -166,7 +166,7 @@ exports[`<SimplePagination /> > should match snapshot for hasPrevious 1`] = `
               d="M15.414 16.584l-4.586-4.586 4.586-4.586-1.415-1.414-6 6 6 6 1.415-1.414z"
             />
           </svg>
-        </div>
+        </span>
       </div>
     </button>
   </div>
@@ -183,8 +183,8 @@ exports[`<SimplePagination /> > should match snapshot for hasPrevious 1`] = `
       <div
         class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
       >
-        <div
-          class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
+        <span
+          class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4"
         >
           <svg
             aria-hidden="true"
@@ -198,7 +198,7 @@ exports[`<SimplePagination /> > should match snapshot for hasPrevious 1`] = `
               d="M8.585 16.584l4.586-4.586-4.586-4.586L10 5.998l6 6-6 6-1.414-1.414z"
             />
           </svg>
-        </div>
+        </span>
       </div>
     </button>
   </div>

--- a/lib/components/StandardModal/__snapshots__/StandardModal.spec.jsx.snap
+++ b/lib/components/StandardModal/__snapshots__/StandardModal.spec.jsx.snap
@@ -57,8 +57,8 @@ exports[`<StandardModal /> > should match snapshot with title and body 1`] = `
                 <div
                   class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
                 >
-                  <div
-                    class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_muted__1xnpmd7h"
+                  <span
+                    class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_muted__1xnpmd7h"
                   >
                     <svg
                       aria-hidden="true"
@@ -72,7 +72,7 @@ exports[`<StandardModal /> > should match snapshot with title and body 1`] = `
                         d="M13.458 12L19 17.543V19h-1.457L12 13.457 6.458 19H5v-1.456L10.544 12 5 6.458V5h1.457L12 10.543 17.544 5H19v1.458L13.458 12z"
                       />
                     </svg>
-                  </div>
+                  </span>
                 </div>
               </button>
             </header>
@@ -151,8 +151,8 @@ exports[`<StandardModal /> > should match snapshot without title and body 1`] = 
                 <div
                   class="reset_block__1oah0223 useBoxStyles_height_full__3xgq1lfl useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Button_body__p2yon51"
                 >
-                  <div
-                    class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_muted__1xnpmd7h"
+                  <span
+                    class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_muted__1xnpmd7h"
                   >
                     <svg
                       aria-hidden="true"
@@ -166,7 +166,7 @@ exports[`<StandardModal /> > should match snapshot without title and body 1`] = 
                         d="M13.458 12L19 17.543V19h-1.457L12 13.457 6.458 19H5v-1.456L10.544 12 5 6.458V5h1.457L12 10.543 17.544 5H19v1.458L13.458 12z"
                       />
                     </svg>
-                  </div>
+                  </span>
                 </div>
               </button>
             </header>

--- a/lib/components/StarRating/__snapshots__/StarRating.spec.jsx.snap
+++ b/lib/components/StarRating/__snapshots__/StarRating.spec.jsx.snap
@@ -16,8 +16,8 @@ exports[`<StarRating /> > should match snapshot for small size 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -31,13 +31,13 @@ exports[`<StarRating /> > should match snapshot for small size 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -51,13 +51,13 @@ exports[`<StarRating /> > should match snapshot for small size 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -71,13 +71,13 @@ exports[`<StarRating /> > should match snapshot for small size 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -91,13 +91,13 @@ exports[`<StarRating /> > should match snapshot for small size 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
           >
             <svg
               aria-hidden="true"
@@ -111,7 +111,7 @@ exports[`<StarRating /> > should match snapshot for small size 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -145,8 +145,8 @@ exports[`<StarRating /> > should match snapshot with label 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -160,13 +160,13 @@ exports[`<StarRating /> > should match snapshot with label 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -180,13 +180,13 @@ exports[`<StarRating /> > should match snapshot with label 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -200,13 +200,13 @@ exports[`<StarRating /> > should match snapshot with label 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -220,13 +220,13 @@ exports[`<StarRating /> > should match snapshot with label 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
           >
             <svg
               aria-hidden="true"
@@ -240,7 +240,7 @@ exports[`<StarRating /> > should match snapshot with label 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -274,8 +274,8 @@ exports[`<StarRating /> > should match snapshot with value 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -289,13 +289,13 @@ exports[`<StarRating /> > should match snapshot with value 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -309,13 +309,13 @@ exports[`<StarRating /> > should match snapshot with value 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0"
           >
             <svg
               aria-hidden="true"
@@ -329,13 +329,13 @@ exports[`<StarRating /> > should match snapshot with value 1`] = `
                 d="M12 15.396V6.095l1.71 4.036 4.38.376-3.323 2.878.995 4.281M22 9.244l-7.19-.617L11.998 2 9.19 8.627 2 9.244l5.454 4.726L5.82 21 12 17.272 18.18 21l-1.635-7.03L22 9.244z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
           >
             <svg
               aria-hidden="true"
@@ -349,13 +349,13 @@ exports[`<StarRating /> > should match snapshot with value 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
           >
             <svg
               aria-hidden="true"
@@ -369,7 +369,7 @@ exports[`<StarRating /> > should match snapshot with value 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -403,8 +403,8 @@ exports[`<StarRating /> > should match snapshot without value 1`] = `
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
           >
             <svg
               aria-hidden="true"
@@ -418,13 +418,13 @@ exports[`<StarRating /> > should match snapshot without value 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
           >
             <svg
               aria-hidden="true"
@@ -438,13 +438,13 @@ exports[`<StarRating /> > should match snapshot without value 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
           >
             <svg
               aria-hidden="true"
@@ -458,13 +458,13 @@ exports[`<StarRating /> > should match snapshot without value 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
           >
             <svg
               aria-hidden="true"
@@ -478,13 +478,13 @@ exports[`<StarRating /> > should match snapshot without value 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
         <div
           class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_relative__3xgq1lfo StarRating_star_default__icwp6r0 StarRating_star_empty__icwp6r1"
           >
             <svg
               aria-hidden="true"
@@ -498,7 +498,7 @@ exports[`<StarRating /> > should match snapshot without value 1`] = `
                 d="M12 17.27l6.18 3.728-1.636-7.03L22 9.244l-7.19-.618L12 1.999 9.19 8.625 2 9.243l5.454 4.726-1.635 7.029L12 17.27z"
               />
             </svg>
-          </div>
+          </span>
         </div>
       </div>
     </div>

--- a/lib/components/Stepper/__snapshots__/Stepper.spec.jsx.snap
+++ b/lib/components/Stepper/__snapshots__/Stepper.spec.jsx.snap
@@ -20,8 +20,8 @@ exports[`<Stepper /> > should match snapshot with label formatter 1`] = `
           class="reset_appearance__1oah0220 reset_cursorPointer__1oah0221 reset_trimmedBlockElement__1oah0225 reset_button__1oah0226 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l24 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l38 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1ldd useBoxStyles_backgroundColours_primary__3xgq1lf0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Stepper_handle_default__10wm9ba4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_white__1xnpmd7g"
           tabindex="-1"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
           >
             <svg
               aria-hidden="true"
@@ -35,7 +35,7 @@ exports[`<Stepper /> > should match snapshot with label formatter 1`] = `
                 d="M19 12.998H5V11l14-.002v2z"
               />
             </svg>
-          </div>
+          </span>
         </button>
       </div>
     </div>
@@ -63,8 +63,8 @@ exports[`<Stepper /> > should match snapshot with label formatter 1`] = `
           class="reset_appearance__1oah0220 reset_cursorPointer__1oah0221 reset_trimmedBlockElement__1oah0225 reset_button__1oah0226 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l24 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l38 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1ldd useBoxStyles_backgroundColours_primary__3xgq1lf0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Stepper_handle_default__10wm9ba4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_white__1xnpmd7g"
           tabindex="-1"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
           >
             <svg
               aria-hidden="true"
@@ -78,7 +78,7 @@ exports[`<Stepper /> > should match snapshot with label formatter 1`] = `
                 d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6v2z"
               />
             </svg>
-          </div>
+          </span>
         </button>
       </div>
     </div>
@@ -106,8 +106,8 @@ exports[`<Stepper /> > should match snapshot with props 1`] = `
           class="reset_appearance__1oah0220 reset_cursorPointer__1oah0221 reset_trimmedBlockElement__1oah0225 reset_button__1oah0226 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l24 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l38 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1ldd useBoxStyles_backgroundColours_primary__3xgq1lf0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Stepper_handle_default__10wm9ba4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_white__1xnpmd7g"
           tabindex="-1"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
           >
             <svg
               aria-hidden="true"
@@ -121,7 +121,7 @@ exports[`<Stepper /> > should match snapshot with props 1`] = `
                 d="M19 12.998H5V11l14-.002v2z"
               />
             </svg>
-          </div>
+          </span>
         </button>
       </div>
     </div>
@@ -149,8 +149,8 @@ exports[`<Stepper /> > should match snapshot with props 1`] = `
           class="reset_appearance__1oah0220 reset_cursorPointer__1oah0221 reset_trimmedBlockElement__1oah0225 reset_button__1oah0226 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l24 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l38 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1ldd useBoxStyles_backgroundColours_primary__3xgq1lf0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Stepper_handle_default__10wm9ba4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_white__1xnpmd7g"
           tabindex="-1"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
           >
             <svg
               aria-hidden="true"
@@ -164,7 +164,7 @@ exports[`<Stepper /> > should match snapshot with props 1`] = `
                 d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6v2z"
               />
             </svg>
-          </div>
+          </span>
         </button>
       </div>
     </div>
@@ -192,8 +192,8 @@ exports[`<Stepper /> > should match snapshot without props 1`] = `
           class="reset_appearance__1oah0220 reset_cursorPointer__1oah0221 reset_trimmedBlockElement__1oah0225 reset_button__1oah0226 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l24 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l38 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1ldd useBoxStyles_backgroundColours_primary__3xgq1lf0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Stepper_handle_default__10wm9ba4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_white__1xnpmd7g"
           tabindex="-1"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
           >
             <svg
               aria-hidden="true"
@@ -207,7 +207,7 @@ exports[`<Stepper /> > should match snapshot without props 1`] = `
                 d="M19 12.998H5V11l14-.002v2z"
               />
             </svg>
-          </div>
+          </span>
         </button>
       </div>
     </div>
@@ -235,8 +235,8 @@ exports[`<Stepper /> > should match snapshot without props 1`] = `
           class="reset_appearance__1oah0220 reset_cursorPointer__1oah0221 reset_trimmedBlockElement__1oah0225 reset_button__1oah0226 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l10 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l24 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l38 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l4c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1ldd useBoxStyles_backgroundColours_primary__3xgq1lf0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lhk Stepper_handle_default__10wm9ba4 useTextStyles_root__1xnpmd70 reset_block__1oah0223 useTextStyles_colours_white__1xnpmd7g"
           tabindex="-1"
         >
-          <div
-            class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
+          <span
+            class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0"
           >
             <svg
               aria-hidden="true"
@@ -250,7 +250,7 @@ exports[`<Stepper /> > should match snapshot without props 1`] = `
                 d="M19 12.998h-6v6h-2v-6H5v-2h6v-6h2v6h6v2z"
               />
             </svg>
-          </div>
+          </span>
         </button>
       </div>
     </div>

--- a/lib/components/Table/__snapshots__/Table.spec.jsx.snap
+++ b/lib/components/Table/__snapshots__/Table.spec.jsx.snap
@@ -56,8 +56,8 @@ exports[`<Table /> > when implemented > should match snapshot 1`] = `
             <div
               class="reset_block__1oah0223 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l0 useBoxStyles_makeResponsiveStyle_key_bp__3xgq1l3c useBoxStyles_display_flex__3xgq1lfy useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgn useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lgv useBoxStyles_flexWrap_nowrap__3xgq1lhf"
             >
-              <div
-                class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 TableHeadCell_sorterRoot__1a20v5n2 TableHeadCell_sorter_root__1a20v5n3 TableHeadCell_sorter_asc__1a20v5n5"
+              <span
+                class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire0 TableHeadCell_sorterRoot__1a20v5n2 TableHeadCell_sorter_root__1a20v5n3 TableHeadCell_sorter_asc__1a20v5n5"
               >
                 <svg
                   aria-hidden="true"
@@ -71,7 +71,7 @@ exports[`<Table /> > when implemented > should match snapshot 1`] = `
                     d="M277.333 426.667h-42.666v-256L117.333 288 87.04 257.707 256 88.747l168.96 168.96L394.667 288 277.333 170.667v256z"
                   />
                 </svg>
-              </div>
+              </span>
             </div>
           </div>
         </button>

--- a/lib/components/TextInput/__snapshots__/TextInput.spec.jsx.snap
+++ b/lib/components/TextInput/__snapshots__/TextInput.spec.jsx.snap
@@ -361,8 +361,8 @@ exports[`<TextInput /> > should match snapshot with both icons 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -374,9 +374,9 @@ exports[`<TextInput /> > should match snapshot with both icons 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      </span>
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -388,7 +388,7 @@ exports[`<TextInput /> > should match snapshot with both icons 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <input
         autocomplete="off"
         class="reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_width_full__3xgq1lfj useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lcp useBoxStyles_backgroundColours_transparent__3xgq1lf9 withEnhancedInput_input_itself_root__5jmdy80 withEnhancedInput_inputItselfSize_medium_root_any__5jmdy8a withEnhancedInput_inputItselfSize_medium_prefixed_any__5jmdy8c undefined withEnhancedInput_inputItselfSize_medium_suffixed_any__5jmdy8d"
@@ -435,8 +435,8 @@ exports[`<TextInput /> > should match snapshot with prefix icon 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_prefixIcon__5jmdy8f withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -448,7 +448,7 @@ exports[`<TextInput /> > should match snapshot with prefix icon 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <input
         autocomplete="off"
         class="reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_width_full__3xgq1lfj useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lcp useBoxStyles_backgroundColours_transparent__3xgq1lf9 withEnhancedInput_input_itself_root__5jmdy80 withEnhancedInput_inputItselfSize_medium_root_any__5jmdy8a withEnhancedInput_inputItselfSize_medium_prefixed_any__5jmdy8c"
@@ -495,8 +495,8 @@ exports[`<TextInput /> > should match snapshot with suffix icon 1`] = `
     <div
       class="reset_block__1oah0223 useBoxStyles_width_full__3xgq1lfj useBoxStyles_height_full__3xgq1lfl"
     >
-      <div
-        class="reset_block__1oah0223 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
+      <span
+        class="reset_inlineText__1oah0222 useBoxStyles_display_block__3xgq1lfx Icon_makeResponsiveStyle_key_bp__1gy3ire4 reset_block__1oah0223 useBoxStyles_position_absolute__3xgq1lfm useBoxStyles_pointerEvents_none__3xgq1li0 withEnhancedInput_iconRoot__5jmdy8e withEnhancedInput_suffixIcon__5jmdy8g withEnhancedInput_iconSize_medium__5jmdy8i InputState_natural_default_colour__a2a1mv4"
       >
         <svg
           aria-hidden="true"
@@ -508,7 +508,7 @@ exports[`<TextInput /> > should match snapshot with suffix icon 1`] = `
             d="M183.253 353.707L280.96 256l-97.707-97.92 30.08-30.08 128 128-128 128-30.08-30.293z"
           />
         </svg>
-      </div>
+      </span>
       <input
         autocomplete="off"
         class="reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 reset_trimmedBlockElement__1oah0225 reset_appearance__1oah0220 reset_input__1oah0228 useBoxStyles_display_flex__3xgq1lfy useBoxStyles_width_full__3xgq1lfj useBoxStyles_position_relative__3xgq1lfo useBoxStyles_makeResponsiveStyle_key_bp__3xgq1lcp useBoxStyles_backgroundColours_transparent__3xgq1lf9 withEnhancedInput_input_itself_root__5jmdy80 withEnhancedInput_inputItselfSize_medium_root_any__5jmdy8a undefined withEnhancedInput_inputItselfSize_medium_suffixed_any__5jmdy8d"


### PR DESCRIPTION
#1077
This pull request fixes the issue described with the icon being nested inside a `div` element by default.
It also converts the Storybook preview file to typescript, and extracts the Storybook preview decorator.