### PR TITLE
patch: missing Flex folder export

### DIFF
--- a/.changeset/real-peaches-kneel.md
+++ b/.changeset/real-peaches-kneel.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+The new Flex components and associated utils are now correctly exported

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -15,6 +15,7 @@ export * from './DividerLine';
 export * from './DropDown';
 export * from './EditableText';
 export * from './FillHeightBox';
+export * from './Flex';
 export * from './Flyout';
 export * from './Heading';
 export * from './HorizontalAutoScroller';


### PR DESCRIPTION
This pull request introduces a fix to ensure the new `Flex` components and their associated utilities are correctly exported. The changes include updating the export statements and documenting the fix.