### PR TITLE
4.43 patch: @vanilla-extract/sprinkles peer dependency

### DIFF
--- a/.changeset/shiny-readers-own.md
+++ b/.changeset/shiny-readers-own.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Better aligns the `alignSelf` prop of <Column /> to existing usage

--- a/.changeset/tall-dogs-rhyme.md
+++ b/.changeset/tall-dogs-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Style props for `order`, `flexGrow`/`flexShrink` are now text unions instead of
+number

--- a/lib/components/AutoSuggest/AutoSuggest.tsx
+++ b/lib/components/AutoSuggest/AutoSuggest.tsx
@@ -671,7 +671,7 @@ const AutoSuggestInputPrimitive = withEnhancedInput(
 						as="button"
 						paddingY={size === 'small' ? '1' : '3'}
 						paddingRight={size === 'small' ? '2' : '3'}
-						flexShrink={0}
+						flexShrink="0"
 						onMouseDown={onRequestReset}
 					>
 						<Icon
@@ -682,7 +682,7 @@ const AutoSuggestInputPrimitive = withEnhancedInput(
 				) : // eslint-disable-next-line sonarjs/no-nested-conditional
 				fieldIcon ? (
 					<Box
-						flexShrink={0}
+						flexShrink="0"
 						paddingY={size === 'medium' ? '3' : '2'}
 						paddingRight={size === 'medium' ? '3' : '2'}
 						onClick={focusHandler}
@@ -711,7 +711,7 @@ const AutoSuggestInputPrimitive = withEnhancedInput(
 			>
 				<Box
 					as="input"
-					flexGrow={1}
+					flexGrow="1"
 					{...inputEventHandlers}
 					{...field}
 					ref={handleRef}

--- a/lib/components/BulletText/BulletText.tsx
+++ b/lib/components/BulletText/BulletText.tsx
@@ -32,13 +32,13 @@ export const BulletText = <E extends ElementType>({
 		alignY="center"
 	>
 		{isValidElement(Bullet) ? (
-			<Box position="relative" flexShrink={0}>
+			<Box position="relative" flexShrink="0">
 				{Bullet}
 			</Box>
 		) : (
 			<Box
 				position="relative"
-				flexShrink={0}
+				flexShrink="0"
 				display="flex"
 				alignItems="center"
 				justifyContent="center"
@@ -60,7 +60,7 @@ export const BulletText = <E extends ElementType>({
 				</Text>
 			</Box>
 		)}
-		<Box flexGrow={1}>
+		<Box flexGrow="1">
 			<Text as="span" size="4" display="block">
 				{children}
 			</Text>

--- a/lib/components/ColourInput/ColourInput.tsx
+++ b/lib/components/ColourInput/ColourInput.tsx
@@ -42,7 +42,7 @@ export const ColourInput = withEnhancedInput<{}, HTMLInputElement>(
 					height="full"
 					alignItems="center"
 					justifyContent="space-around"
-					flexShrink={0}
+					flexShrink="0"
 					pointerEvents="none"
 					position="absolute"
 				>
@@ -67,7 +67,7 @@ export const ColourInput = withEnhancedInput<{}, HTMLInputElement>(
 				<Box
 					as="input"
 					type="color"
-					flexGrow={1}
+					flexGrow="1"
 					{...eventHandlers}
 					{...field}
 					{...rest}

--- a/lib/components/Columns/Column.css.ts
+++ b/lib/components/Columns/Column.css.ts
@@ -3,7 +3,10 @@ import { recipe, type RecipeVariants } from '@vanilla-extract/recipes';
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
 
 import { cssLayerComponent } from '../../styles/layers.css';
-import { responsiveConditions } from '../../styles/sprinkles.css';
+import {
+	responsiveConditions,
+	sprinklesResponsive,
+} from '../../styles/sprinkles.css';
 
 const getSizeStyle = (scale: number) => `${scale * 100}%`;
 
@@ -39,6 +42,12 @@ export type SprinklesColumnWidthResponsive = Parameters<
 export const columnStyle = recipe({
 	base: {},
 	variants: {
+		alignSelf: {
+			bottom: sprinklesResponsive({ alignSelf: 'flex-end' }),
+			center: sprinklesResponsive({ alignSelf: 'center' }),
+			stretch: sprinklesResponsive({ alignSelf: 'stretch' }),
+			top: sprinklesResponsive({ alignSelf: 'flex-start' }),
+		},
 		grow: {
 			true: { flexGrow: 1 },
 			false: { flexGrow: 0 },

--- a/lib/components/Columns/Column.tsx
+++ b/lib/components/Columns/Column.tsx
@@ -1,14 +1,16 @@
 import { invariant } from '@autoguru/utilities';
 import React, { cloneElement, type ElementType, useContext } from 'react';
 
-import { Box, useBox, type UseBoxProps } from '../Box';
+import { Box, type BoxLikeProps, useBox, type UseBoxProps } from '../Box';
 
 import * as styles from './Column.css';
 import { ColumnContext } from './Columns';
 
-export interface ColumnProps extends styles.ColumnRecipeVariants {
+interface CustomProps extends styles.ColumnRecipeVariants {
 	width?: styles.SprinklesColumnWidthResponsive['flexBasis'];
 }
+
+export type ColumnProps<E extends ElementType> = BoxLikeProps<E, CustomProps>;
 
 /**
  * Used within a `Columns` container. This component is designed to be a flex
@@ -25,7 +27,7 @@ export const Column = <E extends ElementType>({
 	ref,
 	width,
 	...boxProps
-}: UseBoxProps<E> & ColumnProps) => {
+}: ColumnProps<E>) => {
 	const columnsContext = useContext(ColumnContext);
 	invariant(
 		columnsContext !== null,
@@ -51,7 +53,6 @@ export const Column = <E extends ElementType>({
 
 	return (
 		<Box
-			alignSelf={alignSelf}
 			as={isList ? 'li' : 'div'}
 			order={order}
 			flexGrow={grow ? 1 : 0}
@@ -61,6 +62,7 @@ export const Column = <E extends ElementType>({
 				spaceYCls,
 				styles.sprinklesColumnWidthResponsive({ flexBasis: width }),
 				styles.columnStyle({
+					alignSelf,
 					grow,
 					noShrink,
 				}),

--- a/lib/components/Columns/Column.tsx
+++ b/lib/components/Columns/Column.tsx
@@ -55,8 +55,8 @@ export const Column = <E extends ElementType>({
 		<Box
 			as={isList ? 'li' : 'div'}
 			order={order}
-			flexGrow={grow ? 1 : 0}
-			flexShrink={noShrink ? 0 : void 0}
+			flexGrow={grow ? '1' : '0'}
+			flexShrink={noShrink ? '0' : undefined}
 			className={[
 				spaceXCls,
 				spaceYCls,

--- a/lib/components/Columns/Columns.stories.tsx
+++ b/lib/components/Columns/Columns.stories.tsx
@@ -41,7 +41,11 @@ type Story = StoryObj<typeof Columns>;
 export const Standard: Story = {
 	render: (args) => (
 		<Columns {...args}>
-			<Column width={['full', '1/3', '1/5']} order={[0, 2]} as="section">
+			<Column
+				width={['full', '1/3', '1/5']}
+				order={['0', '2']}
+				as="section"
+			>
 				<Box
 					borderColour="gray"
 					borderWidth="1"

--- a/lib/components/DateTimePicker/DateTimePicker.tsx
+++ b/lib/components/DateTimePicker/DateTimePicker.tsx
@@ -201,7 +201,7 @@ export const DateTimePicker = <D extends DateValue>({
 				</h2>
 			)}
 			<div className={layoutStyle}>
-				<div className={sprinklesResponsive({ flexShrink: 0 })}>
+				<div className={sprinklesResponsive({ flexShrink: '0' })}>
 					<h3 className={subheadingStyle}>
 						{lang?.dateLabel ?? defaultEnglish.dateLabel}
 					</h3>
@@ -231,7 +231,7 @@ export const DateTimePicker = <D extends DateValue>({
 					{/* {state.value && <h2>{dateText}</h2>} */}
 				</div>
 
-				<div className={sprinklesResponsive({ flexGrow: 1 })}>
+				<div className={sprinklesResponsive({ flexGrow: '1' })}>
 					<h3 className={subheadingStyle}>
 						{lang?.timeLabel ?? defaultEnglish.timeLabel}
 					</h3>

--- a/lib/components/HorizontalAutoScroller/HorizontalAutoScroller.tsx
+++ b/lib/components/HorizontalAutoScroller/HorizontalAutoScroller.tsx
@@ -63,8 +63,8 @@ export const HorizontalAutoScroller: FunctionComponent<
 					if (el) itemsRef.push(el);
 				}}
 				key={index}
-				flexGrow={0}
-				flexShrink={0}
+				flexGrow="0"
+				flexShrink="0"
 				alignSelf="stretch"
 				className={clsx(
 					styles.itemMinWidth,

--- a/lib/components/MinimalModal/MinimalModal.tsx
+++ b/lib/components/MinimalModal/MinimalModal.tsx
@@ -79,7 +79,7 @@ export const MinimalModal: FunctionComponent<MinimalModalProps> = ({
 						as="main"
 						display="flex"
 						flexDirection="column"
-						flexGrow={1}
+						flexGrow="0"
 						height="full"
 						className={styles.content}
 					>

--- a/lib/components/MinimalModal/__snapshots__/MinimalModal.spec.jsx.snap
+++ b/lib/components/MinimalModal/__snapshots__/MinimalModal.spec.jsx.snap
@@ -42,7 +42,7 @@ exports[`<MinimalModal /> > should match snapshot with body 1`] = `
             role="dialog"
           >
             <main
-              class="sprinkles_display_flex_mobile__onxwju88 sprinkles_flexDirection_column_mobile__onxwjuns sprinkles_flexGrow_1_mobile__onxwjuo8 sprinkles_height_full_mobile__onxwjuew MinimalModal_content__13ik47w1"
+              class="sprinkles_display_flex_mobile__onxwju88 sprinkles_flexDirection_column_mobile__onxwjuns sprinkles_flexGrow_0_mobile__onxwjuo4 sprinkles_height_full_mobile__onxwjuew MinimalModal_content__13ik47w1"
             >
               <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis convallis neque a laoreet maximus. Vestibulum hendrerit quam at mi venenatis faucibus at vel nisi. In ut risus et ipsum tincidunt tempor. Suspendisse potenti. Praesent faucibus posuere risus, at congue mauris porttitor ut. Donec sit amet elit vitae purus dictum aliquet quis ut ligula. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vestibulum dui sapien, porttitor ac erat vel, malesuada rutrum mauris. Nam arcu tellus, pretium ut aliquet eget, ultrices vel est. Maecenas dapibus volutpat eros a volutpat.
@@ -103,7 +103,7 @@ exports[`<MinimalModal /> > should match snapshot without title and body 1`] = `
             role="dialog"
           >
             <main
-              class="sprinkles_display_flex_mobile__onxwju88 sprinkles_flexDirection_column_mobile__onxwjuns sprinkles_flexGrow_1_mobile__onxwjuo8 sprinkles_height_full_mobile__onxwjuew MinimalModal_content__13ik47w1"
+              class="sprinkles_display_flex_mobile__onxwju88 sprinkles_flexDirection_column_mobile__onxwjuns sprinkles_flexGrow_0_mobile__onxwjuo4 sprinkles_height_full_mobile__onxwjuew MinimalModal_content__13ik47w1"
             />
           </article>
         </div>

--- a/lib/components/OptionGrid/OptionGrid.css.ts
+++ b/lib/components/OptionGrid/OptionGrid.css.ts
@@ -176,7 +176,7 @@ export const styledCheckbox = recipe({
 		sprinklesResponsive({
 			alignItems: 'center',
 			display: 'flex',
-			flexShrink: 0,
+			flexShrink: '0',
 			justifyContent: 'center',
 			size: '6',
 		}),

--- a/lib/components/OptionList/OptionList.css.ts
+++ b/lib/components/OptionList/OptionList.css.ts
@@ -113,7 +113,7 @@ export const checkbox = recipe({
 		sprinklesResponsive({
 			alignItems: 'center',
 			display: 'flex',
-			flexShrink: 0,
+			flexShrink: '0',
 			justifyContent: 'center',
 			size: '6',
 		}),

--- a/lib/components/SelectInput/SelectInput.tsx
+++ b/lib/components/SelectInput/SelectInput.tsx
@@ -35,7 +35,7 @@ export const SelectInput = withEnhancedInput<
 		>
 			<Box
 				as="select"
-				flexGrow={1}
+				flexGrow="1"
 				{...eventHandlers}
 				{...field}
 				{...rest}
@@ -52,7 +52,7 @@ export const SelectInput = withEnhancedInput<
 					alignItems="center"
 					height="full"
 					marginRight={size === 'medium' ? '4' : '2'}
-					flexShrink={0}
+					flexShrink="0"
 					pointerEvents="none"
 					position="absolute"
 				>

--- a/lib/components/StandardModal/StandardModal.tsx
+++ b/lib/components/StandardModal/StandardModal.tsx
@@ -115,7 +115,7 @@ export const StandardModal: FunctionComponent<StandardModalProps> = ({
 				>
 					<Box
 						as="header"
-						flexShrink={0}
+						flexShrink="0"
 						position="relative"
 						display="flex"
 						alignItems="center"
@@ -127,7 +127,7 @@ export const StandardModal: FunctionComponent<StandardModalProps> = ({
 						borderBottomWidth="1"
 						borderColour="light"
 					>
-						<Box flexGrow={1} id={titleId!}>
+						<Box flexGrow="1" id={titleId!}>
 							<Heading as="h4">{title}</Heading>
 						</Box>
 						<Button
@@ -149,7 +149,7 @@ export const StandardModal: FunctionComponent<StandardModalProps> = ({
 						as="main"
 						display="flex"
 						flexDirection="column"
-						flexGrow={1}
+						flexGrow="1"
 						height="full"
 						className={styles.content}
 					>

--- a/lib/stories/shared/argTypes-box.ts
+++ b/lib/stories/shared/argTypes-box.ts
@@ -26,7 +26,11 @@ const scaledProps: Array<keyof ComponentProps<typeof Box>> = [
 
 const widthOptions: Array<ComponentProps<typeof Box>['width']> = ['full'];
 
-const orderOptions: Array<ComponentProps<typeof Box>['order']> = [0, 1, 2];
+const orderOptions: Array<ComponentProps<typeof Box>['order']> = [
+	'0',
+	'1',
+	'2',
+];
 
 export const boxArgTypes: Partial<ArgTypes<ComponentProps<typeof Box>>> = {
 	backgroundColour: {

--- a/lib/styles/sprinkles.css.ts
+++ b/lib/styles/sprinkles.css.ts
@@ -269,10 +269,10 @@ const responsiveProperties = defineProperties({
 		justifySelf: ['flex-start', 'center', 'flex-end'],
 		// Flexbox
 		flexDirection: ['row', 'column', 'row-reverse', 'column-reverse'],
-		flexGrow: [0, 1],
-		flexShrink: [0, 1],
+		flexGrow: ['0', '1'],
+		flexShrink: ['0', '1'],
 		flexWrap: ['nowrap', 'wrap', 'wrap-reverse'],
-		order: [0, 1, 2, 3, 4],
+		order: ['0', '1', '2', '3', '4'],
 		// Grid
 		gridAutoColumns: ['auto', '1fr', 'min-content', 'max-content'],
 		gridAutoRows: ['auto', '1fr'],

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
 		"@popperjs/core": "^2.11.8",
 		"@vanilla-extract/dynamic": "^2.1.2",
 		"@vanilla-extract/recipes": "^0.5.5",
+		"@vanilla-extract/sprinkles": "^1.6.3",
 		"clsx": "^2.1.1",
 		"colord": "^2.9.3",
 		"csstype": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,6 +212,7 @@ __metadata:
     "@popperjs/core": ^2.11.8
     "@vanilla-extract/dynamic": ^2.1.2
     "@vanilla-extract/recipes": ^0.5.5
+    "@vanilla-extract/sprinkles": ^1.6.3
     clsx: ^2.1.1
     colord: ^2.9.3
     csstype: ^3.1.3


### PR DESCRIPTION
Solves typechecking issue in MFEs by ensuring that sprinkles is a peer dependency of Overdrive.
Customise the `alignSelf` prop on Column to match existing usage.
Also improves the prop autocomplete for sprinkles style props that were numerical by converting to string union.