### PR TITLE
Checkbox indeterminate state

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,4 +22,10 @@ export default [
 			'unicorn/prefer-global-this': 'warn',
 		},
 	},
+	{
+		files: ['**/*.stories.{jsx,tsx}'],
+		rules: {
+			'react-hooks/rules-of-hooks': 'off',
+		},
+	},
 ];

--- a/lib/components/CheckBox/CheckBox.css.ts
+++ b/lib/components/CheckBox/CheckBox.css.ts
@@ -29,9 +29,10 @@ export const checkbox = styleVariants({
 		borderWidth: borderWidth,
 		zIndex: 0,
 		selectors: {
-			[`${nativeInput}:not(:checked):hover ~${checkable} &`]: {
-				backgroundColor: colorMid,
-			},
+			[`${nativeInput}:not(:checked):hover ~${checkable} &:not([data-indeterminate])`]:
+				{
+					backgroundColor: colorMid,
+				},
 		},
 		transition,
 	},

--- a/lib/components/CheckBox/CheckBox.stories.tsx
+++ b/lib/components/CheckBox/CheckBox.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Badge } from '../Badge';
 import { Heading } from '../Heading';
@@ -36,12 +36,19 @@ const meta: Meta<typeof CheckBox> = {
 		onChange: fn(),
 		onClick: fn(),
 	},
-	render: ({ ...args }) => {
-		const [checked, setChecked] = React.useState(false);
+	render: ({ indeterminate, ...args }) => {
+		const [checked, setChecked] = useState(false);
+		const [isIndeterminate, setIsIndeterminate] = useState(indeterminate);
+
 		return (
 			<CheckBox
 				{...args}
+				indeterminate={isIndeterminate}
 				checked={checked}
+				onClick={() => {
+					if (isIndeterminate) setIsIndeterminate(false);
+					args.onClick?.(checked);
+				}}
 				onChange={(checked) => {
 					setChecked(checked);
 					args.onChange?.(checked);
@@ -58,15 +65,21 @@ export const Default: Story = {};
 
 export const Disabled: Story = {
 	args: {
-		checked: false,
 		disabled: true,
 		children: "Can't check me",
 	},
 };
 
+export const Indeterminate: Story = {
+	args: {
+		indeterminate: true,
+		children: 'Not sure',
+	},
+};
+
 export const List = {
 	render: ({ disabled, onChange }) => {
-		const [selected, setSelected] = React.useState(() => ({
+		const [selected, setSelected] = useState(() => ({
 			avocado: true,
 			blueberries: true,
 			cherries: false,

--- a/lib/components/CheckBox/CheckBox.stories.tsx
+++ b/lib/components/CheckBox/CheckBox.stories.tsx
@@ -70,6 +70,11 @@ export const Disabled: Story = {
 	},
 };
 
+/**
+ * The indeterminate checkbox will typically be set by the parent component in a form with nested checkboxes.
+ * The indeterminate prop cannot be set by the component itself. This example uses an `onClick` handler to toggle
+ * the checked state when the indeterminate checkbox is clicked, the checkbox does not natively have this behaviour.
+ */
 export const Indeterminate: Story = {
 	args: {
 		indeterminate: true,

--- a/lib/components/CheckBox/CheckBox.tsx
+++ b/lib/components/CheckBox/CheckBox.tsx
@@ -1,19 +1,21 @@
-import { CheckIcon } from '@autoguru/icons';
+import { CheckIcon, MinusIcon } from '@autoguru/icons';
 import clsx from 'clsx';
-import * as React from 'react';
-import { forwardRef, ReactNode } from 'react';
+import React, { forwardRef, ReactNode, useEffect, useRef } from 'react';
 
-import { noop } from '../../utils';
+import { mergeRefs, noop } from '../../utils';
+import { dataAttrs } from '../../utils/dataAttrs';
 import { Box } from '../Box';
 import { Icon } from '../Icon';
 import { CheckableBase } from '../private/CheckableBase';
 import { checkableIndicator } from '../private/CheckableBase/CheckableBase.css';
 
 import * as styles from './CheckBox.css';
+
 export interface Props {
 	className?: string;
 	checked?: boolean;
 	disabled?: boolean;
+	indeterminate?: boolean;
 	name?: string;
 	value: string;
 	children?: ReactNode;
@@ -29,15 +31,24 @@ export const CheckBox = forwardRef<HTMLInputElement, Props>(
 			name = '',
 			disabled = false,
 			checked = false,
+			indeterminate = false,
 			onClick = noop,
 			onChange = noop,
 			children,
 		},
 		ref,
 	) => {
+		const internalRef = useRef<HTMLInputElement>(null);
+
+		useEffect(() => {
+			if (internalRef.current) {
+				internalRef.current.indeterminate = indeterminate;
+			}
+		}, [indeterminate]);
+
 		return (
 			<CheckableBase
-				ref={ref}
+				ref={mergeRefs([ref, internalRef])}
 				inputType="checkbox"
 				className={className}
 				inputName={name}
@@ -53,12 +64,16 @@ export const CheckBox = forwardRef<HTMLInputElement, Props>(
 						styles.checkbox.default,
 						checkableIndicator,
 						{
-							[styles.checkbox.selected]: checked,
+							[styles.checkbox.selected]:
+								checked || indeterminate,
 						},
 					)}
+					{...dataAttrs({
+						indeterminate: indeterminate,
+					})}
 				>
 					<Icon
-						icon={CheckIcon}
+						icon={indeterminate ? MinusIcon : CheckIcon}
 						size="medium"
 						className={styles.icon}
 					/>


### PR DESCRIPTION
Introduce an indeterminate state for checkboxes, allowing for better representation of partial selections. Update stories to demonstrate the new functionality.