### PR TITLE
Cleaning up circular imports

### DIFF
--- a/.changeset/proud-symbols-remain.md
+++ b/.changeset/proud-symbols-remain.md
@@ -1,0 +1,6 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Default exports have been removed from components. Imports requiring a default
+export should now point to `.../[component]/default`.

--- a/lib/components/Actions/Actions.stories.tsx
+++ b/lib/components/Actions/Actions.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Button } from '../Button';
+import { Button } from '../Button/Button';
 
-import { Actions } from '.';
+import { Actions } from './Actions';
 
 const meta = {
 	title: 'Components/Actions',

--- a/lib/components/Actions/Actions.tsx
+++ b/lib/components/Actions/Actions.tsx
@@ -2,13 +2,13 @@ import React, { type FunctionComponent, type ReactElement } from 'react';
 
 import { Inline, type InlineProps } from '../Inline';
 
-export interface Props extends Pick<InlineProps, 'noWrap'> {
+export interface ActiontsProps extends Pick<InlineProps, 'noWrap'> {
 	children: ReactElement | ReactElement[];
 	className?: string;
 	wrappingDirection?: 'default' | 'reverse';
 }
 
-export const Actions: FunctionComponent<Props> = ({
+export const Actions: FunctionComponent<ActiontsProps> = ({
 	children,
 	noWrap,
 	wrappingDirection,
@@ -21,5 +21,3 @@ export const Actions: FunctionComponent<Props> = ({
 		{children}
 	</Inline>
 );
-
-export default Actions;

--- a/lib/components/Actions/default.ts
+++ b/lib/components/Actions/default.ts
@@ -1,0 +1,1 @@
+export { Actions as default } from './Actions';

--- a/lib/components/Alert/Alert.stories.tsx
+++ b/lib/components/Alert/Alert.stories.tsx
@@ -2,9 +2,9 @@ import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
-import { Text } from '../Text';
+import { Text } from '../Text/Text';
 
-import { Alert } from '.';
+import { Alert } from './Alert';
 
 const onRequestClose = action('onRequestClose');
 type Intent = ComponentProps<typeof Alert>['intent'];

--- a/lib/components/Alert/Alert.tsx
+++ b/lib/components/Alert/Alert.tsx
@@ -21,7 +21,7 @@ import * as styles from './Alert.css';
 type IntentStripeProps = ComponentProps<typeof IntentStripe>;
 type Intent = IntentStripeProps['intent'];
 
-export interface Props extends IntentStripeProps {
+export interface AlertProps extends IntentStripeProps {
 	children?: ReactNode;
 	className?: string;
 	inline?: boolean;
@@ -37,7 +37,7 @@ const iconMapForIntent: Record<Intent, IconType> = {
 	warning: AlertIcon,
 };
 
-export const Alert: FunctionComponent<Props> = ({
+export const Alert: FunctionComponent<AlertProps> = ({
 	children,
 	className = '',
 	intent = 'success',

--- a/lib/components/Alert/Alert.tsx
+++ b/lib/components/Alert/Alert.tsx
@@ -10,11 +10,13 @@ import clsx from 'clsx';
 import * as React from 'react';
 import { ComponentProps, FunctionComponent, ReactNode } from 'react';
 
-import { Box, boxStyles } from '../Box';
-import { Button } from '../Button';
-import { Icon } from '../Icon';
-import { IntentStripe } from '../IntentStripe';
-import { Text, useTextStyles } from '../Text';
+import { Box } from '../Box/Box';
+import { boxStyles } from '../Box/boxStyles';
+import { Button } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
+import { IntentStripe } from '../IntentStripe/IntentStripe';
+import { Text } from '../Text/Text';
+import { useTextStyles } from '../Text/useTextStyles';
 
 import * as styles from './Alert.css';
 

--- a/lib/components/Alert/default.ts
+++ b/lib/components/Alert/default.ts
@@ -1,0 +1,1 @@
+export { Alert as default } from './Alert';

--- a/lib/components/Anchor/Anchor.stories.tsx
+++ b/lib/components/Anchor/Anchor.stories.tsx
@@ -2,9 +2,9 @@ import { PhoneIcon } from '@autoguru/icons';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { argTypesExampleIcons } from '../../stories/shared/argTypes';
-import { Button } from '../Button';
+import { Button } from '../Button/Button';
 
-import { Anchor } from '.';
+import { Anchor } from './Anchor';
 
 const meta = {
 	title: 'Primatives/Anchor',

--- a/lib/components/Anchor/Anchor.tsx
+++ b/lib/components/Anchor/Anchor.tsx
@@ -19,7 +19,7 @@ import { Text, useTextStyles } from '../Text';
 
 import * as styles from './Anchor.css';
 
-export interface Props
+export interface AnchorProps
 	extends Omit<
 		AnchorHTMLAttributes<HTMLAnchorElement>,
 		'children' | 'style' | 'is'
@@ -32,7 +32,7 @@ export interface Props
 	icon?: IconType;
 }
 
-export const Anchor: FunctionComponent<Props> = ({
+export const Anchor: FunctionComponent<AnchorProps> = ({
 	className = '',
 
 	is: Component = 'a',
@@ -74,5 +74,3 @@ export const Anchor: FunctionComponent<Props> = ({
 		? cloneElement(Component, props, childs)
 		: createElement(Component, props, childs);
 };
-
-export default Anchor;

--- a/lib/components/Anchor/Anchor.tsx
+++ b/lib/components/Anchor/Anchor.tsx
@@ -12,10 +12,11 @@ import {
 	ReactNode,
 } from 'react';
 
-import { boxStyles } from '../Box';
-import { Icon } from '../Icon';
-import { Inline } from '../Inline';
-import { Text, useTextStyles } from '../Text';
+import { boxStyles } from '../Box/boxStyles';
+import { Icon } from '../Icon/Icon';
+import { Inline } from '../Inline/Inline';
+import { Text } from '../Text/Text';
+import { useTextStyles } from '../Text/useTextStyles';
 
 import * as styles from './Anchor.css';
 

--- a/lib/components/Anchor/default.ts
+++ b/lib/components/Anchor/default.ts
@@ -1,0 +1,1 @@
+export { Anchor as default } from './Anchor';

--- a/lib/components/AutoSuggest/AutoSuggest.stories.tsx
+++ b/lib/components/AutoSuggest/AutoSuggest.stories.tsx
@@ -4,9 +4,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
 import { argTypesExampleIcons } from '../../stories/shared/argTypes';
-import { DateInput } from '../DateInput';
+import { DateInput } from '../DateInput/DateInput';
 
-import { AutoSuggest } from '.';
+import { AutoSuggest } from './AutoSuggest';
 
 const mockSuggestions = [
 	'Alfa Romeo',

--- a/lib/components/AutoSuggest/AutoSuggest.tsx
+++ b/lib/components/AutoSuggest/AutoSuggest.tsx
@@ -20,17 +20,17 @@ import React, {
 	useState,
 } from 'react';
 
-import { useMedia } from '../../hooks/useMedia';
+import { useMedia } from '../../hooks/useMedia/useMedia';
 import { useWindowScrollLock } from '../../hooks/useWindowScrollLock';
 import { setRef, useId } from '../../utils';
-import { Box } from '../Box';
-import { Button } from '../Button';
-import { Icon } from '../Icon';
-import { Portal } from '../Portal';
-import { Positioner } from '../Positioner';
+import { Box } from '../Box/Box';
+import { Button } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
+import { Portal } from '../Portal/Portal';
+import { Positioner } from '../Positioner/Positioner';
 import { EAlignment } from '../Positioner/alignment';
-import { Text } from '../Text';
-import { TextInput } from '../TextInput';
+import { Text } from '../Text/Text';
+import { TextInput } from '../TextInput/TextInput';
 import { withEnhancedInput } from '../private/InputBase';
 
 import * as styles from './AutoSuggest.css';

--- a/lib/components/AutoSuggest/AutoSuggest.tsx
+++ b/lib/components/AutoSuggest/AutoSuggest.tsx
@@ -81,7 +81,7 @@ type Actions =
 
 type Suggestions<PayloadType> = Array<AutoSuggestValue<PayloadType>>;
 
-export interface Props<PayloadType>
+export interface AutoSuggestProps<PayloadType>
 	extends Omit<
 		ComponentPropsWithoutRef<typeof TextInput>,
 		'onChange' | 'value' | 'type' | 'suffixIcon'
@@ -100,7 +100,7 @@ export interface Props<PayloadType>
 }
 
 interface AutoSuggestInputProps<PayloadType extends unknown>
-	extends Props<PayloadType> {
+	extends AutoSuggestProps<PayloadType> {
 	noScroll?: boolean;
 	isFocused?: boolean;
 }
@@ -291,7 +291,7 @@ export const AutoSuggest = forwardRef(function AutoSuggest(
 		/>
 	);
 }) as <PayloadType extends unknown>(
-	p: Props<PayloadType> & { ref?: Ref<HTMLInputElement> },
+	p: AutoSuggestProps<PayloadType> & { ref?: Ref<HTMLInputElement> },
 ) => ReactElement;
 
 const AutoSuggestFullscreenInput = forwardRef(
@@ -537,7 +537,7 @@ const AutoSuggestInput = forwardRef(function AutoSuggestInput(
 
 interface SuggestionProps<PayloadType>
 	extends Pick<
-		Props<PayloadType>,
+		AutoSuggestProps<PayloadType>,
 		'suggestions' | 'itemRenderer' | 'onChange'
 	> {
 	className?: string;
@@ -832,5 +832,3 @@ const getNextIndex = <
 
 	return itter > maxIndex ? -1 : returnIdx;
 };
-
-export default AutoSuggest;

--- a/lib/components/AutoSuggest/default.ts
+++ b/lib/components/AutoSuggest/default.ts
@@ -1,0 +1,1 @@
+export { AutoSuggest as default } from './AutoSuggest';

--- a/lib/components/Badge/Badge.stories.tsx
+++ b/lib/components/Badge/Badge.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
-import { Badge } from '.';
+import { Badge } from './Badge';
 
 type Story = StoryObj<typeof Badge>;
 

--- a/lib/components/Badge/Badge.tsx
+++ b/lib/components/Badge/Badge.tsx
@@ -62,5 +62,3 @@ export const Badge = ({
 		</Box>
 	);
 };
-
-export default Badge;

--- a/lib/components/Badge/default.ts
+++ b/lib/components/Badge/default.ts
@@ -1,0 +1,1 @@
+export { Badge as default } from './Badge';

--- a/lib/components/Box/default.ts
+++ b/lib/components/Box/default.ts
@@ -1,1 +1,1 @@
-export { Box as default } from './';
+export { Box as default } from './Box';

--- a/lib/components/BulletList/Bullet.stories.tsx
+++ b/lib/components/BulletList/Bullet.stories.tsx
@@ -1,9 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Text } from '../Text';
+import { Text } from '../Text/Text';
 
-import { Bullet, BulletList } from '.';
+import { Bullet } from './Bullet';
+import { BulletList } from './BulletList';
 
 const meta = {
 	title: 'Primatives/Bullet List',

--- a/lib/components/BulletList/Bullet.tsx
+++ b/lib/components/BulletList/Bullet.tsx
@@ -12,7 +12,7 @@ import * as styles from './Bullet.css';
 import { BulletList } from './BulletList';
 import { BulletListContext, bulletMap, BulletType } from './context';
 
-export interface Props {
+export interface BulletProps {
 	children?: ReactNode;
 	className?: string;
 }
@@ -34,7 +34,10 @@ const getBulletCls = (styles, type: BulletType): string => {
 	}
 };
 
-export const Bullet: FunctionComponent<Props> = ({ children, className }) => (
+export const Bullet: FunctionComponent<BulletProps> = ({
+	children,
+	className,
+}) => (
 	<Box
 		is="li"
 		className={[

--- a/lib/components/BulletList/BulletList.tsx
+++ b/lib/components/BulletList/BulletList.tsx
@@ -7,12 +7,12 @@ import { Box } from '../Box';
 import * as styles from './BulletList.css';
 import { BulletListContext, bulletMap } from './context';
 
-export interface Props {
+export interface BulletListProps {
 	className?: string;
 	children?: ReactNode;
 }
 
-export const BulletList: FunctionComponent<Props> = ({
+export const BulletList: FunctionComponent<BulletListProps> = ({
 	children,
 	className,
 }) => {
@@ -32,5 +32,3 @@ export const BulletList: FunctionComponent<Props> = ({
 		</Box>
 	);
 };
-
-export default BulletList;

--- a/lib/components/BulletList/default.ts
+++ b/lib/components/BulletList/default.ts
@@ -1,0 +1,1 @@
+export { BulletList as default } from './BulletList';

--- a/lib/components/BulletText/BulletText.stories.tsx
+++ b/lib/components/BulletText/BulletText.stories.tsx
@@ -2,9 +2,9 @@ import { CheckIcon } from '@autoguru/icons';
 import { Meta, StoryObj } from '@storybook/react';
 import * as React from 'react';
 
-import { Icon } from '../Icon';
+import { Icon } from '../Icon/Icon';
 
-import { BulletText } from '.';
+import { BulletText } from './BulletText';
 
 const meta = {
 	title: 'Components/Bullet Text',

--- a/lib/components/BulletText/BulletText.tsx
+++ b/lib/components/BulletText/BulletText.tsx
@@ -12,7 +12,7 @@ import { Text } from '../Text';
 
 import * as styles from './BulletText.css';
 
-export interface Props {
+export interface BulletTextProps {
 	bullet?: ReactNode;
 	variant?: 'primary' | 'secondary';
 }
@@ -22,7 +22,7 @@ export const BulletText = <E extends ElementType>({
 	variant = 'primary',
 	children,
 	bullet: Bullet = '•',
-}: UseBoxProps<E> & Props) => (
+}: UseBoxProps<E> & BulletTextProps) => (
 	<Inline
 		as={as satisfies ComponentProps<typeof Inline>['as']}
 		noWrap
@@ -66,5 +66,3 @@ export const BulletText = <E extends ElementType>({
 		</Box>
 	</Inline>
 );
-
-export default BulletText;

--- a/lib/components/BulletText/BulletText.tsx
+++ b/lib/components/BulletText/BulletText.tsx
@@ -6,9 +6,10 @@ import React, {
 	type ReactNode,
 } from 'react';
 
-import { Box, type UseBoxProps } from '../Box';
-import { Inline } from '../Inline';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import type { UseBoxProps } from '../Box/useBox';
+import { Inline } from '../Inline/Inline';
+import { Text } from '../Text/Text';
 
 import * as styles from './BulletText.css';
 

--- a/lib/components/BulletText/default.ts
+++ b/lib/components/BulletText/default.ts
@@ -1,0 +1,1 @@
+export { BulletText as default } from './BulletText';

--- a/lib/components/Button/Button.stories.tsx
+++ b/lib/components/Button/Button.stories.tsx
@@ -3,13 +3,11 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import React, { type ComponentProps } from 'react';
 
-import { Box } from '../Box';
-import { Icon } from '../Icon';
-import { Inline } from '../Inline';
+import { Box } from '../Box/Box';
+import { Icon } from '../Icon/Icon';
+import { Inline } from '../Inline/Inline';
 
-import { type ButtonProps } from './Button';
-
-import { Button } from '.';
+import { Button, type ButtonProps } from './Button';
 
 const meta: Meta<typeof Button> = {
 	title: 'Primatives/Buttons',

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -16,10 +16,11 @@ import React, {
 
 import type { TextFontWeight, TextSizeScale } from '../../themes';
 import { dataAttrs } from '../../utils/dataAttrs';
-import { Box, BoxLikeProps, useBox, type UseBoxProps } from '../Box';
-import { Icon } from '../Icon';
-import { ProgressSpinner } from '../ProgressSpinner';
-import { useTextStyles } from '../Text';
+import { Box } from '../Box/Box';
+import { BoxLikeProps, useBox, type UseBoxProps } from '../Box/useBox';
+import { Icon } from '../Icon/Icon';
+import { ProgressSpinner } from '../ProgressSpinner/ProgressSpinner';
+import { useTextStyles } from '../Text/useTextStyles';
 
 import * as styles from './Button.css';
 import type { ButtonSize, StyledButtonProps } from './Button.css';

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -275,5 +275,3 @@ export const Button = forwardRef<
 ) as ButtonForwardRefReturn;
 
 Button.displayName = 'Button';
-
-export default Button;

--- a/lib/components/Button/default.ts
+++ b/lib/components/Button/default.ts
@@ -1,0 +1,1 @@
+export { Button as default } from './Button';

--- a/lib/components/CheckBox/CheckBox.stories.tsx
+++ b/lib/components/CheckBox/CheckBox.stories.tsx
@@ -2,12 +2,12 @@ import { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import React, { useEffect, useState } from 'react';
 
-import { Badge } from '../Badge';
-import { Heading } from '../Heading';
-import { StarRating } from '../StarRating';
-import { Text } from '../Text';
+import { Badge } from '../Badge/Badge';
+import { Heading } from '../Heading/Heading';
+import { StarRating } from '../StarRating/StarRating';
+import { Text } from '../Text/Text';
 
-import { CheckBox } from '.';
+import { CheckBox } from './CheckBox';
 
 const listData: Array<{ label: string; value: string }> = [
 	{ label: 'Avocado', value: 'avocado' },

--- a/lib/components/CheckBox/CheckBox.tsx
+++ b/lib/components/CheckBox/CheckBox.tsx
@@ -4,9 +4,9 @@ import React, { forwardRef, ReactNode, useEffect, useRef } from 'react';
 
 import { mergeRefs, noop } from '../../utils';
 import { dataAttrs } from '../../utils/dataAttrs';
-import { Box } from '../Box';
-import { Icon } from '../Icon';
-import { CheckableBase } from '../private/CheckableBase';
+import { Box } from '../Box/Box';
+import { Icon } from '../Icon/Icon';
+import { CheckableBase } from '../private/CheckableBase/CheckableBase';
 import { checkableIndicator } from '../private/CheckableBase/CheckableBase.css';
 
 import * as styles from './CheckBox.css';

--- a/lib/components/CheckBox/CheckBox.tsx
+++ b/lib/components/CheckBox/CheckBox.tsx
@@ -11,7 +11,7 @@ import { checkableIndicator } from '../private/CheckableBase/CheckableBase.css';
 
 import * as styles from './CheckBox.css';
 
-export interface Props {
+export interface CheckboxProps {
 	className?: string;
 	checked?: boolean;
 	disabled?: boolean;
@@ -27,7 +27,7 @@ export interface Props {
 	onChange?(checked: boolean): void;
 }
 
-export const CheckBox = forwardRef<HTMLInputElement, Props>(
+export const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(
 	(
 		{
 			value,
@@ -88,5 +88,3 @@ export const CheckBox = forwardRef<HTMLInputElement, Props>(
 );
 
 CheckBox.displayName = 'Checkbox';
-
-export default CheckBox;

--- a/lib/components/CheckBox/default.ts
+++ b/lib/components/CheckBox/default.ts
@@ -1,0 +1,1 @@
+export { CheckBox as default } from './CheckBox';

--- a/lib/components/ColourInput/ColourInput.stories.tsx
+++ b/lib/components/ColourInput/ColourInput.stories.tsx
@@ -4,9 +4,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { type ComponentProps } from 'react';
 
 import { argTypesExampleIcons } from '../../stories/shared/argTypes';
-import { DateInput } from '../DateInput';
+import { DateInput } from '../DateInput/DateInput';
 
-import { ColourInput } from '.';
+import { ColourInput } from './ColourInput';
 
 const defaultColour = '#ec4040';
 

--- a/lib/components/ColourInput/ColourInput.tsx
+++ b/lib/components/ColourInput/ColourInput.tsx
@@ -82,5 +82,3 @@ export const ColourInput = withEnhancedInput<{}, HTMLInputElement>(
 		defaultValue: '#000000',
 	},
 );
-
-export default ColourInput;

--- a/lib/components/ColourInput/ColourInput.tsx
+++ b/lib/components/ColourInput/ColourInput.tsx
@@ -2,8 +2,9 @@ import { warning } from '@autoguru/utilities';
 import clsx from 'clsx';
 import * as React from 'react';
 
-import { Box, boxStyles } from '../Box';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { boxStyles } from '../Box/boxStyles';
+import { Text } from '../Text/Text';
 import { withEnhancedInput } from '../private/InputBase';
 
 import * as styles from './ColourInput.css';

--- a/lib/components/ColourInput/default.ts
+++ b/lib/components/ColourInput/default.ts
@@ -1,0 +1,1 @@
+export { ColourInput as default } from './ColourInput';

--- a/lib/components/Columns/Columns.stories.tsx
+++ b/lib/components/Columns/Columns.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
+import { Column } from './Column';
+import { Columns } from './Columns';
 import { columnsStyle } from './Columns.css';
-
-import { Column, Columns } from '.';
 
 type ColumnProps = React.ComponentProps<typeof Column>;
 

--- a/lib/components/Columns/Columns.tsx
+++ b/lib/components/Columns/Columns.tsx
@@ -180,5 +180,3 @@ export const Columns = forwardRef<ComponentRef<'div'>, ColumnsPolyProps<'div'>>(
 ) as ColumnsForwardRefReturn;
 
 Columns.displayName = 'Columns';
-
-export default Columns;

--- a/lib/components/Columns/default.ts
+++ b/lib/components/Columns/default.ts
@@ -1,0 +1,1 @@
+export { Columns as default } from './Columns';

--- a/lib/components/DateInput/DateInput.stories.tsx
+++ b/lib/components/DateInput/DateInput.stories.tsx
@@ -11,7 +11,7 @@ import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import isChromatic from 'chromatic/isChromatic';
 
-import { DateInput } from '.';
+import { DateInput } from './DateInput';
 
 const formatDate = (date: Date = new Date()) => {
 	const year = date.getFullYear();

--- a/lib/components/DateInput/DateInput.tsx
+++ b/lib/components/DateInput/DateInput.tsx
@@ -37,5 +37,3 @@ export const DateInput = withEnhancedInput<
 		primitiveType: 'date',
 	},
 );
-
-export default DateInput;

--- a/lib/components/DateInput/DateInput.tsx
+++ b/lib/components/DateInput/DateInput.tsx
@@ -1,7 +1,7 @@
 import { warning } from '@autoguru/utilities';
 import * as React from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 import { withEnhancedInput } from '../private/InputBase';
 
 export const DateInput = withEnhancedInput<

--- a/lib/components/DateInput/default.ts
+++ b/lib/components/DateInput/default.ts
@@ -1,0 +1,1 @@
+export { DateInput as default } from './DateInput';

--- a/lib/components/DatePicker/DatePicker.stories.tsx
+++ b/lib/components/DatePicker/DatePicker.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
 import { argTypesExampleIcons } from '../../stories/shared/argTypes';
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
-import { DatePicker } from '.';
+import { DatePicker } from './DatePicker';
 
 const meta = {
 	title: 'Components/Date Picker',

--- a/lib/components/DatePicker/DatePicker.tsx
+++ b/lib/components/DatePicker/DatePicker.tsx
@@ -12,7 +12,7 @@ import * as styles from './DatePicker.css';
 
 type SizeScale = 'small' | 'medium' | 'large';
 
-export interface Props
+export interface DatePickerProps
 	extends Partial<Pick<HTMLInputElement, 'min' | 'max' | 'value'>> {
 	size?: SizeScale;
 	className?: string;
@@ -29,7 +29,7 @@ const textSizeMap: Record<SizeScale, ComponentProps<typeof Text>['size']> = {
 	medium: '3',
 	large: '5',
 };
-export const DatePicker: FunctionComponent<Props> = ({
+export const DatePicker: FunctionComponent<DatePickerProps> = ({
 	className = '',
 	icon = CalendarIcon,
 	size = 'medium',
@@ -98,5 +98,3 @@ export const DatePicker: FunctionComponent<Props> = ({
 		</Box>
 	);
 };
-
-export default DatePicker;

--- a/lib/components/DatePicker/DatePicker.tsx
+++ b/lib/components/DatePicker/DatePicker.tsx
@@ -3,10 +3,11 @@ import clsx from 'clsx';
 import * as React from 'react';
 import { ChangeEvent, ComponentProps, FunctionComponent } from 'react';
 
-import { Box, boxStyles } from '../Box';
-import { Icon } from '../Icon';
-import { ProgressSpinner } from '../ProgressSpinner';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { boxStyles } from '../Box/boxStyles';
+import { Icon } from '../Icon/Icon';
+import { ProgressSpinner } from '../ProgressSpinner/ProgressSpinner';
+import { Text } from '../Text/Text';
 
 import * as styles from './DatePicker.css';
 

--- a/lib/components/DatePicker/default.ts
+++ b/lib/components/DatePicker/default.ts
@@ -1,0 +1,1 @@
+export { DatePicker as default } from './DatePicker';

--- a/lib/components/DateTimePicker/default.ts
+++ b/lib/components/DateTimePicker/default.ts
@@ -1,0 +1,1 @@
+export { DateTimePicker as default } from './DateTimePicker';

--- a/lib/components/DividerLine/DividerLine.stories.tsx
+++ b/lib/components/DividerLine/DividerLine.stories.tsx
@@ -1,11 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
-import { Box } from '../Box';
-import { Heading } from '../Heading';
-import { Inline } from '../Inline';
+import { Box } from '../Box/Box';
+import { Heading } from '../Heading/Heading';
+import { Inline } from '../Inline/Inline';
 
-import { DividerLine } from '.';
+import { DividerLine } from './DividerLine';
 
 const spacingOptions: Record<
 	string,

--- a/lib/components/DividerLine/DividerLine.tsx
+++ b/lib/components/DividerLine/DividerLine.tsx
@@ -6,7 +6,7 @@ import { Box } from '../Box';
 
 import * as styles from './DividerLine.css';
 
-export interface Props {
+export interface DividerLineProps {
 	isVertical?: boolean;
 	className?: string;
 	space: ComponentProps<typeof Box>['marginY'];
@@ -14,7 +14,7 @@ export interface Props {
 	size?: keyof (typeof styles.size)['horizontal'];
 }
 
-export const DividerLine: FunctionComponent<Props> = ({
+export const DividerLine: FunctionComponent<DividerLineProps> = ({
 	className = '',
 	isVertical = false,
 	space = '3',

--- a/lib/components/DividerLine/default.ts
+++ b/lib/components/DividerLine/default.ts
@@ -1,0 +1,1 @@
+export { DividerLine as default } from './DividerLine';

--- a/lib/components/DropDown/DropDown.stories.tsx
+++ b/lib/components/DropDown/DropDown.stories.tsx
@@ -8,10 +8,11 @@ import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
-import { Box } from '../Box';
-import { Button } from '../Button';
+import { Box } from '../Box/Box';
+import { Button } from '../Button/Button';
 
-import { DropDown, DropDownOption } from '.';
+import { DropDown } from './DropDown';
+import { DropDownOption } from './DropDownOption';
 
 const onClick = action('onClick');
 

--- a/lib/components/DropDown/DropDown.tsx
+++ b/lib/components/DropDown/DropDown.tsx
@@ -10,11 +10,11 @@ import {
 	useState,
 } from 'react';
 
-import { Button } from '../Button';
-import { Flyout } from '../Flyout';
-import { Icon } from '../Icon';
-import { useOutsideClick } from '../OutsideClick';
-import { EPositionerAlignment } from '../Positioner';
+import { Button } from '../Button/Button';
+import { Flyout } from '../Flyout/Flyout';
+import { Icon } from '../Icon/Icon';
+import { useOutsideClick } from '../OutsideClick/OutsideClick';
+import { EPositionerAlignment } from '../Positioner/index';
 
 import { DropDownOptionsList } from './DropDownOptionsList';
 

--- a/lib/components/DropDown/DropDown.tsx
+++ b/lib/components/DropDown/DropDown.tsx
@@ -24,7 +24,7 @@ type ButtonProps = Omit<
 >;
 type FlyoutProps = Pick<ComponentProps<typeof Flyout>, 'alignment'>;
 
-export interface Props extends ButtonProps, FlyoutProps {
+export interface DropDownProps extends ButtonProps, FlyoutProps {
 	children: ReactNode;
 	label: string;
 	icon?: IconType;
@@ -32,7 +32,7 @@ export interface Props extends ButtonProps, FlyoutProps {
 	onClick?: ComponentProps<typeof Button>['onClick'];
 }
 
-export const DropDown: FunctionComponent<Props> = ({
+export const DropDown: FunctionComponent<DropDownProps> = ({
 	children: options,
 	label,
 	icon = ChevronDownIcon,
@@ -71,5 +71,3 @@ export const DropDown: FunctionComponent<Props> = ({
 		</>
 	);
 };
-
-export default DropDown;

--- a/lib/components/DropDown/DropDownOption.tsx
+++ b/lib/components/DropDown/DropDownOption.tsx
@@ -10,14 +10,14 @@ import { Text, useTextStyles } from '../Text';
 
 import * as styles from './DropDownOption.css';
 
-interface Props
+interface DropDownOptionProps
 	extends Omit<ComponentProps<typeof Box>, 'paddingX' | 'paddingY'> {
 	icon?: IconType;
 	label: string;
 	iconColour?: ComponentProps<typeof Text>['colour'];
 }
 
-export const DropDownOption: FunctionComponent<Props> = ({
+export const DropDownOption: FunctionComponent<DropDownOptionProps> = ({
 	label,
 	icon,
 	className,

--- a/lib/components/DropDown/DropDownOption.tsx
+++ b/lib/components/DropDown/DropDownOption.tsx
@@ -3,10 +3,11 @@ import clsx from 'clsx';
 import { ComponentProps, FunctionComponent } from 'react';
 import * as React from 'react';
 
-import { Box } from '../Box';
-import { Icon } from '../Icon';
-import { Inline } from '../Inline';
-import { Text, useTextStyles } from '../Text';
+import { Box } from '../Box/Box';
+import { Icon } from '../Icon/Icon';
+import { Inline } from '../Inline/Inline';
+import { Text } from '../Text/Text';
+import { useTextStyles } from '../Text/useTextStyles';
 
 import * as styles from './DropDownOption.css';
 

--- a/lib/components/DropDown/DropDownOptionsList.tsx
+++ b/lib/components/DropDown/DropDownOptionsList.tsx
@@ -6,20 +6,21 @@ import { Stack } from '../Stack';
 
 import * as styles from './DropDownOptionsList.css';
 
-interface Props {
+interface DropDownOptionsListProps {
 	children: ReactNode;
 }
 
-export const DropDownOptionsList = forwardRef<HTMLDivElement, Props>(
-	({ children }, ref) => (
-		<Box ref={ref} className={styles.root}>
-			<Box className={styles.list} overflow="auto">
-				<Stack dividers width="full" space="none">
-					{children}
-				</Stack>
-			</Box>
+export const DropDownOptionsList = forwardRef<
+	HTMLDivElement,
+	DropDownOptionsListProps
+>(({ children }, ref) => (
+	<Box ref={ref} className={styles.root}>
+		<Box className={styles.list} overflow="auto">
+			<Stack dividers width="full" space="none">
+				{children}
+			</Stack>
 		</Box>
-	),
-);
+	</Box>
+));
 
 DropDownOptionsList.displayName = 'DropDownOptionsList';

--- a/lib/components/DropDown/default.ts
+++ b/lib/components/DropDown/default.ts
@@ -1,0 +1,1 @@
+export { DropDown as default } from './DropDown';

--- a/lib/components/EditableText/EditableText.stories.tsx
+++ b/lib/components/EditableText/EditableText.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import isChromatic from 'chromatic';
 import React, { type ChangeEvent, useState } from 'react';
 
-import { EditableText } from '.';
+import { EditableText } from './EditableText';
 
 const meta = {
 	title: 'Forms & Input Fields/Editable Text',

--- a/lib/components/EditableText/EditableText.tsx
+++ b/lib/components/EditableText/EditableText.tsx
@@ -40,7 +40,7 @@ type InputProps = Omit<
 	| keyof BoxProps
 >;
 
-export interface Props
+export interface EditableTextProps
 	extends FilteredTextProps,
 		InputProps,
 		Partial<BoxProps> {
@@ -50,7 +50,7 @@ export interface Props
 }
 const numberInputValuePattern = /^\d*\.?\d*$/;
 type InputMode = 'TEXT' | 'INPUT';
-export const EditableText = forwardRef<HTMLDivElement, Props>(
+export const EditableText = forwardRef<HTMLDivElement, EditableTextProps>(
 	(
 		{
 			is,
@@ -171,5 +171,3 @@ export const EditableText = forwardRef<HTMLDivElement, Props>(
 );
 
 EditableText.displayName = 'EditableText';
-
-export default EditableText;

--- a/lib/components/EditableText/EditableText.tsx
+++ b/lib/components/EditableText/EditableText.tsx
@@ -9,8 +9,10 @@ import React, {
 	useState,
 } from 'react';
 
-import { Box, type UseBoxProps } from '../Box';
-import { Text, type TextProps, useTextStyles } from '../Text';
+import { Box } from '../Box/Box';
+import type { UseBoxProps } from '../Box/useBox';
+import { Text, type TextProps } from '../Text/Text';
+import { useTextStyles } from '../Text/useTextStyles';
 import * as inputStyles from '../private/InputBase/withEnhancedInput.css';
 
 import * as styles from './EditableText.css';

--- a/lib/components/EditableText/default.ts
+++ b/lib/components/EditableText/default.ts
@@ -1,0 +1,1 @@
+export { EditableText as default } from './EditableText';

--- a/lib/components/FillHeightBox/FillHeightBox.stories.tsx
+++ b/lib/components/FillHeightBox/FillHeightBox.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Box } from '../Box';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { Text } from '../Text/Text';
 
 import { FillHeightBox } from './FillHeightBox';
 

--- a/lib/components/FillHeightBox/FillHeightBox.tsx
+++ b/lib/components/FillHeightBox/FillHeightBox.tsx
@@ -4,7 +4,7 @@ import { ComponentProps, FunctionComponent } from 'react';
 import useWindowHeightFill, {
 	UseWindowHeightFillProps,
 } from '../../hooks/useWindowHeightFill/useWindowHeightFill';
-import { ScrollPane } from '../ScrollPane';
+import { ScrollPane } from '../ScrollPane/ScrollPane';
 
 type FillHeightBoxProps = Omit<UseWindowHeightFillProps, 'containerRef'> &
 	ComponentProps<typeof ScrollPane>;

--- a/lib/components/FillHeightBox/FillHeightBox.tsx
+++ b/lib/components/FillHeightBox/FillHeightBox.tsx
@@ -6,10 +6,10 @@ import useWindowHeightFill, {
 } from '../../hooks/useWindowHeightFill/useWindowHeightFill';
 import { ScrollPane } from '../ScrollPane';
 
-type Props = Omit<UseWindowHeightFillProps, 'containerRef'> &
+type FillHeightBoxProps = Omit<UseWindowHeightFillProps, 'containerRef'> &
 	ComponentProps<typeof ScrollPane>;
 
-export const FillHeightBox: FunctionComponent<Props> = ({
+export const FillHeightBox: FunctionComponent<FillHeightBoxProps> = ({
 	includeMobile,
 	bottomGap,
 	serverVhFallback,

--- a/lib/components/FillHeightBox/default.ts
+++ b/lib/components/FillHeightBox/default.ts
@@ -1,0 +1,1 @@
+export { FillHeightBox as default } from './FillHeightBox';

--- a/lib/components/Flyout/Flyout.stories.tsx
+++ b/lib/components/Flyout/Flyout.stories.tsx
@@ -2,12 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react';
 import * as React from 'react';
 import { ComponentProps, useRef } from 'react';
 
-import { Box } from '../Box';
-import { Button } from '../Button';
+import { Box } from '../Box/Box';
+import { Button } from '../Button/Button';
 import { EAlignment } from '../Positioner/alignment';
-import { TextInput } from '../TextInput';
+import { TextInput } from '../TextInput/TextInput';
 
-import { Flyout } from '.';
+import { Flyout } from './Flyout';
 
 const meta = {
 	title: 'Components/Flyout',

--- a/lib/components/Flyout/Flyout.tsx
+++ b/lib/components/Flyout/Flyout.tsx
@@ -1,8 +1,8 @@
 import type { ComponentProps } from 'react';
 import * as React from 'react';
 
-import { Box } from '../Box';
-import { Positioner } from '../Positioner';
+import { Box } from '../Box/Box';
+import { Positioner } from '../Positioner/Positioner';
 
 export const Flyout = ({
 	children,

--- a/lib/components/Flyout/Flyout.tsx
+++ b/lib/components/Flyout/Flyout.tsx
@@ -31,5 +31,3 @@ export const Flyout = ({
 		</Box>
 	</Positioner>
 );
-
-export default Flyout;

--- a/lib/components/Flyout/default.ts
+++ b/lib/components/Flyout/default.ts
@@ -1,0 +1,1 @@
+export { Flyout as default } from './Flyout';

--- a/lib/components/Heading/default.ts
+++ b/lib/components/Heading/default.ts
@@ -1,0 +1,1 @@
+export { Heading as default } from './Heading';

--- a/lib/components/HorizontalAutoScroller/HorizontalAutoScroller.stories.tsx
+++ b/lib/components/HorizontalAutoScroller/HorizontalAutoScroller.stories.tsx
@@ -3,9 +3,9 @@ import Rand from 'rand-seed';
 import React, { type ComponentProps } from 'react';
 
 import { boxArgTypes, scaleOptions } from '../../stories/shared/argTypes-box';
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
-import { HorizontalAutoScroller } from '.';
+import { HorizontalAutoScroller } from './HorizontalAutoScroller';
 
 export default {
 	title: 'Components/Horizontal Auto Scroller',

--- a/lib/components/HorizontalAutoScroller/HorizontalAutoScroller.tsx
+++ b/lib/components/HorizontalAutoScroller/HorizontalAutoScroller.tsx
@@ -24,7 +24,7 @@ import {
 	UseHorizontalAutoScrollerProps,
 } from './useHorizontalAutoScroller';
 
-export interface Props
+export interface HorizontalAutoScrollerProps
 	extends Omit<UseHorizontalAutoScrollerProps, 'itemsRef'> {
 	durationSeconds?: number;
 	className?: string;
@@ -37,7 +37,9 @@ export interface Props
 	children: ReactNode | ReactNode[];
 }
 
-export const HorizontalAutoScroller: FunctionComponent<Props> = ({
+export const HorizontalAutoScroller: FunctionComponent<
+	HorizontalAutoScrollerProps
+> = ({
 	sliderProgressColour = 'primary',
 	noControls = false,
 	space = ['7', '5'],

--- a/lib/components/HorizontalAutoScroller/HorizontalAutoScroller.tsx
+++ b/lib/components/HorizontalAutoScroller/HorizontalAutoScroller.tsx
@@ -12,11 +12,11 @@ import flattenChildren from 'react-keyed-flatten-children';
 import { useSwipeable } from 'react-swipeable';
 
 import { SprinklesResponsive } from '../../styles/sprinkles.css';
-import { Box } from '../Box';
-import { Button } from '../Button';
-import { Icon } from '../Icon';
+import { Box } from '../Box/Box';
+import { Button } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
 import { Section } from '../Section/Section';
-import { SliderProgress } from '../SliderProgress';
+import { SliderProgress } from '../SliderProgress/SliderProgress';
 
 import * as styles from './HorizontalAutoScroller.css';
 import {

--- a/lib/components/HorizontalAutoScroller/default.ts
+++ b/lib/components/HorizontalAutoScroller/default.ts
@@ -1,0 +1,1 @@
+export { HorizontalAutoScroller as default } from './HorizontalAutoScroller';

--- a/lib/components/Icon/Icon.stories.tsx
+++ b/lib/components/Icon/Icon.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import { argTypesExampleIcons } from '../../stories/shared/argTypes';
 
-import { Icon } from '.';
+import { Icon } from './Icon';
 
 type Story = StoryObj<typeof Icon>;
 

--- a/lib/components/Icon/Icon.tsx
+++ b/lib/components/Icon/Icon.tsx
@@ -13,14 +13,14 @@ import * as styles from './Icon.css';
 
 export type IconEl = IconType | ReactElement<SVGAttributes<SVGElement>, 'svg'>;
 
-export interface Props {
+export interface IconProps {
 	display?: Extract<UseBoxProps['display'], 'block' | 'inline-block'>;
 	className?: string;
 	size?: ResponsiveProp<keyof typeof styles.size | string>;
 	icon: IconEl;
 }
 
-export const Icon: FunctionComponent<Props> = ({
+export const Icon: FunctionComponent<IconProps> = ({
 	className = '',
 	icon,
 	size = 'small',

--- a/lib/components/Icon/Icon.tsx
+++ b/lib/components/Icon/Icon.tsx
@@ -49,5 +49,3 @@ export const Icon: FunctionComponent<Props> = ({
 		</Box>
 	);
 };
-
-export default Icon;

--- a/lib/components/Icon/default.ts
+++ b/lib/components/Icon/default.ts
@@ -1,0 +1,1 @@
+export { Icon as default } from './Icon';

--- a/lib/components/Icon/index.ts
+++ b/lib/components/Icon/index.ts
@@ -1,1 +1,1 @@
-export { Icon, type IconEl, type Props as IconProps } from './Icon';
+export { Icon, type IconEl, type IconProps } from './Icon';

--- a/lib/components/Image/Image.stories.tsx
+++ b/lib/components/Image/Image.stories.tsx
@@ -2,12 +2,11 @@ import { Meta, StoryObj } from '@storybook/react';
 import isChromatic from 'chromatic/isChromatic';
 import React, { type ComponentProps } from 'react';
 
-import { Stack } from '../Stack';
-import { Text } from '../Text';
+import { Stack } from '../Stack/Stack';
+import { Text } from '../Text/Text';
 
+import { Image } from './Image';
 import { ImageServerProvider, widthMap } from './ImageServerProvider';
-
-import { Image } from '.';
 
 type SizeOption = ComponentProps<typeof Image>['imageWidth'];
 const sizeOptions: SizeOption[] = isChromatic()

--- a/lib/components/Image/Image.tsx
+++ b/lib/components/Image/Image.tsx
@@ -5,14 +5,14 @@ import { useImageServer } from './ImageServerProvider';
 import { ResponsiveImage } from './ResponsiveImage';
 import { SimpleImage } from './SimpleImage';
 
-export interface Props extends ComponentProps<typeof ResponsiveImage> {
+export interface ImageProps extends ComponentProps<typeof ResponsiveImage> {
 	/**
 	 * If set to true, no size/quality optimisation will be done even when `ImageServerProvider` has been defined upstream.
 	 **/
 	unoptimised?: boolean;
 }
 
-export const Image: FunctionComponent<Props> = ({
+export const Image: FunctionComponent<ImageProps> = ({
 	unoptimised = false,
 	imageWidth,
 	...props

--- a/lib/components/Image/Image.tsx
+++ b/lib/components/Image/Image.tsx
@@ -22,5 +22,3 @@ export const Image: FunctionComponent<Props> = ({
 	) : (
 		<SimpleImage {...(props as ComponentProps<typeof SimpleImage>)} />
 	);
-
-export default Image;

--- a/lib/components/Image/ImageServerProvider.tsx
+++ b/lib/components/Image/ImageServerProvider.tsx
@@ -94,5 +94,3 @@ export const ImageServerProvider: FunctionComponent<
 		</imageServerCtx.Provider>
 	);
 };
-
-export default ImageServerProvider;

--- a/lib/components/Image/ResponsiveImage.tsx
+++ b/lib/components/Image/ResponsiveImage.tsx
@@ -3,7 +3,7 @@ import type { ComponentProps, FunctionComponent } from 'react';
 import * as React from 'react';
 import { useMemo } from 'react';
 
-import { useResponsiveValue } from '../../hooks/useResponsiveValue';
+import { useResponsiveValue } from '../../hooks/useResponsiveValue/useResponsiveValue';
 import { ResponsiveProp } from '../../utils/responsiveProps.css';
 
 import { useImageServer, widthMap } from './ImageServerProvider';

--- a/lib/components/Image/ResponsiveImage.tsx
+++ b/lib/components/Image/ResponsiveImage.tsx
@@ -9,7 +9,7 @@ import { ResponsiveProp } from '../../utils/responsiveProps.css';
 import { useImageServer, widthMap } from './ImageServerProvider';
 import { SimpleImage } from './SimpleImage';
 
-export interface Props
+export interface ResponsiveImageProps
 	extends Omit<ComponentProps<typeof SimpleImage>, 'sizes'> {
 	/**
 	 * Only effective if `ImageServerProvider` is defined upstream.
@@ -40,7 +40,7 @@ export interface Props
 	quality?: number;
 }
 
-export const ResponsiveImage: FunctionComponent<Props> = ({
+export const ResponsiveImage: FunctionComponent<ResponsiveImageProps> = ({
 	imageWidth: imageWidthList,
 	sizes: sizesList = '100vw',
 	quality = 70,

--- a/lib/components/Image/ResponsiveImage.tsx
+++ b/lib/components/Image/ResponsiveImage.tsx
@@ -86,5 +86,3 @@ export const ResponsiveImage: FunctionComponent<Props> = ({
 		/>
 	);
 };
-
-export default ResponsiveImage;

--- a/lib/components/Image/SimpleImage.tsx
+++ b/lib/components/Image/SimpleImage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FunctionComponent, ReactElement, useState } from 'react';
 
-export interface Props
+export interface SimpleImageProps
 	extends Partial<
 		Omit<HTMLImageElement, 'loading' | 'className' | 'width' | 'height'>
 	> {
@@ -40,7 +40,7 @@ export interface Props
 	fallbackComponent?: ReactElement; // Add this line
 }
 
-export const SimpleImage: FunctionComponent<Props> = ({
+export const SimpleImage: FunctionComponent<SimpleImageProps> = ({
 	eager = 'false',
 	syncDecoding = 'false',
 	className = '',

--- a/lib/components/Image/default.ts
+++ b/lib/components/Image/default.ts
@@ -1,0 +1,1 @@
+export { Image as default } from './Image';

--- a/lib/components/Inline/Inline.stories.tsx
+++ b/lib/components/Inline/Inline.stories.tsx
@@ -2,11 +2,11 @@ import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
 // import { scaleOptions } from '../Box/argTypes';
-import { Button } from '../Button';
-import { Stack } from '../Stack';
-import { Text } from '../Text';
+import { Button } from '../Button/Button';
+import { Stack } from '../Stack/Stack';
+import { Text } from '../Text/Text';
 
-import { Inline } from '.';
+import { Inline } from './Inline';
 
 const meta: Meta<typeof Inline> = {
 	title: 'Layout/Inline',

--- a/lib/components/Inline/Inline.tsx
+++ b/lib/components/Inline/Inline.tsx
@@ -8,8 +8,9 @@ import React, {
 import flattenChildren from 'react-keyed-flatten-children';
 
 import type { SprinklesResponsive } from '../../styles/sprinkles.css';
-import { Box, useBox, type UseBoxProps } from '../Box';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { useBox, type UseBoxProps } from '../Box/useBox';
+import { Text } from '../Text/Text';
 
 export type InlineDivider = ReactNode | boolean;
 export interface InlineProps {

--- a/lib/components/Inline/default.ts
+++ b/lib/components/Inline/default.ts
@@ -1,0 +1,1 @@
+export { Inline as default } from './Inline';

--- a/lib/components/IntentStripe/IntentStripe.stories.tsx
+++ b/lib/components/IntentStripe/IntentStripe.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
-import { IntentStripe } from '.';
+import { IntentStripe } from './IntentStripe';
 
 type Intent = ComponentProps<typeof IntentStripe>['intent'];
 export default {

--- a/lib/components/IntentStripe/IntentStripe.tsx
+++ b/lib/components/IntentStripe/IntentStripe.tsx
@@ -23,5 +23,3 @@ export const IntentStripe: FunctionComponent<Props> = ({
 		backgroundColour={intent}
 	/>
 );
-
-export default IntentStripe;

--- a/lib/components/IntentStripe/IntentStripe.tsx
+++ b/lib/components/IntentStripe/IntentStripe.tsx
@@ -7,12 +7,12 @@ import * as styles from './IntentStripe.css';
 
 type Intent = 'danger' | 'information' | 'success' | 'warning';
 
-export interface Props {
+export interface IntentStripeProps {
 	className?: string;
 	intent: Intent;
 }
 
-export const IntentStripe: FunctionComponent<Props> = ({
+export const IntentStripe: FunctionComponent<IntentStripeProps> = ({
 	className = '',
 	intent = 'success',
 }) => (

--- a/lib/components/IntentStripe/default.ts
+++ b/lib/components/IntentStripe/default.ts
@@ -1,0 +1,1 @@
+export { IntentStripe as default } from './IntentStripe';

--- a/lib/components/LinearProgressIndicator/LinearProgressIndicator.stories.tsx
+++ b/lib/components/LinearProgressIndicator/LinearProgressIndicator.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 import * as React from 'react';
 
-import { LinearProgressIndicator } from '.';
+import { LinearProgressIndicator } from './LinearProgressIndicator';
 
 export default {
 	title: 'Components/Progress/Linear',

--- a/lib/components/LinearProgressIndicator/LinearProgressIndicator.tsx
+++ b/lib/components/LinearProgressIndicator/LinearProgressIndicator.tsx
@@ -40,5 +40,3 @@ export const LinearProgressIndicator: NamedExoticComponent<Props> = memo(
 );
 
 LinearProgressIndicator.displayName = 'LinearProgressIndicator';
-
-export default LinearProgressIndicator;

--- a/lib/components/LinearProgressIndicator/LinearProgressIndicator.tsx
+++ b/lib/components/LinearProgressIndicator/LinearProgressIndicator.tsx
@@ -5,12 +5,12 @@ import { Box } from '../Box';
 
 import * as styles from './LinearProgressIndicator.css';
 
-export interface Props {
+export interface LinearProgressIndicatorProps {
 	className?: string;
 }
 
-export const LinearProgressIndicator: NamedExoticComponent<Props> = memo(
-	({ className = '' }) => {
+export const LinearProgressIndicator: NamedExoticComponent<LinearProgressIndicatorProps> =
+	memo(({ className = '' }) => {
 		return (
 			<Box
 				position="relative"
@@ -36,7 +36,6 @@ export const LinearProgressIndicator: NamedExoticComponent<Props> = memo(
 				</Box>
 			</Box>
 		);
-	},
-);
+	});
 
 LinearProgressIndicator.displayName = 'LinearProgressIndicator';

--- a/lib/components/LinearProgressIndicator/default.ts
+++ b/lib/components/LinearProgressIndicator/default.ts
@@ -1,0 +1,1 @@
+export { LinearProgressIndicator as default } from './LinearProgressIndicator';

--- a/lib/components/LoadingBox/LoadingBox.stories.tsx
+++ b/lib/components/LoadingBox/LoadingBox.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { boxArgTypes } from '../../stories/shared/argTypes-box';
 
-import { LoadingBox } from '.';
+import { LoadingBox } from './LoadingBox';
 
 export default {
 	title: 'Components/Loading Box',

--- a/lib/components/LoadingBox/LoadingBox.tsx
+++ b/lib/components/LoadingBox/LoadingBox.tsx
@@ -5,13 +5,14 @@ import { Box } from '../Box';
 
 import * as styles from './LoadingBox.css';
 
-export interface Props extends Omit<ComponentProps<typeof Box>, 'width'> {
+export interface LoadingBoxProps
+	extends Omit<ComponentProps<typeof Box>, 'width'> {
 	className?: string;
 	randomWidth?: boolean;
 	blinking?: boolean;
 }
 
-export const LoadingBox: FunctionComponent<Props> = ({
+export const LoadingBox: FunctionComponent<LoadingBoxProps> = ({
 	className = '',
 	randomWidth = false,
 	blinking = true,

--- a/lib/components/LoadingBox/LoadingBox.tsx
+++ b/lib/components/LoadingBox/LoadingBox.tsx
@@ -35,5 +35,3 @@ export const LoadingBox: FunctionComponent<Props> = ({
 
 const getRandomIntWidth = (max: number, min: number) =>
 	`${Math.random() * (max - min) + min}%`;
-
-export default LoadingBox;

--- a/lib/components/LoadingBox/default.ts
+++ b/lib/components/LoadingBox/default.ts
@@ -1,0 +1,1 @@
+export { LoadingBox as default } from './LoadingBox';

--- a/lib/components/Meta/Meta.stories.tsx
+++ b/lib/components/Meta/Meta.stories.tsx
@@ -3,7 +3,7 @@ import { Meta as ComponentMeta, StoryObj } from '@storybook/react';
 
 import { argTypesExampleIcons } from '../../stories/shared/argTypes';
 
-import { Meta } from '.';
+import { Meta } from './Meta';
 
 export default {
 	title: 'Components/Meta',

--- a/lib/components/Meta/Meta.tsx
+++ b/lib/components/Meta/Meta.tsx
@@ -25,5 +25,3 @@ export const Meta: FunctionComponent<Props> = ({
 		<Text breakWord={breakWord}>{label}</Text>
 	</Inline>
 );
-
-export default Meta;

--- a/lib/components/Meta/Meta.tsx
+++ b/lib/components/Meta/Meta.tsx
@@ -2,9 +2,9 @@ import { IconType } from '@autoguru/icons';
 import * as React from 'react';
 import { ComponentProps, FunctionComponent } from 'react';
 
-import { Icon } from '../Icon';
-import { Inline } from '../Inline';
-import { Text } from '../Text';
+import { Icon } from '../Icon/Icon';
+import { Inline } from '../Inline/Inline';
+import { Text } from '../Text/Text';
 
 import * as styles from './Meta.css';
 

--- a/lib/components/Meta/Meta.tsx
+++ b/lib/components/Meta/Meta.tsx
@@ -8,13 +8,14 @@ import { Text } from '../Text';
 
 import * as styles from './Meta.css';
 
-export interface Props extends Pick<ComponentProps<typeof Text>, 'breakWord'> {
+export interface MetaProps
+	extends Pick<ComponentProps<typeof Text>, 'breakWord'> {
 	icon: IconType;
 	label: string;
 	variant?: keyof typeof styles.variant;
 }
 
-export const Meta: FunctionComponent<Props> = ({
+export const Meta: FunctionComponent<MetaProps> = ({
 	icon,
 	label,
 	variant = 'primary',

--- a/lib/components/Meta/default.ts
+++ b/lib/components/Meta/default.ts
@@ -1,0 +1,1 @@
+export { Meta as default } from './Meta';

--- a/lib/components/MinimalModal/MinimalModal.stories.tsx
+++ b/lib/components/MinimalModal/MinimalModal.stories.tsx
@@ -2,12 +2,11 @@ import { action } from '@storybook/addon-actions';
 import { ArgTypes, Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
-import { Box } from '../Box';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { Text } from '../Text/Text';
 
+import { MinimalModal } from './MinimalModal';
 import * as styles from './MinimalModal.css';
-
-import { MinimalModal } from '.';
 
 const argTypes: ArgTypes = {
 	alignItems: {

--- a/lib/components/MinimalModal/MinimalModal.tsx
+++ b/lib/components/MinimalModal/MinimalModal.tsx
@@ -12,14 +12,14 @@ import { Modal } from '../Modal';
 
 import * as styles from './MinimalModal.css';
 
-export interface Props
+export interface MinimalModalProps
 	extends ComponentProps<typeof Modal>,
 		Pick<ComponentProps<typeof Box>, 'alignItems'> {
 	className?: string;
 	children?: ReactNode;
 }
 
-export const MinimalModal: FunctionComponent<Props> = ({
+export const MinimalModal: FunctionComponent<MinimalModalProps> = ({
 	isOpen,
 	alignItems = 'center',
 	className = '',

--- a/lib/components/MinimalModal/MinimalModal.tsx
+++ b/lib/components/MinimalModal/MinimalModal.tsx
@@ -90,5 +90,3 @@ export const MinimalModal: FunctionComponent<Props> = ({
 		</Modal>
 	);
 };
-
-export default MinimalModal;

--- a/lib/components/MinimalModal/default.ts
+++ b/lib/components/MinimalModal/default.ts
@@ -1,0 +1,1 @@
+export { MinimalModal as default } from './MinimalModal';

--- a/lib/components/Modal/Modal.stories.tsx
+++ b/lib/components/Modal/Modal.stories.tsx
@@ -2,10 +2,10 @@ import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import * as React from 'react';
 
-import { Box } from '../Box';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { Text } from '../Text/Text';
 
-import { Modal } from '.';
+import { Modal } from './Modal';
 
 const meta = {
 	title: 'Components/Modal',

--- a/lib/components/Modal/Modal.tsx
+++ b/lib/components/Modal/Modal.tsx
@@ -15,7 +15,7 @@ import { Portal } from '../Portal';
 
 import * as styles from './Modal.css';
 
-export interface Props extends ComponentProps<typeof Portal> {
+export interface ModalProps extends ComponentProps<typeof Portal> {
 	isOpen: boolean;
 	hideBackdrop?: boolean;
 	disableBackdropClick?: boolean;
@@ -79,7 +79,7 @@ const reducer: Reducer<State, Action> = (prevState, action) => {
 	}
 };
 
-export const Modal: FunctionComponent<Props> = ({
+export const Modal: FunctionComponent<ModalProps> = ({
 	isOpen,
 	hideBackdrop = false,
 	disableBackdropClick = false,
@@ -166,8 +166,8 @@ export const Modal: FunctionComponent<Props> = ({
 
 export const withModal =
 	<TIncomingProps extends {} = {}>(
-		WrappedComponent: ComponentType<Props & TIncomingProps>,
-	): FunctionComponent<Props & TIncomingProps> =>
+		WrappedComponent: ComponentType<ModalProps & TIncomingProps>,
+	): FunctionComponent<ModalProps & TIncomingProps> =>
 	({ onRequestClose, isOpen, ...rest }) => {
 		// TODO: Deprecate me
 		warning(

--- a/lib/components/Modal/Modal.tsx
+++ b/lib/components/Modal/Modal.tsx
@@ -184,5 +184,3 @@ export const withModal =
 			</Modal>
 		);
 	};
-
-export default Modal;

--- a/lib/components/Modal/default.ts
+++ b/lib/components/Modal/default.ts
@@ -1,0 +1,1 @@
+export { Modal as default } from './Modal';

--- a/lib/components/NumberBubble/NumberBubble.stories.tsx
+++ b/lib/components/NumberBubble/NumberBubble.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { NumberBubble } from '.';
+import { NumberBubble } from './NumberBubble';
 
 type Story = StoryObj<typeof NumberBubble>;
 

--- a/lib/components/NumberBubble/NumberBubble.tsx
+++ b/lib/components/NumberBubble/NumberBubble.tsx
@@ -8,7 +8,7 @@ import { Text } from '../Text';
 
 import * as styles from './NumberBubble.css';
 
-export interface Props
+export interface NumberBubbleProps
 	extends Omit<
 		ComponentProps<typeof Box>,
 		'borderRadius' | 'position' | 'padding'
@@ -29,7 +29,7 @@ const valuePaddingMap: Record<
 	X_LARGE: '5',
 };
 
-export const NumberBubble: FunctionComponent<Props> = ({
+export const NumberBubble: FunctionComponent<NumberBubbleProps> = ({
 	value,
 	textColour = 'white',
 	rawNumbers = false,

--- a/lib/components/NumberBubble/NumberBubble.tsx
+++ b/lib/components/NumberBubble/NumberBubble.tsx
@@ -3,8 +3,9 @@ import * as React from 'react';
 import { ComponentProps, FunctionComponent, useMemo } from 'react';
 
 import { toPrettyBigNumber } from '../../utils/number';
-import { Box, boxStyles } from '../Box';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { boxStyles } from '../Box/boxStyles';
+import { Text } from '../Text/Text';
 
 import * as styles from './NumberBubble.css';
 

--- a/lib/components/NumberBubble/NumberBubble.tsx
+++ b/lib/components/NumberBubble/NumberBubble.tsx
@@ -66,5 +66,3 @@ export const NumberBubble: FunctionComponent<Props> = ({
 		</Box>
 	);
 };
-
-export default NumberBubble;

--- a/lib/components/NumberBubble/default.ts
+++ b/lib/components/NumberBubble/default.ts
@@ -1,0 +1,1 @@
+export { NumberBubble as default } from './NumberBubble';

--- a/lib/components/NumberInput/NumberInput.stories.tsx
+++ b/lib/components/NumberInput/NumberInput.stories.tsx
@@ -5,9 +5,9 @@ import isChromatic from 'chromatic/isChromatic';
 import React, { type ComponentProps } from 'react';
 
 import { argTypesExampleIcons } from '../../stories/shared/argTypes';
-import { DateInput } from '../DateInput';
+import { DateInput } from '../DateInput/DateInput';
 
-import { NumberInput } from '.';
+import { NumberInput } from './NumberInput';
 
 const defaultValue = isChromatic()
 	? '42'

--- a/lib/components/NumberInput/NumberInput.tsx
+++ b/lib/components/NumberInput/NumberInput.tsx
@@ -68,5 +68,3 @@ export const NumberInput = withEnhancedInput<Props>(
 		primitiveType: type,
 	},
 );
-
-export default NumberInput;

--- a/lib/components/NumberInput/NumberInput.tsx
+++ b/lib/components/NumberInput/NumberInput.tsx
@@ -17,11 +17,11 @@ type InputAttributes = Pick<
 	'min' | 'max' | 'onChange' | 'onFocus' | 'onBlur' | 'step' | 'value'
 >;
 
-interface Props extends InputAttributes {
+interface NumberInputProps extends InputAttributes {
 	preventMouseWheel?: boolean;
 }
 
-export const NumberInput = withEnhancedInput<Props>(
+export const NumberInput = withEnhancedInput<NumberInputProps>(
 	({
 		field: { ref, ...incomingFieldProps },
 		eventHandlers,

--- a/lib/components/NumberInput/default.ts
+++ b/lib/components/NumberInput/default.ts
@@ -1,0 +1,1 @@
+export { NumberInput as default } from './NumberInput';

--- a/lib/components/NumberInput/useNumberInputBehaviours.ts
+++ b/lib/components/NumberInput/useNumberInputBehaviours.ts
@@ -10,7 +10,7 @@ import {
 
 import { EnhanceInputPrimitiveProps } from '../private/InputBase/withEnhancedInput';
 
-interface Props {
+interface UseNumberInputBehaviourProps {
 	value: EnhanceInputPrimitiveProps<HTMLInputElement>['value'];
 	ref: RefObject<HTMLInputElement>;
 	preventMouseWheel: boolean;
@@ -34,7 +34,7 @@ export const useNumberInputBehaviours = ({
 	onFocus: incomingOnFocus,
 	onChange: incomingOnChange,
 	value,
-}: Props): Returns => {
+}: UseNumberInputBehaviourProps): Returns => {
 	const inputRef = useRef<HTMLInputElement>(ref?.current);
 	const [isFocused, setIsFocused] = useState(false);
 	const [displayValue, setDisplayValue] = useState<string | undefined>(value);

--- a/lib/components/OptionGrid/default.ts
+++ b/lib/components/OptionGrid/default.ts
@@ -1,0 +1,1 @@
+export { OptionGrid as default } from './OptionGrid';

--- a/lib/components/OptionList/default.ts
+++ b/lib/components/OptionList/default.ts
@@ -1,0 +1,1 @@
+export { OptionList as default } from './OptionList';

--- a/lib/components/OrderedList/OrderedList.stories.tsx
+++ b/lib/components/OrderedList/OrderedList.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Text } from '../Text';
+import { Text } from '../Text/Text';
 
-import { OrderedList } from '.';
+import { OrderedList } from './OrderedList';
 
 export default {
 	title: 'Primatives/Ordered List',

--- a/lib/components/OrderedList/OrderedList.tsx
+++ b/lib/components/OrderedList/OrderedList.tsx
@@ -78,5 +78,3 @@ const Item: FunctionComponent<ItemProps> = ({ className = '', children }) => (
 );
 
 OrderedList.Item = Item;
-
-export default OrderedList;

--- a/lib/components/OrderedList/OrderedList.tsx
+++ b/lib/components/OrderedList/OrderedList.tsx
@@ -24,7 +24,7 @@ const cycles: ListStyleType[] = [
 	'lower-roman',
 ];
 
-export interface Props
+export interface OrderedListProps
 	extends Pick<OlHTMLAttributes<HTMLOListElement>, 'start'> {
 	type?: ListStyleType;
 	className?: string;
@@ -38,7 +38,7 @@ export interface ItemProps {
 
 const OrderedListContext = createContext(-1);
 
-export const OrderedList: FunctionComponent<Props> & {
+export const OrderedList: FunctionComponent<OrderedListProps> & {
 	Item: FunctionComponent<ItemProps>;
 } = ({ children, className = '', type = null, start }) => {
 	const cycle = useContext(OrderedListContext);

--- a/lib/components/OrderedList/default.ts
+++ b/lib/components/OrderedList/default.ts
@@ -1,0 +1,1 @@
+export { OrderedList as default } from './OrderedList';

--- a/lib/components/OutsideClick/OutsideClick.stories.tsx
+++ b/lib/components/OutsideClick/OutsideClick.stories.tsx
@@ -2,9 +2,9 @@ import { action } from '@storybook/addon-actions';
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Button } from '../Button';
+import { Button } from '../Button/Button';
 
-import { OutsideClick } from '.';
+import { OutsideClick } from './OutsideClick';
 
 export default {
 	title: 'Utility/OutsideClick',

--- a/lib/components/OutsideClick/OutsideClick.tsx
+++ b/lib/components/OutsideClick/OutsideClick.tsx
@@ -61,13 +61,13 @@ const bindEvent = <
 	};
 };
 
-export interface Props {
+export interface OutsideClickProps {
 	children: ReactElement;
 
 	onOutsideClick?(): void;
 }
 
-export const OutsideClick: FunctionComponent<Props> = ({
+export const OutsideClick: FunctionComponent<OutsideClickProps> = ({
 	children,
 	onOutsideClick = noop,
 }) => {

--- a/lib/components/OutsideClick/OutsideClick.tsx
+++ b/lib/components/OutsideClick/OutsideClick.tsx
@@ -88,5 +88,3 @@ export const OutsideClick: FunctionComponent<Props> = ({
 		ref: rootClickRef,
 	});
 };
-
-export default OutsideClick;

--- a/lib/components/OutsideClick/default.ts
+++ b/lib/components/OutsideClick/default.ts
@@ -1,0 +1,1 @@
+export { OutsideClick as default } from './OutsideClick';

--- a/lib/components/OverdriveProvider/OverdriveProvider.stories.tsx
+++ b/lib/components/OverdriveProvider/OverdriveProvider.stories.tsx
@@ -2,12 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
 import flatRed from '../../themes/flat_red';
-import { Box } from '../Box';
-import { Button } from '../Button';
-import { Inline } from '../Inline';
-import { Stack } from '../Stack';
+import { Box } from '../Box/Box';
+import { Button } from '../Button/Button';
+import { Inline } from '../Inline/Inline';
+import { Stack } from '../Stack/Stack';
 
-import { OverdriveProvider } from '.';
+import { OverdriveProvider } from './OverdriveProvider';
 
 const meta: Meta<typeof OverdriveProvider> = {
 	title: 'Utility/OverdriveProvider',

--- a/lib/components/OverdriveProvider/default.ts
+++ b/lib/components/OverdriveProvider/default.ts
@@ -1,0 +1,1 @@
+export { OverdriveProvider as default } from './OverdriveProvider';

--- a/lib/components/Pagination/Bubble.tsx
+++ b/lib/components/Pagination/Bubble.tsx
@@ -12,7 +12,7 @@ import { useTextStyles } from '../Text';
 
 import * as styles from './Pagination.css';
 
-export interface Props {
+export interface BubbleProps {
 	selected?: boolean;
 	disabled?: boolean;
 	gap?: boolean;
@@ -21,7 +21,7 @@ export interface Props {
 	children?: ReactNode;
 }
 
-export const Bubble: FunctionComponent<Props> = ({
+export const Bubble: FunctionComponent<BubbleProps> = ({
 	className = '',
 	selected = false,
 	gap = false,

--- a/lib/components/Pagination/Bubble.tsx
+++ b/lib/components/Pagination/Bubble.tsx
@@ -64,5 +64,3 @@ export const Bubble: FunctionComponent<Props> = ({
 		</Box>
 	);
 };
-
-export default Bubble;

--- a/lib/components/Pagination/Pagination.stories.tsx
+++ b/lib/components/Pagination/Pagination.stories.tsx
@@ -2,9 +2,9 @@ import { action } from '@storybook/addon-actions';
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
-import { Pagination } from '.';
+import { Pagination } from './Pagination';
 
 export default {
 	title: 'Components/Pagination',

--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -236,5 +236,3 @@ function buildPagesList(
 
 	return generateJumpBackwardArray(numPages, numPagesDisplayed);
 }
-
-export default Pagination;

--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -23,7 +23,7 @@ interface OnChangeObject {
 
 export type TOnChangeEventHandler = (event: OnChangeObject) => void;
 
-export interface Props {
+export interface PaginationProps {
 	numPagesDisplayed?: number;
 	activePage: number;
 	total: number;
@@ -88,7 +88,7 @@ const Loading: FunctionComponent<LoadingComponentProps> = ({
 	</Inline>
 );
 
-export const Pagination: FunctionComponent<Props> = ({
+export const Pagination: FunctionComponent<PaginationProps> = ({
 	total,
 	pageSize,
 	activePage,

--- a/lib/components/Pagination/default.ts
+++ b/lib/components/Pagination/default.ts
@@ -1,0 +1,1 @@
+export { Pagination as default } from './Pagination';

--- a/lib/components/Portal/Portal.stories.tsx
+++ b/lib/components/Portal/Portal.stories.tsx
@@ -1,11 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Heading } from '../Heading';
-import { Stack } from '../Stack';
-import { Text } from '../Text';
+import { Heading } from '../Heading/Heading';
+import { Stack } from '../Stack/Stack';
+import { Text } from '../Text/Text';
 
-import { Portal } from '.';
+import { Portal } from './Portal';
 
 export default {
 	title: 'Utility/Portal',

--- a/lib/components/Portal/Portal.tsx
+++ b/lib/components/Portal/Portal.tsx
@@ -62,5 +62,3 @@ function Portal(
 
 const _Portal = forwardRef(Portal);
 export { _Portal as Portal };
-
-export default Portal;

--- a/lib/components/Portal/default.ts
+++ b/lib/components/Portal/default.ts
@@ -1,0 +1,1 @@
+export { Portal as default } from './Portal';

--- a/lib/components/Positioner/Positioner.stories.tsx
+++ b/lib/components/Positioner/Positioner.stories.tsx
@@ -2,13 +2,12 @@ import { Meta, StoryObj } from '@storybook/react';
 import isChromatic from 'chromatic/isChromatic';
 import React, { useRef } from 'react';
 
-import { Box } from '../Box';
-import { Button } from '../Button';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { Button } from '../Button/Button';
+import { Text } from '../Text/Text';
 
+import { Positioner } from './Positioner';
 import { EAlignment } from './alignment';
-
-import { Positioner } from '.';
 
 export default {
 	title: 'Layout/Positioner',

--- a/lib/components/Positioner/Positioner.tsx
+++ b/lib/components/Positioner/Positioner.tsx
@@ -167,5 +167,3 @@ const convertPlacement = (alignment: EAlignment): Placement => {
 		}
 	}
 };
-
-export default Positioner;

--- a/lib/components/Positioner/Positioner.tsx
+++ b/lib/components/Positioner/Positioner.tsx
@@ -40,7 +40,7 @@ const createPopper = popperGenerator({
 	},
 });
 
-export interface Props
+export interface PositionerProps
 	extends Exclude<
 		ComponentPropsWithoutRef<typeof Box>,
 		'aria-hidden' | 'className'
@@ -52,7 +52,7 @@ export interface Props
 	children?: ReactNode;
 }
 
-export const Positioner: FunctionComponent<Props> = ({
+export const Positioner: FunctionComponent<PositionerProps> = ({
 	alignment = EAlignment.BOTTOM_LEFT,
 	isOpen = false,
 	triggerRef,

--- a/lib/components/Positioner/default.ts
+++ b/lib/components/Positioner/default.ts
@@ -1,0 +1,1 @@
+export { Positioner as default } from './Positioner';

--- a/lib/components/ProgressBar/ProgressBar.stories.tsx
+++ b/lib/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Stack } from '../Stack';
+import { Stack } from '../Stack/Stack';
 
-import { ProgressBar } from '.';
+import { ProgressBar } from './ProgressBar';
 
 export default {
 	title: 'Components/Progress/Progress Bar',

--- a/lib/components/ProgressBar/ProgressBar.tsx
+++ b/lib/components/ProgressBar/ProgressBar.tsx
@@ -10,13 +10,13 @@ import * as styles from './ProgressBar.css';
 const colours: ReadonlyArray<'red' | 'green' | 'blue' | 'yellow' | 'neutral'> =
 	['red', 'green', 'blue', 'yellow', 'neutral'] as const;
 
-export interface Props {
+export interface ProgressBarProps {
 	value?: number;
 	colour?: (typeof colours)[number];
 }
 
 const backgroundColorMap: Record<
-	Required<Props>['colour'],
+	Required<ProgressBarProps>['colour'],
 	ComponentProps<typeof Box>['backgroundColour']
 > = {
 	red: 'red500',
@@ -26,7 +26,7 @@ const backgroundColorMap: Record<
 	neutral: 'gray500',
 };
 
-export const ProgressBar: FunctionComponent<Props> = ({
+export const ProgressBar: FunctionComponent<ProgressBarProps> = ({
 	value = 0,
 	colour = 'green',
 }) => (

--- a/lib/components/ProgressBar/ProgressBar.tsx
+++ b/lib/components/ProgressBar/ProgressBar.tsx
@@ -45,5 +45,3 @@ export const ProgressBar: FunctionComponent<Props> = ({
 		/>
 	</Box>
 );
-
-export default ProgressBar;

--- a/lib/components/ProgressBar/default.ts
+++ b/lib/components/ProgressBar/default.ts
@@ -1,0 +1,1 @@
+export { ProgressBar as default } from './ProgressBar';

--- a/lib/components/ProgressBarGroup/ProgressBarGroup.stories.tsx
+++ b/lib/components/ProgressBarGroup/ProgressBarGroup.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProgressBarGroup } from '.';
+import { ProgressBarGroup } from './ProgressBarGroup';
 
 type Story = StoryObj<typeof ProgressBarGroup>;
 

--- a/lib/components/ProgressBarGroup/ProgressBarGroup.tsx
+++ b/lib/components/ProgressBarGroup/ProgressBarGroup.tsx
@@ -49,5 +49,3 @@ export const ProgressBarGroup: FunctionComponent<Props> = ({
 		</Box>
 	);
 };
-
-export default ProgressBarGroup;

--- a/lib/components/ProgressBarGroup/ProgressBarGroup.tsx
+++ b/lib/components/ProgressBarGroup/ProgressBarGroup.tsx
@@ -7,7 +7,7 @@ import { Text } from '../Text';
 
 import * as styles from './ProgressBarGroup.css';
 
-export interface Props
+export interface ProgressBarGroupProps
 	extends Pick<ComponentProps<typeof ProgressBar>, 'colour'> {
 	prefixLabels?: string[];
 	suffixLabels?: string[];
@@ -15,7 +15,7 @@ export interface Props
 	values: number[];
 }
 
-export const ProgressBarGroup: FunctionComponent<Props> = ({
+export const ProgressBarGroup: FunctionComponent<ProgressBarGroupProps> = ({
 	prefixLabels,
 	suffixLabels,
 	values,

--- a/lib/components/ProgressBarGroup/ProgressBarGroup.tsx
+++ b/lib/components/ProgressBarGroup/ProgressBarGroup.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { ComponentProps, Fragment, FunctionComponent } from 'react';
 
-import { Box } from '../Box';
-import { ProgressBar } from '../ProgressBar';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { ProgressBar } from '../ProgressBar/ProgressBar';
+import { Text } from '../Text/Text';
 
 import * as styles from './ProgressBarGroup.css';
 

--- a/lib/components/ProgressBarGroup/default.ts
+++ b/lib/components/ProgressBarGroup/default.ts
@@ -1,0 +1,1 @@
+export { ProgressBarGroup as default } from './ProgressBarGroup';

--- a/lib/components/ProgressSpinner/ProgressSpinner.stories.tsx
+++ b/lib/components/ProgressSpinner/ProgressSpinner.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { ProgressSpinner } from '.';
+import { ProgressSpinner } from './ProgressSpinner';
 
 export default {
 	title: 'Primatives/Progress Spinner',

--- a/lib/components/ProgressSpinner/ProgressSpinner.tsx
+++ b/lib/components/ProgressSpinner/ProgressSpinner.tsx
@@ -6,13 +6,13 @@ import { Box, boxStyles } from '../Box';
 
 import * as styles from './ProgressSpinner.css';
 
-export interface Props {
+export interface ProgressSpinnerProps {
 	className?: string;
 	size?: keyof typeof styles.size;
 	colour?: keyof typeof styles.colours;
 }
 
-export const ProgressSpinner: FunctionComponent<Props> = ({
+export const ProgressSpinner: FunctionComponent<ProgressSpinnerProps> = ({
 	className = '',
 	colour = 'primary',
 	size = 'medium',

--- a/lib/components/ProgressSpinner/ProgressSpinner.tsx
+++ b/lib/components/ProgressSpinner/ProgressSpinner.tsx
@@ -46,5 +46,3 @@ export const ProgressSpinner: FunctionComponent<Props> = ({
 		</svg>
 	</Box>
 );
-
-export default ProgressSpinner;

--- a/lib/components/ProgressSpinner/default.ts
+++ b/lib/components/ProgressSpinner/default.ts
@@ -1,0 +1,1 @@
+export { ProgressSpinner as default } from './ProgressSpinner';

--- a/lib/components/Radio/Radio.stories.tsx
+++ b/lib/components/Radio/Radio.stories.tsx
@@ -2,7 +2,8 @@ import { StoryObj, Meta } from '@storybook/react';
 import { fn } from '@storybook/test';
 import React, { type ComponentProps } from 'react';
 
-import { Radio, RadioGroup as RadioGroupComponent } from '.';
+import { Radio } from './Radio';
+import { RadioGroup as RadioGroupComponent } from './RadioGroup';
 
 const listData: Array<{ label: string; value: string }> = [
 	{ label: 'Avocado', value: 'avocado' },

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -9,14 +9,14 @@ import { checkableIndicator } from '../private/CheckableBase/CheckableBase.css';
 import * as styles from './Radio.css';
 import { useRadioContext } from './RadioGroup';
 
-export interface Props {
+export interface RadioProps {
 	value: string;
 	className?: string;
 	disabled?: boolean;
 	children?: ReactNode;
 }
 
-export const Radio = forwardRef<HTMLInputElement, Props>(
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(
 	({ value, className = '', children, disabled = false }, ref) => {
 		const radioContext = useRadioContext();
 

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -52,5 +52,3 @@ export const Radio = forwardRef<HTMLInputElement, Props>(
 );
 
 Radio.displayName = 'Radio';
-
-export default Radio;

--- a/lib/components/Radio/RadioGroup.tsx
+++ b/lib/components/Radio/RadioGroup.tsx
@@ -8,7 +8,7 @@ import React, {
 
 import { Box } from '../Box';
 
-export interface Props {
+export interface RadioGroupProps {
 	name: string;
 	className?: string;
 	value: string;
@@ -29,7 +29,7 @@ export const RadioContext = createContext<RadioGroupContext | null>(null);
 export const useRadioContext = (): RadioGroupContext =>
 	useContext(RadioContext)!;
 
-export const RadioGroup = forwardRef<HTMLDivElement, Props>(
+export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
 	({ name, value, className = '', onChange, children }, ref) => {
 		const contextValue = useMemo(
 			() => ({ value, inputName: name, radioSelected: onChange }),

--- a/lib/components/Radio/RadioGroup.tsx
+++ b/lib/components/Radio/RadioGroup.tsx
@@ -55,5 +55,3 @@ export const RadioGroup = forwardRef<HTMLDivElement, Props>(
 );
 
 RadioGroup.displayName = 'RadioGroup';
-
-export default RadioGroup;

--- a/lib/components/Radio/default.ts
+++ b/lib/components/Radio/default.ts
@@ -1,0 +1,1 @@
+export { Radio as default } from './Radio';

--- a/lib/components/ScrollPane/ScrollPane.stories.tsx
+++ b/lib/components/ScrollPane/ScrollPane.stories.tsx
@@ -1,12 +1,12 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Box } from '../Box';
-import { Heading } from '../Heading';
-import { StickyBox } from '../StickyBox';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { Heading } from '../Heading/Heading';
+import { StickyBox } from '../StickyBox/StickyBox';
+import { Text } from '../Text/Text';
 
-import { ScrollPane } from '.';
+import { ScrollPane } from './ScrollPane';
 
 export default {
 	title: 'Layout/Scroll Pane',

--- a/lib/components/ScrollPane/ScrollPane.tsx
+++ b/lib/components/ScrollPane/ScrollPane.tsx
@@ -6,7 +6,8 @@ import { Box } from '../Box';
 
 import * as styles from './ScrollPane.css';
 
-export interface Props extends Omit<ComponentProps<typeof Box>, 'overflow'> {
+export interface ScrollPaneProps
+	extends Omit<ComponentProps<typeof Box>, 'overflow'> {
 	bottomGap?: keyof Tokens['space'];
 	serverVhFallback?: number;
 	includeMobile?: boolean;
@@ -14,7 +15,7 @@ export interface Props extends Omit<ComponentProps<typeof Box>, 'overflow'> {
 	className?: string;
 }
 
-export const ScrollPane = forwardRef<HTMLDivElement, Props>(
+export const ScrollPane = forwardRef<HTMLDivElement, ScrollPaneProps>(
 	({ className = '', rounded = false, ...rest }, ref) => (
 		<Box
 			ref={ref}

--- a/lib/components/ScrollPane/default.ts
+++ b/lib/components/ScrollPane/default.ts
@@ -1,0 +1,1 @@
+export { ScrollPane as default } from './ScrollPane';

--- a/lib/components/SearchBar/default.ts
+++ b/lib/components/SearchBar/default.ts
@@ -1,0 +1,1 @@
+export { SearchBar as default } from './SearchBar';

--- a/lib/components/Section/Section.stories.tsx
+++ b/lib/components/Section/Section.stories.tsx
@@ -2,9 +2,9 @@ import { Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
 import { boxArgTypes } from '../../stories/shared/argTypes-box';
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
-import { Section } from '.';
+import { Section } from './Section';
 
 export default {
 	title: 'Layout/Section',

--- a/lib/components/Section/default.ts
+++ b/lib/components/Section/default.ts
@@ -1,0 +1,1 @@
+export { Section as default } from './Section';

--- a/lib/components/SelectInput/SelectInput.stories.tsx
+++ b/lib/components/SelectInput/SelectInput.stories.tsx
@@ -4,9 +4,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
 import { argTypesExampleIcons } from '../../stories/shared/argTypes';
-import { DateInput } from '../DateInput';
+import { DateInput } from '../DateInput/DateInput';
 
-import { SelectInput } from '.';
+import { SelectInput } from './SelectInput';
 
 const valueOptions = ['Kia', 'Toyota', 'BMW', 'Mitsubishi', 'Hyundai'];
 const selectOptions = valueOptions.map((item) => (

--- a/lib/components/SelectInput/SelectInput.tsx
+++ b/lib/components/SelectInput/SelectInput.tsx
@@ -2,8 +2,8 @@ import { ChevronDownIcon } from '@autoguru/icons';
 import clsx from 'clsx';
 import React from 'react';
 
-import { Box } from '../Box';
-import { Icon } from '../Icon';
+import { Box } from '../Box/Box';
+import { Icon } from '../Icon/Icon';
 import { withEnhancedInput } from '../private/InputBase';
 
 import * as styles from './SelectInput.css';

--- a/lib/components/SelectInput/SelectInput.tsx
+++ b/lib/components/SelectInput/SelectInput.tsx
@@ -69,5 +69,3 @@ export const SelectInput = withEnhancedInput<
 		withSuffixIcon: false,
 	},
 );
-
-export default SelectInput;

--- a/lib/components/SelectInput/default.ts
+++ b/lib/components/SelectInput/default.ts
@@ -1,0 +1,1 @@
+export { SelectInput as default } from './SelectInput';

--- a/lib/components/SimplePagination/SimplePagination.stories.tsx
+++ b/lib/components/SimplePagination/SimplePagination.stories.tsx
@@ -2,9 +2,9 @@ import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
-import { SimplePagination } from '.';
+import { SimplePagination } from './SimplePagination';
 
 const meta = {
 	title: 'Primatives/Simple Pagination',

--- a/lib/components/SimplePagination/SimplePagination.tsx
+++ b/lib/components/SimplePagination/SimplePagination.tsx
@@ -14,13 +14,13 @@ export enum EChangeDirection {
 
 type TOnChangeEventHandler = (event: EChangeDirection) => void;
 
-export interface Props {
+export interface SimplePaginationProps {
 	hasNext?: boolean;
 	hasPrevious?: boolean;
 	onChange?: TOnChangeEventHandler;
 }
 
-export const SimplePagination: FunctionComponent<Props> = ({
+export const SimplePagination: FunctionComponent<SimplePaginationProps> = ({
 	hasNext = false,
 	hasPrevious = false,
 	onChange = noop,

--- a/lib/components/SimplePagination/SimplePagination.tsx
+++ b/lib/components/SimplePagination/SimplePagination.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { FunctionComponent } from 'react';
 
 import { noop } from '../../utils';
-import { Button } from '../Button';
-import { Icon } from '../Icon';
-import { Inline } from '../Inline';
+import { Button } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
+import { Inline } from '../Inline/Inline';
 
 export enum EChangeDirection {
 	Previous = 'previous',

--- a/lib/components/SimplePagination/SimplePagination.tsx
+++ b/lib/components/SimplePagination/SimplePagination.tsx
@@ -62,5 +62,3 @@ export const SimplePagination: FunctionComponent<Props> = ({
 		</Inline>
 	);
 };
-
-export default SimplePagination;

--- a/lib/components/SimplePagination/default.ts
+++ b/lib/components/SimplePagination/default.ts
@@ -1,0 +1,1 @@
+export { SimplePagination as default } from './SimplePagination';

--- a/lib/components/SliderProgress/ProgressStep.tsx
+++ b/lib/components/SliderProgress/ProgressStep.tsx
@@ -6,7 +6,8 @@ import { Box } from '../Box';
 
 import * as styles from './ProgressStep.css';
 
-interface Props extends Pick<ComponentProps<typeof Box>, 'backgroundColour'> {
+interface ProgressStepProps
+	extends Pick<ComponentProps<typeof Box>, 'backgroundColour'> {
 	className?: string;
 	paused: boolean;
 	isActive: boolean;
@@ -16,7 +17,7 @@ interface Props extends Pick<ComponentProps<typeof Box>, 'backgroundColour'> {
 	onFinished(): void;
 }
 
-export const ProgressStep: NamedExoticComponent<Props> = memo(
+export const ProgressStep: NamedExoticComponent<ProgressStepProps> = memo(
 	({
 		className = '',
 		paused,

--- a/lib/components/SliderProgress/SliderProgress.stories.tsx
+++ b/lib/components/SliderProgress/SliderProgress.stories.tsx
@@ -3,9 +3,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
 import { boxArgTypes } from '../../stories/shared/argTypes-box';
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
-import { SliderProgress } from '.';
+import { SliderProgress } from './SliderProgress';
 
 const meta = {
 	title: 'Components/Progress/Slider Progress',

--- a/lib/components/SliderProgress/SliderProgress.tsx
+++ b/lib/components/SliderProgress/SliderProgress.tsx
@@ -7,7 +7,7 @@ import { Box } from '../Box';
 import { ProgressStep } from './ProgressStep';
 import * as styles from './SliderProgress.css';
 
-export interface Props
+export interface SliderProgressProps
 	extends Pick<ComponentProps<typeof Box>, 'backgroundColour'>,
 		Pick<ComponentProps<typeof ProgressStep>, 'paused' | 'duration'> {
 	className?: string;
@@ -17,7 +17,7 @@ export interface Props
 	onRequestNext(): void;
 }
 
-export const SliderProgress: NamedExoticComponent<Props> = memo(
+export const SliderProgress: NamedExoticComponent<SliderProgressProps> = memo(
 	({
 		className = '',
 		paused,

--- a/lib/components/SliderProgress/default.ts
+++ b/lib/components/SliderProgress/default.ts
@@ -1,0 +1,1 @@
+export { SliderProgress as default } from './SliderProgress';

--- a/lib/components/Stack/Stack.stories.tsx
+++ b/lib/components/Stack/Stack.stories.tsx
@@ -2,9 +2,9 @@ import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
 // import { boxArgTypes } from '../Box/argTypes';
-import { Text } from '../Text';
+import { Text } from '../Text/Text';
 
-import { Stack } from '.';
+import { Stack } from './Stack';
 
 // const spacingOptions: Record<string, ComponentProps<typeof Stack>['space']> = {
 // 	none: 'none',

--- a/lib/components/Stack/default.ts
+++ b/lib/components/Stack/default.ts
@@ -1,0 +1,1 @@
+export { Stack as default } from './Stack';

--- a/lib/components/StandardModal/StandardModal.stories.tsx
+++ b/lib/components/StandardModal/StandardModal.stories.tsx
@@ -2,10 +2,10 @@ import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Box } from '../Box';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { Text } from '../Text/Text';
 
-import { StandardModal } from '.';
+import { StandardModal } from './StandardModal';
 
 const meta = {
 	title: 'Components/Modal: Standard with Title',

--- a/lib/components/StandardModal/StandardModal.tsx
+++ b/lib/components/StandardModal/StandardModal.tsx
@@ -9,12 +9,12 @@ import * as React from 'react';
 import { useLayoutEffect, useRef } from 'react';
 
 import { isBrowser, useEventCallback, useId } from '../../utils';
-import { Box } from '../Box';
-import { Button } from '../Button';
-import { Heading } from '../Heading';
-import { Icon } from '../Icon';
-import { Modal } from '../Modal';
-import { useTextStyles } from '../Text';
+import { Box } from '../Box/Box';
+import { Button } from '../Button/Button';
+import { Heading } from '../Heading/Heading';
+import { Icon } from '../Icon/Icon';
+import { Modal } from '../Modal/Modal';
+import { useTextStyles } from '../Text/useTextStyles';
 
 import * as styles from './StandardModal.css';
 

--- a/lib/components/StandardModal/StandardModal.tsx
+++ b/lib/components/StandardModal/StandardModal.tsx
@@ -26,13 +26,13 @@ export enum ESize {
 
 type Size = 'skinny' | 'narrow' | 'standard';
 
-export interface Props extends ComponentProps<typeof Modal> {
+export interface StandardModalProps extends ComponentProps<typeof Modal> {
 	size?: ESize | Size;
 	className?: string;
 	title: string;
 }
 
-export const StandardModal: FunctionComponent<Props> = ({
+export const StandardModal: FunctionComponent<StandardModalProps> = ({
 	isOpen,
 	size = 'standard',
 	className = '',

--- a/lib/components/StandardModal/StandardModal.tsx
+++ b/lib/components/StandardModal/StandardModal.tsx
@@ -160,5 +160,3 @@ export const StandardModal: FunctionComponent<Props> = ({
 		</Modal>
 	);
 };
-
-export default StandardModal;

--- a/lib/components/StandardModal/default.ts
+++ b/lib/components/StandardModal/default.ts
@@ -1,0 +1,1 @@
+export { StandardModal as default } from './StandardModal';

--- a/lib/components/StarRating/StarRating.stories.tsx
+++ b/lib/components/StarRating/StarRating.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { EStarRatingSize, StarRating } from '.';
+import { EStarRatingSize, StarRating } from './StarRating';
 
 const meta = {
 	title: 'Components/Star Rating',

--- a/lib/components/StarRating/StarRating.tsx
+++ b/lib/components/StarRating/StarRating.tsx
@@ -4,10 +4,11 @@ import * as React from 'react';
 import { FunctionComponent, memo, NamedExoticComponent } from 'react';
 
 import { ThemeTokens as Tokens } from '../../themes';
-import { Box, boxStyles } from '../Box';
-import { Icon } from '../Icon';
-import { Inline } from '../Inline';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { boxStyles } from '../Box/boxStyles';
+import { Icon } from '../Icon/Icon';
+import { Inline } from '../Inline/Inline';
+import { Text } from '../Text/Text';
 
 import * as styles from './StarRating.css';
 

--- a/lib/components/StarRating/StarRating.tsx
+++ b/lib/components/StarRating/StarRating.tsx
@@ -132,5 +132,3 @@ const Star: FunctionComponent<StarProps> = ({
 		/>
 	);
 };
-
-export default StarRating;

--- a/lib/components/StarRating/StarRating.tsx
+++ b/lib/components/StarRating/StarRating.tsx
@@ -37,14 +37,14 @@ const labelSizeMap: Map<EStarRatingSize, keyof Tokens['typography']['size']> =
 		[EStarRatingSize.Medium, '4'],
 	]);
 
-export interface Props {
+export interface StarRatingProps {
 	className?: string; // TODO: Remove this in the future
 	rating: number;
 	size?: EStarRatingSize;
 	label?: string;
 }
 
-export const StarRating: NamedExoticComponent<Props> = memo(
+export const StarRating: NamedExoticComponent<StarRatingProps> = memo(
 	({
 		className = '',
 		rating,

--- a/lib/components/StarRating/default.ts
+++ b/lib/components/StarRating/default.ts
@@ -1,0 +1,1 @@
+export { StarRating as default } from './StarRating';

--- a/lib/components/Stepper/Stepper.stories.tsx
+++ b/lib/components/Stepper/Stepper.stories.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
 
-import { Stepper } from '.';
+import { Stepper } from './Stepper';
 
 const meta = {
 	title: 'Forms & Input Fields/Stepper',

--- a/lib/components/Stepper/Stepper.tsx
+++ b/lib/components/Stepper/Stepper.tsx
@@ -17,7 +17,7 @@ import { Text, useTextStyles } from '../Text';
 
 import * as styles from './Stepper.css';
 
-export interface Props {
+export interface StepperProps {
 	className?: string;
 	disabled?: boolean;
 	value?: number;
@@ -79,7 +79,7 @@ const Handle: FunctionComponent<HandleProps> = ({
 	</Box>
 );
 
-export const Stepper: FunctionComponent<Props> = ({
+export const Stepper: FunctionComponent<StepperProps> = ({
 	className = '',
 	disabled: incomingDisabled = false,
 	isFullWidth = false,

--- a/lib/components/Stepper/Stepper.tsx
+++ b/lib/components/Stepper/Stepper.tsx
@@ -10,10 +10,12 @@ import {
 } from 'react';
 
 import { addWithSafeDecimal } from '../../utils/number';
-import { Box, boxStyles } from '../Box';
-import { Icon } from '../Icon';
-import { Inline } from '../Inline';
-import { Text, useTextStyles } from '../Text';
+import { Box } from '../Box/Box';
+import { boxStyles } from '../Box/boxStyles';
+import { Icon } from '../Icon/Icon';
+import { Inline } from '../Inline/Inline';
+import { Text } from '../Text/Text';
+import { useTextStyles } from '../Text/useTextStyles';
 
 import * as styles from './Stepper.css';
 

--- a/lib/components/Stepper/Stepper.tsx
+++ b/lib/components/Stepper/Stepper.tsx
@@ -198,5 +198,3 @@ export const Stepper: FunctionComponent<Props> = ({
 		</Box>
 	);
 };
-
-export default Stepper;

--- a/lib/components/Stepper/default.ts
+++ b/lib/components/Stepper/default.ts
@@ -1,0 +1,1 @@
+export { Stepper as default } from './Stepper';

--- a/lib/components/StickyBox/StickyBox.stories.tsx
+++ b/lib/components/StickyBox/StickyBox.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Box } from '../Box';
-import { FillHeightBox } from '../FillHeightBox';
-import { Heading } from '../Heading';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { FillHeightBox } from '../FillHeightBox/FillHeightBox';
+import { Heading } from '../Heading/Heading';
+import { Text } from '../Text/Text';
 
-import { StickyBox } from '.';
+import { StickyBox } from './StickyBox';
 
 const meta = {
 	title: 'Layout/StickyBox',

--- a/lib/components/StickyBox/StickyBox.tsx
+++ b/lib/components/StickyBox/StickyBox.tsx
@@ -6,7 +6,7 @@ import { Box } from '../Box';
 
 import * as styles from './StickyBox.css';
 
-export interface Props extends ComponentProps<typeof Box> {
+export interface StickyBoxProps extends ComponentProps<typeof Box> {
 	top?: 'none' | '1' | '2' | '3' | '5' | '7' | 'subHeader';
 	bottom?: 'none' | '1' | '2' | '3' | 'subHeader';
 	zIndex?: 0 | 1 | 2 | 3 | 99;
@@ -14,7 +14,7 @@ export interface Props extends ComponentProps<typeof Box> {
 	className?: string;
 }
 
-export const StickyBox: FunctionComponent<Props> = ({
+export const StickyBox: FunctionComponent<StickyBoxProps> = ({
 	top = 'none',
 	bottom = 'none',
 	noPopShadow = false,

--- a/lib/components/StickyBox/default.ts
+++ b/lib/components/StickyBox/default.ts
@@ -1,0 +1,1 @@
+export { StickyBox as default } from './StickyBox';

--- a/lib/components/Switch/Switch.stories.tsx
+++ b/lib/components/Switch/Switch.stories.tsx
@@ -2,12 +2,11 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import React from 'react';
 
-import { Box } from '../Box';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { Text } from '../Text/Text';
 
+import { Switch } from './Switch';
 import { storyLabel } from './Switch.css';
-
-import { Switch } from '.';
 
 const meta: Meta<typeof Switch> = {
 	title: 'Primatives/Switch',

--- a/lib/components/Switch/Switch.tsx
+++ b/lib/components/Switch/Switch.tsx
@@ -82,5 +82,3 @@ export const Switch = ({
 		</label>
 	);
 };
-
-export default Switch;

--- a/lib/components/Switch/default.ts
+++ b/lib/components/Switch/default.ts
@@ -1,0 +1,1 @@
+export { Switch as default } from './Switch';

--- a/lib/components/Table/Table.stories.tsx
+++ b/lib/components/Table/Table.stories.tsx
@@ -2,14 +2,18 @@ import { Meta, type StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
 
 import { arrayRingLookup } from '../../utils';
-import { Actions } from '../Actions';
-import { Badge } from '../Badge';
-import { Button } from '../Button';
-import { Inline } from '../Inline';
-import { Stack } from '../Stack';
-import { Text } from '../Text';
+import { Actions } from '../Actions/Actions';
+import { Badge } from '../Badge/Badge';
+import { Button } from '../Button/Button';
+import { Inline } from '../Inline/Inline';
+import { Stack } from '../Stack/Stack';
+import { Text } from '../Text/Text';
 
-import { Table, TableCell, TableHeadCell, TableRow, TableRowGroup } from '.';
+import { Table } from './Table';
+import { TableCell } from './TableCell';
+import { TableHeadCell } from './TableHeadCell';
+import { TableRow } from './TableRow';
+import { TableRowGroup } from './TableRowGroup';
 
 const meta: Meta<typeof Table> = {
 	title: 'Components/Table',

--- a/lib/components/Table/Table.tsx
+++ b/lib/components/Table/Table.tsx
@@ -2,13 +2,13 @@ import type { ReactNode } from 'react';
 import * as React from 'react';
 import { forwardRef } from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
 import * as styles from './Table.css';
 import type { TableContext } from './context';
 import { TableContextProvider } from './context';
 
-export interface Props extends Partial<TableContext> {
+export interface TableProps extends Partial<TableContext> {
 	columnTemplate: string;
 
 	children: ReactNode | ReactNode[];
@@ -20,7 +20,7 @@ Worth noting we use the aria role grid here instead of table, as we have areas
 
 @see https://www.w3.org/TR/wai-aria-1.1/#table
  */
-export const Table = forwardRef<HTMLDivElement, Props>(
+export const Table = forwardRef<HTMLDivElement, TableProps>(
 	({ children, padding = '4', stickyHead = false, columnTemplate }, ref) => (
 		<TableContextProvider padding={padding} stickyHead={stickyHead}>
 			<Box
@@ -36,4 +36,4 @@ export const Table = forwardRef<HTMLDivElement, Props>(
 	),
 );
 
-export default Table;
+Table.displayName = 'Table';

--- a/lib/components/Table/TableCell.tsx
+++ b/lib/components/Table/TableCell.tsx
@@ -5,20 +5,21 @@ import { AriaAttributes, forwardRef } from 'react';
 import { ThemeTokens as Tokens } from '../../themes';
 import type { Alignment } from '../../utils';
 import { alignmentToFlexAlignment } from '../../utils';
-import { Box } from '../Box';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { Text } from '../Text/Text';
 
 import * as styles from './TableCell.css';
 import { useTableContext } from './context';
 
-export interface Props extends Partial<Pick<AriaAttributes, 'aria-label'>> {
+export interface TableCellProps
+	extends Partial<Pick<AriaAttributes, 'aria-label'>> {
 	align?: Alignment;
 	padding?: keyof Tokens['space'];
 
 	children?: ReactNode | null;
 }
 
-export const TableCell = forwardRef<HTMLDivElement, Props>(
+export const TableCell = forwardRef<HTMLDivElement, TableCellProps>(
 	(
 		{
 			padding: incomingPadding,
@@ -66,5 +67,3 @@ export const TableCell = forwardRef<HTMLDivElement, Props>(
 );
 
 TableCell.displayName = 'TableCell';
-
-export default TableCell;

--- a/lib/components/Table/TableHeadCell.tsx
+++ b/lib/components/Table/TableHeadCell.tsx
@@ -5,18 +5,18 @@ import * as React from 'react';
 import { forwardRef, useCallback } from 'react';
 
 import { Alignment, alignmentToFlexAlignment } from '../../utils';
-import { Box } from '../Box';
-import { Icon } from '../Icon';
-import { Inline } from '../Inline';
-import { Text } from '../Text';
-import { VisuallyHidden } from '../VisuallyHidden';
+import { Box } from '../Box/Box';
+import { Icon } from '../Icon/Icon';
+import { Inline } from '../Inline/Inline';
+import { Text } from '../Text/Text';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 
 import * as styles from './TableHeadCell.css';
 import { useTableContext } from './context';
 
 type Sort = 'asc' | 'desc' | 'none';
 
-export interface Props
+export interface TableHeadCellProps
 	extends Partial<Pick<AriaAttributes, 'aria-label'>>,
 		Pick<ComponentProps<typeof Box>, 'padding'> {
 	align?: Alignment;
@@ -35,7 +35,10 @@ const sortToAria = (sort: Sort): AriaAttributes['aria-sort'] => {
 	return 'none';
 };
 
-export const TableHeadCell = forwardRef<HTMLTableCellElement, Props>(
+export const TableHeadCell = forwardRef<
+	HTMLTableCellElement,
+	TableHeadCellProps
+>(
 	(
 		{
 			align = 'left',
@@ -132,5 +135,3 @@ export const TableHeadCell = forwardRef<HTMLTableCellElement, Props>(
 );
 
 TableHeadCell.displayName = 'TableHeadCell';
-
-export default TableHeadCell;

--- a/lib/components/Table/TableRow.tsx
+++ b/lib/components/Table/TableRow.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { forwardRef, MouseEventHandler, ReactNode } from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
-export interface Props {
+export interface TableRowProps {
 	onClick?: MouseEventHandler<HTMLDivElement>;
 
 	children: ReactNode | ReactNode[];
 }
 
-export const TableRow = forwardRef<HTMLDivElement, Props>(
+export const TableRow = forwardRef<HTMLDivElement, TableRowProps>(
 	({ children, onClick }, ref) => (
 		<Box ref={ref} display="contents" role="row" onClick={onClick}>
 			{children}
@@ -17,4 +17,4 @@ export const TableRow = forwardRef<HTMLDivElement, Props>(
 	),
 );
 
-export default TableRow;
+TableRow.displayName = 'TableRow';

--- a/lib/components/Table/TableRowGroup.tsx
+++ b/lib/components/Table/TableRowGroup.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { forwardRef, ReactNode } from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
-export interface Props {
+export interface TableRowGroupProps {
 	children: ReactNode | ReactNode[];
 }
 
-export const TableRowGroup = forwardRef<HTMLDivElement, Props>(
+export const TableRowGroup = forwardRef<HTMLDivElement, TableRowGroupProps>(
 	({ children }, ref) => (
 		<Box ref={ref} role="rowgroup" display="contents">
 			{children}
@@ -15,4 +15,4 @@ export const TableRowGroup = forwardRef<HTMLDivElement, Props>(
 	),
 );
 
-export default TableRowGroup;
+TableRowGroup.displayName = 'TableRowGroup';

--- a/lib/components/Table/default.ts
+++ b/lib/components/Table/default.ts
@@ -1,0 +1,1 @@
+export { Table as default } from './Table';

--- a/lib/components/Table/index.ts
+++ b/lib/components/Table/index.ts
@@ -1,4 +1,4 @@
-export { Table } from './Table';
+export * from './Table';
 export { TableCell } from './TableCell';
 export { TableHeadCell } from './TableHeadCell';
 export { TableRow } from './TableRow';

--- a/lib/components/Tabs/Tab.tsx
+++ b/lib/components/Tabs/Tab.tsx
@@ -1,9 +1,10 @@
 import { invariant } from '@autoguru/utilities';
 import React, { cloneElement, type ElementType, useContext } from 'react';
 
-import { useBox, type UseBoxProps } from '../Box';
-import { Inline } from '../Inline';
-import { Text, useTextStyles } from '../Text';
+import { useBox, type UseBoxProps } from '../Box/useBox';
+import { Inline } from '../Inline/Inline';
+import { Text } from '../Text/Text';
+import { useTextStyles } from '../Text/useTextStyles';
 
 import * as styles from './Tab.css';
 import { TabListContext } from './TabList';

--- a/lib/components/Tabs/TabList.tsx
+++ b/lib/components/Tabs/TabList.tsx
@@ -15,15 +15,15 @@ import React, {
 import flattenChildren from 'react-keyed-flatten-children';
 
 import { animate, ownerWindow, useEventCallback } from '../../utils';
-import { Box } from '../Box';
-import { Button } from '../Button';
-import { Icon } from '../Icon';
-import { useTextStyles } from '../Text';
+import { Box } from '../Box/Box';
+import { Button } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
+import { useTextStyles } from '../Text/useTextStyles';
 
 import * as styles from './TabList.css';
 import { TabsContext } from './Tabs';
 
-export interface Props {
+export interface TabListProps {
 	stretch?: boolean;
 	scrollable?: boolean;
 	children?: ReactNode;
@@ -36,7 +36,7 @@ const defaultEnglish = {
 
 export const TabListContext = createContext<number | null>(null);
 
-export const TabList: FunctionComponent<Props> = ({
+export const TabList: FunctionComponent<TabListProps> = ({
 	children,
 	stretch = false,
 	scrollable = false,
@@ -180,5 +180,3 @@ export const TabList: FunctionComponent<Props> = ({
 		</Box>
 	);
 };
-
-export default TabList;

--- a/lib/components/Tabs/TabPane.tsx
+++ b/lib/components/Tabs/TabPane.tsx
@@ -3,7 +3,7 @@ import type { FunctionComponent } from 'react';
 import * as React from 'react';
 import { ReactNode, useContext } from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
 import * as styles from './TabPane.css';
 import { TabPanesContext } from './TabPanes';
@@ -44,5 +44,3 @@ export const TabPane: FunctionComponent<{
 		</Box>
 	);
 };
-
-export default TabPane;

--- a/lib/components/Tabs/TabPanes.tsx
+++ b/lib/components/Tabs/TabPanes.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Children, createContext, ReactNode } from 'react';
 import flattenChildren from 'react-keyed-flatten-children';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 
 import * as styles from './TabPanes.css';
 
@@ -14,14 +14,14 @@ interface TabPanesContextValue {
 
 export const TabPanesContext = createContext<TabPanesContextValue | null>(null);
 
-interface Props
+interface TabPanesProps
 	extends Pick<ComponentProps<typeof Box>, 'paddingTop' | 'paddingBottom'> {
 	/** Render tab panels even when visually hidden. */
 	renderInactivePanes?: boolean;
 	children?: ReactNode;
 }
 
-export const TabPanes: FunctionComponent<Props> = ({
+export const TabPanes: FunctionComponent<TabPanesProps> = ({
 	renderInactivePanes = false,
 	children,
 	paddingTop = '6',
@@ -45,5 +45,3 @@ export const TabPanes: FunctionComponent<Props> = ({
 		))}
 	</Box>
 );
-
-export default TabPanes;

--- a/lib/components/Tabs/Tabs.stories.tsx
+++ b/lib/components/Tabs/Tabs.stories.tsx
@@ -4,15 +4,19 @@ import { fn } from '@storybook/test';
 import isChromatic from 'chromatic/isChromatic';
 import React, { useEffect, useState } from 'react';
 
-import { Box } from '../Box';
-import { Icon } from '../Icon';
-import { Inline } from '../Inline';
+import { Box } from '../Box/Box';
+import { Icon } from '../Icon/Icon';
+import { Inline } from '../Inline/Inline';
 import { EAlignment } from '../Positioner/alignment';
-import { Stack } from '../Stack';
-import { StarRating } from '../StarRating';
-import { Tooltip } from '../Tooltip';
+import { Stack } from '../Stack/Stack';
+import { StarRating } from '../StarRating/StarRating';
+import { Tooltip } from '../Tooltip/Tooltip';
 
-import { Tab, TabList, TabPane, TabPanes, Tabs } from '.';
+import { Tab } from './Tab';
+import { TabList } from './TabList';
+import { TabPane } from './TabPane';
+import { TabPanes } from './TabPanes';
+import { Tabs } from './Tabs';
 
 const TestChild = ({ label }) => {
 	const [thing, sething] = useState(isChromatic() ? 0.5 : Math.random() * 5);

--- a/lib/components/Tabs/Tabs.tsx
+++ b/lib/components/Tabs/Tabs.tsx
@@ -14,7 +14,7 @@ interface TabsContextValue {
 
 export const TabsContext = createContext<TabsContextValue | null>(null);
 
-export interface Props {
+export interface TabsProps {
 	id?: string | null;
 	active: number;
 	appearance?: 'underlined' | 'pill';
@@ -22,7 +22,7 @@ export interface Props {
 	onChange?: (index: number) => void;
 }
 
-export const Tabs: FunctionComponent<Props> = ({
+export const Tabs: FunctionComponent<TabsProps> = ({
 	id: incomingId,
 	active = 0,
 	appearance = 'underlined',
@@ -52,5 +52,3 @@ export const Tabs: FunctionComponent<Props> = ({
 		</TabsContext.Provider>
 	);
 };
-
-export default Tabs;

--- a/lib/components/Tabs/default.ts
+++ b/lib/components/Tabs/default.ts
@@ -1,0 +1,1 @@
+export { Tabs as default } from './Tabs';

--- a/lib/components/Tabs/index.ts
+++ b/lib/components/Tabs/index.ts
@@ -1,4 +1,4 @@
-export { Tabs } from './Tabs';
+export * from './Tabs';
 export { Tab } from './Tab';
 export { TabList } from './TabList';
 export { TabPane } from './TabPane';

--- a/lib/components/Text/Text.tsx
+++ b/lib/components/Text/Text.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { Sprinkles } from '../../styles/sprinkles.css';
 import type { WithTestId } from '../../types';
 import { dataAttrs } from '../../utils/dataAttrs';
-import type { UseBoxProps } from '../Box';
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
+import type { UseBoxProps } from '../Box/useBox';
 
 import { TextStyleProps, useTextStyles } from './useTextStyles';
 
@@ -71,5 +71,3 @@ export const Text = React.forwardRef<HTMLElement, WithTestId<TextProps>>(
 );
 
 Text.displayName = 'Text';
-
-export default Text;

--- a/lib/components/Text/default.ts
+++ b/lib/components/Text/default.ts
@@ -1,0 +1,1 @@
+export { Text as default } from './Text';

--- a/lib/components/Text/useTextStyles.ts
+++ b/lib/components/Text/useTextStyles.ts
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 
-import type { UseBoxProps } from '../Box';
-import { boxStyles } from '../Box';
+import { boxStyles } from '../Box/boxStyles';
+import type { UseBoxProps } from '../Box/useBox';
 
 import * as styles from './useTextStyles.css';
 

--- a/lib/components/TextAreaInput/TextAreaInput.stories.tsx
+++ b/lib/components/TextAreaInput/TextAreaInput.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { TextAreaInput } from '.';
+import { TextAreaInput } from './TextAreaInput';
 
 const meta: Meta<typeof TextAreaInput> = {
 	title: 'Forms & Input Fields/Text Area Input',

--- a/lib/components/TextAreaInput/TextAreaInput.tsx
+++ b/lib/components/TextAreaInput/TextAreaInput.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 import { withEnhancedInput } from '../private/InputBase';
 
 const MAX_TEXT_AREA_INPUT_LENGTH = 4000;
@@ -34,5 +34,3 @@ export const TextAreaInput = withEnhancedInput<
 		withPrefixIcon: false,
 	},
 );
-
-export default TextAreaInput;

--- a/lib/components/TextAreaInput/default.ts
+++ b/lib/components/TextAreaInput/default.ts
@@ -1,0 +1,1 @@
+export { TextAreaInput as default } from './TextAreaInput';

--- a/lib/components/TextAreaInput/index.ts
+++ b/lib/components/TextAreaInput/index.ts
@@ -1,1 +1,1 @@
-export { TextAreaInput } from './TextAreaInput';
+export * from './TextAreaInput';

--- a/lib/components/TextBubble/TextBubble.stories.tsx
+++ b/lib/components/TextBubble/TextBubble.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { TextBubble } from '.';
+import { TextBubble } from './TextBubble';
 
 type Story = StoryObj<typeof TextBubble>;
 

--- a/lib/components/TextBubble/TextBubble.tsx
+++ b/lib/components/TextBubble/TextBubble.tsx
@@ -2,12 +2,13 @@ import clsx from 'clsx';
 import * as React from 'react';
 import { ComponentProps, FunctionComponent, useMemo } from 'react';
 
-import { Box, boxStyles } from '../Box';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { boxStyles } from '../Box/boxStyles';
+import { Text } from '../Text/Text';
 
 import * as styles from './TextBubble.css';
 
-export interface Props
+export interface TextBubbleProps
 	extends Omit<
 		ComponentProps<typeof Box>,
 		'borderRadius' | 'position' | 'padding'
@@ -28,7 +29,7 @@ const valuePaddingMap: Record<
 	X_LARGE: '6',
 };
 
-export const TextBubble: FunctionComponent<Props> = ({
+export const TextBubble: FunctionComponent<TextBubbleProps> = ({
 	textColour = 'white',
 	rawNumbers = false,
 	label,
@@ -81,5 +82,3 @@ export const TextBubble: FunctionComponent<Props> = ({
 		</Box>
 	);
 };
-
-export default TextBubble;

--- a/lib/components/TextBubble/default.ts
+++ b/lib/components/TextBubble/default.ts
@@ -1,0 +1,1 @@
+export { TextBubble as default } from './TextBubble';

--- a/lib/components/TextBubble/index.ts
+++ b/lib/components/TextBubble/index.ts
@@ -1,1 +1,1 @@
-export { TextBubble } from './TextBubble';
+export * from './TextBubble';

--- a/lib/components/TextContainer/TextContainer.stories.tsx
+++ b/lib/components/TextContainer/TextContainer.stories.tsx
@@ -1,11 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Button } from '../Button';
-import { Heading } from '../Heading';
-import { Text } from '../Text';
+import { Button } from '../Button/Button';
+import { Heading } from '../Heading/Heading';
+import { Text } from '../Text/Text';
 
-import { TextContainer } from '.';
+import { TextContainer } from './TextContainer';
 
 const meta = {
 	title: 'Components/Text Container',

--- a/lib/components/TextContainer/TextContainer.tsx
+++ b/lib/components/TextContainer/TextContainer.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import { FunctionComponent, ReactElement } from 'react';
 
-import { Box } from '../Box';
-import { Stack } from '../Stack';
+import { Box } from '../Box/Box';
+import { Stack } from '../Stack/Stack';
 
-export interface Props {
+export interface TextContainerProps {
 	heading?: ReactElement;
 	action?: ReactElement;
 	className?: string;
 	children: ReactElement | ReactElement[];
 }
 
-export const TextContainer: FunctionComponent<Props> = ({
+export const TextContainer: FunctionComponent<TextContainerProps> = ({
 	heading,
 	className = '',
 	children,

--- a/lib/components/TextContainer/default.ts
+++ b/lib/components/TextContainer/default.ts
@@ -1,0 +1,1 @@
+export { TextContainer as default } from './TextContainer';

--- a/lib/components/TextContainer/index.ts
+++ b/lib/components/TextContainer/index.ts
@@ -1,1 +1,1 @@
-export { TextContainer } from './TextContainer';
+export * from './TextContainer';

--- a/lib/components/TextInput/TextInput.stories.tsx
+++ b/lib/components/TextInput/TextInput.stories.tsx
@@ -5,9 +5,9 @@ import { type ComponentProps } from 'react';
 
 import { argTypesExampleIcons } from '../../stories/shared/argTypes';
 import { boxArgTypes } from '../../stories/shared/argTypes-box';
-import { DateInput } from '../DateInput';
+import { DateInput } from '../DateInput/DateInput';
 
-import { TextInput } from '.';
+import { TextInput } from './TextInput';
 
 const defaultValue = 'user@autoguru.com.au';
 const defaultPlaceholder = 'Email address';

--- a/lib/components/TextInput/TextInput.tsx
+++ b/lib/components/TextInput/TextInput.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Box } from '../Box';
+import { Box } from '../Box/Box';
 import { withEnhancedInput } from '../private/InputBase';
 
 const MAX_TEXT_INPUT_LENGTH = 2000;
@@ -32,5 +32,3 @@ export const TextInput = withEnhancedInput<
 		primitiveType: 'text',
 	},
 );
-
-export default TextInput;

--- a/lib/components/TextInput/default.ts
+++ b/lib/components/TextInput/default.ts
@@ -1,0 +1,1 @@
+export { TextInput as default } from './TextInput';

--- a/lib/components/TextInput/index.ts
+++ b/lib/components/TextInput/index.ts
@@ -1,1 +1,1 @@
-export { TextInput } from './TextInput';
+export * from './TextInput';

--- a/lib/components/TextLink/TextLink.stories.tsx
+++ b/lib/components/TextLink/TextLink.stories.tsx
@@ -2,11 +2,11 @@ import { ArrowRightIcon, ChevronRightIcon } from '@autoguru/icons';
 import { Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
-import { Box } from '../Box';
-import { Heading } from '../Heading';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { Heading } from '../Heading/Heading';
+import { Text } from '../Text/Text';
 
-import { TextLink } from '.';
+import { TextLink } from './TextLink';
 
 const sizeScale = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
 const alignOptions: ['left', 'center', 'right'] = ['left', 'center', 'right'];

--- a/lib/components/TextLink/TextLink.tsx
+++ b/lib/components/TextLink/TextLink.tsx
@@ -14,9 +14,10 @@ import {
 	ReactNode,
 } from 'react';
 
-import { Box, boxStyles } from '../Box';
-import { Icon } from '../Icon';
-import { Text } from '../Text';
+import { Box } from '../Box/Box';
+import { boxStyles } from '../Box/boxStyles';
+import { Icon } from '../Icon/Icon';
+import { Text } from '../Text/Text';
 
 import * as styles from './TextLink.css';
 
@@ -26,7 +27,7 @@ type AnchorProps = Omit<
 	'children' | 'color' | 'style' | 'is' | keyof TextProps
 >;
 
-export interface Props extends TextProps, AnchorProps {
+export interface TextLinkProps extends TextProps, AnchorProps {
 	children?: ReactNode;
 	className?: string;
 	is?: ElementType | ReactElement;
@@ -34,7 +35,7 @@ export interface Props extends TextProps, AnchorProps {
 	icon?: IconType;
 }
 
-export const TextLink = forwardRef<HTMLAnchorElement, Props>(
+export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
 	(
 		{
 			is: Component,

--- a/lib/components/TextLink/default.ts
+++ b/lib/components/TextLink/default.ts
@@ -1,1 +1,1 @@
-export { TextLink as default } from './';
+export { TextLink as default } from './TextLink';

--- a/lib/components/TextLink/index.ts
+++ b/lib/components/TextLink/index.ts
@@ -1,1 +1,1 @@
-export { TextLink } from './TextLink';
+export * from './TextLink';

--- a/lib/components/Toaster/Toast.stories.tsx
+++ b/lib/components/Toaster/Toast.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
-import { Actions } from '../Actions';
-import { Button } from '../Button';
-import { StandardModal } from '../StandardModal';
-import { Text } from '../Text';
+import { Actions } from '../Actions/Actions';
+import { Button } from '../Button/Button';
+import { StandardModal } from '../StandardModal/StandardModal';
+import { Text } from '../Text/Text';
 
-import { ToastProvider, useToast } from '.';
+import { ToastProvider, useToast } from './Toast';
 
 export default {
 	title: 'Components/Toast (useToast)',

--- a/lib/components/Toaster/Toast.tsx
+++ b/lib/components/Toaster/Toast.tsx
@@ -15,10 +15,10 @@ import {
 } from 'react';
 
 import { isBrowser } from '../../utils';
-import { Alert } from '../Alert';
-import { Box } from '../Box';
-import { Portal } from '../Portal';
-import { Stack } from '../Stack';
+import { Alert } from '../Alert/Alert';
+import { Box } from '../Box/Box';
+import { Portal } from '../Portal/Portal';
+import { Stack } from '../Stack/Stack';
 
 import * as styles from './Toast.css';
 
@@ -231,5 +231,3 @@ const Toast: FunctionComponent<
 		</Alert>
 	);
 };
-
-export default Toast;

--- a/lib/components/Toaster/default.ts
+++ b/lib/components/Toaster/default.ts
@@ -1,0 +1,1 @@
+export { ToastProvider, useToast } from './Toast';

--- a/lib/components/Toaster/index.ts
+++ b/lib/components/Toaster/index.ts
@@ -1,1 +1,1 @@
-export { useToast, ToastProvider } from './Toast';
+export * from './Toast';

--- a/lib/components/Tooltip/Tooltip.stories.tsx
+++ b/lib/components/Tooltip/Tooltip.stories.tsx
@@ -2,9 +2,9 @@ import { Meta, StoryObj } from '@storybook/react';
 import React, { type ComponentProps } from 'react';
 
 import { EAlignment } from '../Positioner/alignment';
-import { Text } from '../Text';
+import { Text } from '../Text/Text';
 
-import { Tooltip } from '.';
+import { Tooltip } from './Tooltip';
 
 const sizeScale: ComponentProps<typeof Text>['size'][] = ['3', '4'];
 

--- a/lib/components/Tooltip/Tooltip.tsx
+++ b/lib/components/Tooltip/Tooltip.tsx
@@ -11,16 +11,16 @@ import {
 	useState,
 } from 'react';
 
-import { Box } from '../Box';
-import { Positioner } from '../Positioner';
+import { Box } from '../Box/Box';
+import { Positioner } from '../Positioner/Positioner';
 import { EAlignment } from '../Positioner/alignment';
-import { Text } from '../Text';
+import { Text } from '../Text/Text';
 
 import * as styles from './Tooltip.css';
 
 type ToolTipSize = 'medium' | 'large';
 
-export interface Props {
+export interface TooltipProps {
 	size?: ToolTipSize;
 	isOpen?: boolean;
 	label: string;
@@ -34,7 +34,7 @@ const sizeMap: Record<ToolTipSize, ComponentProps<typeof Text>['size']> = {
 	large: '3',
 };
 
-export const Tooltip: FunctionComponent<Props> = ({
+export const Tooltip: FunctionComponent<TooltipProps> = ({
 	alignment = EAlignment.RIGHT,
 	isOpen: incomingIsOpen,
 	label,
@@ -110,5 +110,3 @@ export const Tooltip: FunctionComponent<Props> = ({
 		<>{children}</>
 	);
 };
-
-export default Tooltip;

--- a/lib/components/Tooltip/index.ts
+++ b/lib/components/Tooltip/index.ts
@@ -1,1 +1,1 @@
-export { Tooltip } from './Tooltip';
+export * from './Tooltip';

--- a/lib/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/lib/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import * as React from 'react';
 
-import { Text } from '../Text';
+import { Text } from '../Text/Text';
 
-import { VisuallyHidden } from '.';
+import { VisuallyHidden } from './VisuallyHidden';
 
 const meta = {
 	title: 'Layout/Visually Hidden',

--- a/lib/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/lib/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,6 +1,6 @@
 import React, { cloneElement, type ElementType } from 'react';
 
-import { useBox, type UseBoxProps } from '../Box';
+import { useBox, type UseBoxProps } from '../Box/useBox';
 
 import { visuallyHidden } from './VisuallyHidden.css';
 
@@ -25,5 +25,3 @@ export const VisuallyHidden = <E extends ElementType>({
 
 	return <Component {...componentProps}>{children}</Component>;
 };
-
-export default VisuallyHidden;

--- a/lib/components/VisuallyHidden/index.ts
+++ b/lib/components/VisuallyHidden/index.ts
@@ -1,1 +1,1 @@
-export { VisuallyHidden } from './VisuallyHidden';
+export * from './VisuallyHidden';

--- a/lib/components/private/CheckableBase/CheckableBase.tsx
+++ b/lib/components/private/CheckableBase/CheckableBase.tsx
@@ -11,7 +11,7 @@ import { Text, useTextStyles } from '../../Text';
 
 import * as styles from './CheckableBase.css';
 
-export interface Props {
+export interface CheckableBaseProps {
 	className?: string;
 	checked?: boolean;
 	disabled?: boolean;
@@ -24,7 +24,7 @@ export interface Props {
 	handleChange?(checked: boolean): void;
 }
 
-export const CheckableBase = forwardRef<HTMLInputElement, Props>(
+export const CheckableBase = forwardRef<HTMLInputElement, CheckableBaseProps>(
 	(
 		{
 			className = '',

--- a/lib/components/private/CheckableBase/CheckableBase.tsx
+++ b/lib/components/private/CheckableBase/CheckableBase.tsx
@@ -6,8 +6,10 @@ import React, {
 	type ReactNode,
 } from 'react';
 
-import { Box, boxStyles } from '../../Box';
-import { Text, useTextStyles } from '../../Text';
+import { Box } from '../../Box/Box';
+import { boxStyles } from '../../Box/boxStyles';
+import { Text } from '../../Text/Text';
+import { useTextStyles } from '../../Text/useTextStyles';
 
 import * as styles from './CheckableBase.css';
 

--- a/lib/components/private/CheckableBase/CheckableBase.tsx
+++ b/lib/components/private/CheckableBase/CheckableBase.tsx
@@ -118,5 +118,3 @@ export const CheckableBase = forwardRef<HTMLInputElement, Props>(
 );
 
 CheckableBase.displayName = 'CheckableBase';
-
-export default CheckableBase;

--- a/lib/components/private/InputBase/HintText.tsx
+++ b/lib/components/private/InputBase/HintText.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React, { type FunctionComponent, type ReactNode } from 'react';
 
-import { boxStyles } from '../../Box';
-import { Text } from '../../Text';
+import { boxStyles } from '../../Box/boxStyles';
+import { Text } from '../../Text/Text';
 
 import * as styles from './HintText.css';
 import type { InputSize } from './withEnhancedInput.css';

--- a/lib/components/private/InputBase/HintText.tsx
+++ b/lib/components/private/InputBase/HintText.tsx
@@ -7,7 +7,7 @@ import { Text } from '../../Text';
 import * as styles from './HintText.css';
 import type { InputSize } from './withEnhancedInput.css';
 
-export interface Props {
+export interface HintTextProps {
 	hintText: ReactNode;
 	reserveHintSpace?: boolean;
 	disabled?: boolean;
@@ -15,7 +15,7 @@ export interface Props {
 	className?: string;
 }
 
-export const HintText: FunctionComponent<Props> = ({
+export const HintText: FunctionComponent<HintTextProps> = ({
 	reserveHintSpace,
 	disabled,
 	hintText,

--- a/lib/components/private/InputBase/NotchedBase.tsx
+++ b/lib/components/private/InputBase/NotchedBase.tsx
@@ -7,7 +7,7 @@ import * as styles from './NotchedBase.css';
 import type { BordersAttach, BordersMerged } from './NotchedBase.css';
 import type { InputSize } from './withEnhancedInput.css';
 
-export interface Props {
+export interface NotchedBaseProps {
 	id: string;
 	placeholder: string;
 	isEmpty: boolean;
@@ -25,7 +25,7 @@ export interface Props {
 	isHovered?: boolean;
 }
 
-export const NotchedBase: FunctionComponent<Props> = ({
+export const NotchedBase: FunctionComponent<NotchedBaseProps> = ({
 	id,
 	placeholder,
 	isEmpty,

--- a/lib/hooks/useAttachedBoxes/useAttachedBoxes.tsx
+++ b/lib/hooks/useAttachedBoxes/useAttachedBoxes.tsx
@@ -12,7 +12,8 @@ import { useMedia } from '../useMedia';
 
 import * as styles from './useAttachedBoxes.css';
 
-interface Props extends Pick<ComponentProps<typeof Box>, 'backgroundColour'> {
+interface UseAttachedBoxesProps
+	extends Pick<ComponentProps<typeof Box>, 'backgroundColour'> {
 	count: number;
 	columnCount: ResponsiveProp<number>;
 	gap?: ResponsiveProp<keyof typeof styles.grid.gaps>;
@@ -45,7 +46,7 @@ export const useAttachedBoxes = ({
 	columnCount: incomingColumnCount,
 	gap = '1',
 	backgroundColour = 'gray900',
-}: Props): Returns => {
+}: UseAttachedBoxesProps): Returns => {
 	const columnCount: number = useResponsiveValue<number>(incomingColumnCount);
 	const decimals: number = (count / columnCount) % 1;
 	let colStart: number;

--- a/lib/hooks/useAttachedBoxes/useAttachedBoxes.tsx
+++ b/lib/hooks/useAttachedBoxes/useAttachedBoxes.tsx
@@ -2,13 +2,13 @@ import clsx from 'clsx';
 import * as React from 'react';
 import { ComponentProps, FunctionComponent } from 'react';
 
-import { Box } from '../../components/Box';
+import { Box } from '../../components/Box/Box';
 import {
 	getEarliestKnownToken,
 	resolveResponsiveStyle,
 } from '../../utils/resolveResponsiveProps';
 import { ResponsiveProp } from '../../utils/responsiveProps.css';
-import { useMedia } from '../useMedia';
+import { useMedia } from '../useMedia/useMedia';
 
 import * as styles from './useAttachedBoxes.css';
 

--- a/lib/hooks/useResponsiveValue/useResponsiveValue.ts
+++ b/lib/hooks/useResponsiveValue/useResponsiveValue.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { useMedia } from '../..';
+import { useMedia } from '../../hooks/useMedia/useMedia';
 import { isBrowser } from '../../utils';
 import { getEarliestKnownToken } from '../../utils/resolveResponsiveProps';
 import { ResponsiveProp } from '../../utils/responsiveProps.css';

--- a/lib/hooks/useWindowHeightFill/useWindowHeightFill.ts
+++ b/lib/hooks/useWindowHeightFill/useWindowHeightFill.ts
@@ -4,7 +4,7 @@ import { useTheme } from '../../components/OverdriveProvider';
 import type { ThemeTokens as Tokens } from '../../themes';
 import { overdriveTokens } from '../../themes/theme.css';
 import { getThemeTokenValue } from '../../utils/css';
-import { useResponsiveValue } from '../useResponsiveValue';
+import { useResponsiveValue } from '../useResponsiveValue/useResponsiveValue';
 
 export interface UseWindowHeightFillProps {
 	bottomGap?: keyof Tokens['space'];

--- a/lib/stories/space.stories.tsx
+++ b/lib/stories/space.stories.tsx
@@ -6,7 +6,7 @@ import { overdriveTokens } from '../themes';
 import { tokens } from '../themes/base/tokens';
 import { breakpoints } from '../themes/makeTheme';
 
-import { Box, Stack, type Sprinkles } from './helpers';
+import { Box, Stack, type Sprinkles } from './helpers/index';
 import { labels, small, titles } from './helpers/styles.css';
 
 const { space } = tokens;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,12 @@ import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	plugins: [vanillaExtractPlugin()],
+	optimizeDeps: {
+		include: [
+			'@vanilla-extract/sprinkles/createRuntimeSprinkles',
+			'@vanilla-extract/recipes/createRuntimeFn',
+		],
+	},
 	test: {
 		coverage: {
 			provider: 'v8',
@@ -10,6 +16,7 @@ export default defineConfig({
 				'lib/**/*.{ts,tsx}',
 				'!**/*stories*.{ts,tsx}',
 				'!**/*.css.ts',
+				'!lib/components/**/{index,default}.ts',
 			],
 			exclude: [...configDefaults.exclude],
 			reporter: ['text', 'lcov'],


### PR DESCRIPTION
Makes imports and exports more explicit internally to avoid circular dep graphs with Vite.
Also moves default component exports to `/Component/default` for better hygiene.
All Props types are now named.