### PR TITLE
Enable caching in GH workflows

### DIFF
--- a/.github/workflows/buildStorybook.yml
+++ b/.github/workflows/buildStorybook.yml
@@ -15,30 +15,25 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup environment
-              id: setups
-              run: |-
-                  echo "::set-output name=yarn_cache::$(yarn cache dir)"
-                  echo "::set-output name=node_version::$(jq -r '.volta.node' package.json)"
+            - name: Get Node version
+              id: version
+              run:
+                  echo "node_version=$(jq -r '.volta.node' package.json)" >>
+                  $GITHUB_OUTPUT
 
-            - name: Setup Node ${{ steps.setups.outputs.node_version }}
+            - name: Setup Node ${{ steps.version.outputs.node_version }}
               uses: actions/setup-node@main
               with:
-                  node-version: ${{ steps.setups.outputs.node_version }}
+                  node-version: ${{ steps.version.outputs.node_version }}
+                  cache: 'yarn'
                   check-latest: true
 
-            - name: Yarn cache
-              uses: actions/cache@main
-              with:
-                  path: ${{ steps.setups.outputs.yarn_cache }}
-                  key:
-                      ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock')
-                      }}-node-${{ steps.setups.outputs.node_version }}
-
-            - run: yarn --immutable
+            - name: Yarn install
+              run: yarn --immutable
 
             - name: Build storybook artefacts
               run: yarn storybook:build
+
             - name: Deploy to GitHub Pages
               uses: peaceiris/actions-gh-pages@v4
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,44 +11,20 @@ concurrency:
 
 jobs:
     setup:
-        name: Setup Environment
+        name: Setup environment
         runs-on: ubuntu-latest
         outputs:
-            node_version: ${{ steps.setups.outputs.node_version }}
-            cache_key: ${{ steps.cache-key.outputs.hash }}
+            node_version: ${{ steps.version.outputs.node_version }}
         steps:
             - uses: actions/checkout@main
               with:
                   fetch-depth: 0
 
-            - name: Setup environment
-              id: setups
+            - name: Get Node version
+              id: version
               run:
                   echo "node_version=$(jq -r '.volta.node' package.json)" >>
                   $GITHUB_OUTPUT
-
-            - name: Generate cache key
-              id: cache-key
-              run:
-                  echo "hash=${{ runner.os }}-node-${{
-                  steps.setups.outputs.node_version }}-${{
-                  hashFiles('**/yarn.lock') }}" >> $GITHUB_OUTPUT
-
-            - name: Setup Node ${{ steps.setups.outputs.node_version }}
-              uses: actions/setup-node@main
-              with:
-                  node-version: ${{ steps.setups.outputs.node_version }}
-                  cache: 'yarn'
-                  check-latest: true
-
-            - run: yarn --immutable
-
-            - name: Cache node modules
-              uses: actions/cache@v3
-              id: cache-nodemodules
-              with:
-                  path: node_modules
-                  key: ${{ steps.cache-key.outputs.hash }}
 
     test:
         name: Lint & Test
@@ -66,12 +42,10 @@ jobs:
               uses: actions/setup-node@main
               with:
                   node-version: ${{ needs.setup.outputs.node_version }}
+                  cache: 'yarn'
 
-            - name: Restore node modules
-              uses: actions/cache@v3
-              with:
-                  path: node_modules
-                  key: ${{ needs.setup.outputs.cache_key }}
+            - name: Yarn install
+              run: yarn --immutable
 
             - name: Lint
               run: yarn lint
@@ -99,12 +73,9 @@ jobs:
               uses: actions/setup-node@main
               with:
                   node-version: ${{ needs.setup.outputs.node_version }}
+                  cache: 'yarn'
 
-            - name: Restore node modules
-              uses: actions/cache@v3
-              with:
-                  path: node_modules
-                  key: ${{ needs.setup.outputs.cache_key }}
+            - run: yarn --immutable
 
             - name: Chromatic
               if: github.event.pull_request.draft == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,8 @@ jobs:
                   node-version: ${{ needs.setup.outputs.node_version }}
                   cache: 'yarn'
 
-            - run: yarn --immutable
+            - name: Yarn install
+              run: yarn --immutable
 
             - name: Chromatic
               if: github.event.pull_request.draft == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,11 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    test:
-        name: Lint & Test
+    setup:
+        name: Setup Environment
         runs-on: ubuntu-latest
-        env:
-            TZ: Australia/Brisbane
-            CI: true
+        outputs:
+            node_version: ${{ steps.setups.outputs.node_version }}
         steps:
             - uses: actions/checkout@main
               with:
@@ -26,7 +25,6 @@ jobs:
               run:
                   echo "node_version=$(jq -r '.volta.node' package.json)" >>
                   $GITHUB_OUTPUT
-                  #echo "yarn_cache=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
             - name: Setup Node ${{ steps.setups.outputs.node_version }}
               uses: actions/setup-node@main
@@ -37,8 +35,68 @@ jobs:
 
             - run: yarn --immutable
 
+            - name: Cache node modules
+              uses: actions/cache@v3
+              id: cache-nodemodules
+              with:
+                  path: node_modules
+                  key:
+                      ${{ runner.os }}-node-${{
+                      steps.setups.outputs.node_version }}-${{
+                      hashFiles('**/yarn.lock') }}
+
+    lint:
+        name: Lint
+        needs: setup
+        runs-on: ubuntu-latest
+        env:
+            TZ: Australia/Brisbane
+            CI: true
+        steps:
+            - uses: actions/checkout@main
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Node ${{ needs.setup.outputs.node_version }}
+              uses: actions/setup-node@main
+              with:
+                  node-version: ${{ needs.setup.outputs.node_version }}
+
+            - name: Restore node modules
+              uses: actions/cache@v3
+              with:
+                  path: node_modules
+                  key:
+                      ${{ runner.os }}-node-${{ needs.setup.outputs.node_version
+                      }}-${{ hashFiles('**/yarn.lock') }}
+
             - name: Lint
               run: yarn lint
+
+    test:
+        name: Test
+        needs: setup
+        runs-on: ubuntu-latest
+        env:
+            TZ: Australia/Brisbane
+            CI: true
+        steps:
+            - uses: actions/checkout@main
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Node ${{ needs.setup.outputs.node_version }}
+              uses: actions/setup-node@main
+              with:
+                  node-version: ${{ needs.setup.outputs.node_version }}
+
+            - name: Restore node modules
+              uses: actions/cache@v3
+              with:
+                  path: node_modules
+                  key:
+                      ${{ runner.os }}-node-${{ needs.setup.outputs.node_version
+                      }}-${{ hashFiles('**/yarn.lock') }}
 
             - name: Test
               run: yarn test --run --coverage
@@ -49,6 +107,7 @@ jobs:
 
     visual_test:
         name: Visual changes
+        needs: setup
         runs-on: ubuntu-latest
         env:
             TZ: Australia/Brisbane
@@ -58,21 +117,18 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup environment
-              id: setups
-              run:
-                  echo "node_version=$(jq -r '.volta.node' package.json)" >>
-                  $GITHUB_OUTPUT
-                  #echo "yarn_cache=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-            - name: Setup Node ${{ steps.setups.outputs.node_version }}
+            - name: Setup Node ${{ needs.setup.outputs.node_version }}
               uses: actions/setup-node@main
               with:
-                  node-version: ${{ steps.setups.outputs.node_version }}
-                  cache: 'yarn'
-                  check-latest: true
+                  node-version: ${{ needs.setup.outputs.node_version }}
 
-            - run: yarn --immutable
+            - name: Restore node modules
+              uses: actions/cache@v3
+              with:
+                  path: node_modules
+                  key:
+                      ${{ runner.os }}-node-${{ needs.setup.outputs.node_version
+                      }}-${{ hashFiles('**/yarn.lock') }}
 
             - name: Chromatic
               if: github.event.pull_request.draft == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,22 +24,15 @@ jobs:
             - name: Setup environment
               id: setups
               run: |-
-                  echo "::set-output name=yarn_cache::$(yarn cache dir)"
-                  echo "::set-output name=node_version::$(jq -r '.volta.node' package.json)"
+                  echo "yarn_cache=$(yarn cache dir)" >> $GITHUB_OUTPUT
+                  echo "node_version=$(jq -r '.volta.node' package.json)" >> $GITHUB_OUTPUT
 
             - name: Setup Node ${{ steps.setups.outputs.node_version }}
               uses: actions/setup-node@main
               with:
                   node-version: ${{ steps.setups.outputs.node_version }}
+                  cache: 'yarn'
                   check-latest: true
-
-            - name: Yarn cache
-              uses: actions/cache@v4
-              with:
-                  path: ${{ steps.setups.outputs.yarn_cache }}
-                  key:
-                      ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock')
-                      }}-node-${{ steps.setups.outputs.node_version }}
 
             - run: yarn --immutable
 
@@ -67,22 +60,15 @@ jobs:
             - name: Setup environment
               id: setups
               run: |-
-                  echo "::set-output name=yarn_cache::$(yarn cache dir)"
-                  echo "::set-output name=node_version::$(jq -r '.volta.node' package.json)"
+                  echo "yarn_cache=$(yarn cache dir)" >> $GITHUB_OUTPUT
+                  echo "node_version=$(jq -r '.volta.node' package.json)" >> $GITHUB_OUTPUT
 
             - name: Setup Node ${{ steps.setups.outputs.node_version }}
               uses: actions/setup-node@main
               with:
                   node-version: ${{ steps.setups.outputs.node_version }}
+                  cache: 'yarn'
                   check-latest: true
-
-            - name: Yarn cache
-              uses: actions/cache@v4
-              with:
-                  path: ${{ steps.setups.outputs.yarn_cache }}
-                  key:
-                      ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock')
-                      }}-node-${{ steps.setups.outputs.node_version }}
 
             - run: yarn --immutable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
 
             - name: Setup environment
               id: setups
-              run: |-
-                  echo "yarn_cache=$(yarn cache dir)" >> $GITHUB_OUTPUT
-                  echo "node_version=$(jq -r '.volta.node' package.json)" >> $GITHUB_OUTPUT
+              run:
+                  echo "node_version=$(jq -r '.volta.node' package.json)" >>
+                  $GITHUB_OUTPUT
+                  #echo "yarn_cache=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
             - name: Setup Node ${{ steps.setups.outputs.node_version }}
               uses: actions/setup-node@main
@@ -59,9 +60,10 @@ jobs:
 
             - name: Setup environment
               id: setups
-              run: |-
-                  echo "yarn_cache=$(yarn cache dir)" >> $GITHUB_OUTPUT
-                  echo "node_version=$(jq -r '.volta.node' package.json)" >> $GITHUB_OUTPUT
+              run:
+                  echo "node_version=$(jq -r '.volta.node' package.json)" >>
+                  $GITHUB_OUTPUT
+                  #echo "yarn_cache=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
             - name: Setup Node ${{ steps.setups.outputs.node_version }}
               uses: actions/setup-node@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         outputs:
             node_version: ${{ steps.setups.outputs.node_version }}
+            cache_key: ${{ steps.cache-key.outputs.hash }}
         steps:
             - uses: actions/checkout@main
               with:
@@ -25,6 +26,13 @@ jobs:
               run:
                   echo "node_version=$(jq -r '.volta.node' package.json)" >>
                   $GITHUB_OUTPUT
+
+            - name: Generate cache key
+              id: cache-key
+              run:
+                  echo "hash=${{ runner.os }}-node-${{
+                  steps.setups.outputs.node_version }}-${{
+                  hashFiles('**/yarn.lock') }}" >> $GITHUB_OUTPUT
 
             - name: Setup Node ${{ steps.setups.outputs.node_version }}
               uses: actions/setup-node@main
@@ -40,13 +48,10 @@ jobs:
               id: cache-nodemodules
               with:
                   path: node_modules
-                  key:
-                      ${{ runner.os }}-node-${{
-                      steps.setups.outputs.node_version }}-${{
-                      hashFiles('**/yarn.lock') }}
+                  key: ${{ steps.cache-key.outputs.hash }}
 
-    lint:
-        name: Lint
+    test:
+        name: Lint & Test
         needs: setup
         runs-on: ubuntu-latest
         env:
@@ -66,37 +71,10 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: node_modules
-                  key:
-                      ${{ runner.os }}-node-${{ needs.setup.outputs.node_version
-                      }}-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ needs.setup.outputs.cache_key }}
 
             - name: Lint
               run: yarn lint
-
-    test:
-        name: Test
-        needs: setup
-        runs-on: ubuntu-latest
-        env:
-            TZ: Australia/Brisbane
-            CI: true
-        steps:
-            - uses: actions/checkout@main
-              with:
-                  fetch-depth: 0
-
-            - name: Setup Node ${{ needs.setup.outputs.node_version }}
-              uses: actions/setup-node@main
-              with:
-                  node-version: ${{ needs.setup.outputs.node_version }}
-
-            - name: Restore node modules
-              uses: actions/cache@v3
-              with:
-                  path: node_modules
-                  key:
-                      ${{ runner.os }}-node-${{ needs.setup.outputs.node_version
-                      }}-${{ hashFiles('**/yarn.lock') }}
 
             - name: Test
               run: yarn test --run --coverage
@@ -126,9 +104,7 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: node_modules
-                  key:
-                      ${{ runner.os }}-node-${{ needs.setup.outputs.node_version
-                      }}-${{ hashFiles('**/yarn.lock') }}
+                  key: ${{ needs.setup.outputs.cache_key }}
 
             - name: Chromatic
               if: github.event.pull_request.draft == false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,28 @@ on:
         branches: [main]
 
 jobs:
+    setup:
+        name: Setup environment
+        runs-on: ubuntu-latest
+        outputs:
+            node_version: ${{ steps.version.outputs.node_version }}
+        steps:
+            - uses: actions/checkout@main
+              with:
+                  fetch-depth: 0
+
+            - name: Get Node version
+              id: version
+              run:
+                  echo "node_version=$(jq -r '.volta.node' package.json)" >>
+                  $GITHUB_OUTPUT
+
     release:
         name: Release
+        needs: setup
         runs-on: ubuntu-latest
+        outputs:
+            published: ${{ steps.changesets.outputs.published }}
         env:
             TZ: Australia/Brisbane
             CI: true
@@ -16,29 +35,18 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup environment
-              id: setups
-              run: |-
-                  echo "::set-output name=yarn_cache::$(yarn cache dir)"
-                  echo "::set-output name=node_version::$(jq -r '.volta.node' package.json)"
-
-            - name: Setup Node ${{ steps.setups.outputs.node_version }}
+            - name: Setup Node ${{ needs.setup.outputs.node_version }}
               uses: actions/setup-node@main
               with:
-                  node-version: ${{ steps.setups.outputs.node_version }}
+                  node-version: ${{ needs.setup.outputs.node_version }}
+                  cache: 'yarn'
                   check-latest: true
 
-            - name: Yarn cache
-              uses: actions/cache@main
-              with:
-                  path: ${{ steps.setups.outputs.yarn_cache }}
-                  key:
-                      ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock')
-                      }}-node-${{ steps.setups.outputs.node_version }}
-
-            - run: yarn --immutable
+            - name: Yarn install
+              run: yarn --immutable
 
             - name: Create Release or Publish
+              id: changesets
               uses: changesets/action@v1
               with:
                   publish: yarn release
@@ -48,7 +56,7 @@ jobs:
 
     storybook:
         name: Publish Storybook
-        needs: release
+        needs: [setup, release]
         if: needs.release.outputs.published == 'true'
         runs-on: ubuntu-latest
         env:
@@ -59,27 +67,15 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup environment
-              id: setups
-              run: |-
-                  echo "::set-output name=yarn_cache::$(yarn cache dir)"
-                  echo "::set-output name=node_version::$(jq -r '.volta.node' package.json)"
-
-            - name: Setup Node ${{ steps.setups.outputs.node_version }}
+            - name: Setup Node ${{ needs.setup.outputs.node_version }}
               uses: actions/setup-node@main
               with:
-                  node-version: ${{ steps.setups.outputs.node_version }}
+                  node-version: ${{ needs.setup.outputs.node_version }}
+                  cache: 'yarn'
                   check-latest: true
 
-            - name: Yarn cache
-              uses: actions/cache@main
-              with:
-                  path: ${{ steps.setups.outputs.yarn_cache }}
-                  key:
-                      ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock')
-                      }}-node-${{ steps.setups.outputs.node_version }}
-
-            - run: yarn --immutable
+            - name: Yarn install
+              run: yarn --immutable
 
             - name: Build Storybook
               run: yarn storybook:build


### PR DESCRIPTION
This pull request restructures workflows to use a common setup node version setup pattern.
It enables the `setup-node` inbuilt caching and converts deprecated set-output commands to GITHUB_OUTPUT.