### PR TITLE
patch: adds `minimal` appearance to Tabs

### DIFF
--- a/.changeset/true-berries-fall.md
+++ b/.changeset/true-berries-fall.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Tabs: `minimal` appearance setting

--- a/lib/components/Tabs/Tab.css.ts
+++ b/lib/components/Tabs/Tab.css.ts
@@ -1,9 +1,8 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
+import { focusOutline } from '../../styles/focusOutline.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';
-
-import { focusOutline } from './../../styles/focusOutline.css';
 
 const lineBottomHeight = '1px';
 const size = '20px';
@@ -44,6 +43,15 @@ export const styledTab = recipe({
 					},
 				},
 			},
+			minimal: {
+				borderBottom: `2px solid transparent`,
+				padding: '6px 0',
+				selectors: {
+					'&+&': {
+						marginLeft: vars.space['6'],
+					},
+				},
+			},
 		},
 		active: {
 			true: {},
@@ -69,6 +77,16 @@ export const styledTab = recipe({
 			style: {
 				backgroundColor: vars.colours.foreground.body,
 				color: vars.colours.background.body,
+			},
+		},
+		{
+			variants: {
+				appearance: 'minimal',
+				active: true,
+			},
+			style: {
+				color: vars.color.content.normal,
+				borderBottomColor: vars.color.content.normal,
 			},
 		},
 	],
@@ -107,6 +125,7 @@ export const indication = recipe({
 						},
 				},
 			},
+			minimal: {},
 		},
 		active: {
 			true: {},
@@ -137,3 +156,6 @@ export const indication = recipe({
 		appearance: 'underlined',
 	},
 });
+
+export type TabVariants = NonNullable<Parameters<typeof styledTab>[0]>;
+export type TabAppearance = NonNullable<TabVariants['appearance']>;

--- a/lib/components/Tabs/TabList.css.ts
+++ b/lib/components/Tabs/TabList.css.ts
@@ -11,6 +11,7 @@ export const styledTabList = recipe({
 				boxShadow: `inset 0 -1px 0 0 ${vars.border.colours.gray}`,
 			},
 			pill: {},
+			minimal: {},
 		},
 		scroll: {
 			true: {

--- a/lib/components/Tabs/Tabs.tsx
+++ b/lib/components/Tabs/Tabs.tsx
@@ -4,11 +4,12 @@ import { createContext, ReactNode, useMemo } from 'react';
 
 import { useId, useUncontrolledState } from '../../utils';
 
-type TabsAppearance = 'underlined' | 'pill';
+import type { TabAppearance } from './Tab.css';
+
 interface TabsContextValue {
 	id?: string;
 	activeIndex: number;
-	appearance: TabsAppearance;
+	appearance: TabAppearance;
 	onChange?: (index: number) => void;
 }
 
@@ -17,7 +18,7 @@ export const TabsContext = createContext<TabsContextValue | null>(null);
 export interface TabsProps {
 	id?: string | null;
 	active: number;
-	appearance?: 'underlined' | 'pill';
+	appearance?: TabAppearance;
 	children?: ReactNode;
 	onChange?: (index: number) => void;
 }

--- a/lib/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
+++ b/lib/components/Tabs/__snapshots__/Tabs.spec.jsx.snap
@@ -18,7 +18,7 @@ exports[`<Tabs /> > should allow id overriding 1`] = `
       >
         <button
           aria-selected="true"
-          class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 sprinkles_display_inline-flex_mobile__onxwju7r sprinkles_justifyContent_center_mobile__onxwjumz sprinkles_backgroundColour_transparent__onxwju5g elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_3__onxwju5v sprinkles_lineHeight_3__onxwju5m sprinkles_fontWeight_bold__onxwju64 sprinkles_textWrap_nowrap__onxwju6b typography_color_light__yhjp339 Tab_styledTab__11wt3mu0 Tab_styledTab_appearance_underlined__11wt3mu1 Tab_styledTab_active_true__11wt3mu3 Tab_styledTab_compound_0__11wt3mu4"
+          class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 sprinkles_display_inline-flex_mobile__onxwju7r sprinkles_justifyContent_center_mobile__onxwjumz sprinkles_backgroundColour_transparent__onxwju5g elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_3__onxwju5v sprinkles_lineHeight_3__onxwju5m sprinkles_fontWeight_bold__onxwju64 sprinkles_textWrap_nowrap__onxwju6b typography_color_light__yhjp339 Tab_styledTab__11wt3mu0 Tab_styledTab_appearance_underlined__11wt3mu1 Tab_styledTab_active_true__11wt3mu4 Tab_styledTab_compound_0__11wt3mu5"
           data-controls="tab-1-title-0"
           role="tab"
         >
@@ -30,7 +30,7 @@ exports[`<Tabs /> > should allow id overriding 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="Tab_item__11wt3mu6"
+                class="Tab_item__11wt3mu8"
               >
                 tab 1 title
               </span>
@@ -52,7 +52,7 @@ exports[`<Tabs /> > should allow id overriding 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="Tab_item__11wt3mu6"
+                class="Tab_item__11wt3mu8"
               >
                 tab 2 title
               </span>
@@ -74,7 +74,7 @@ exports[`<Tabs /> > should allow id overriding 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="Tab_item__11wt3mu6"
+                class="Tab_item__11wt3mu8"
               >
                 tab 3 title
               </span>
@@ -135,7 +135,7 @@ exports[`<Tabs /> > should allow rendering indications 1`] = `
       >
         <button
           aria-selected="true"
-          class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 sprinkles_display_inline-flex_mobile__onxwju7r sprinkles_justifyContent_center_mobile__onxwjumz sprinkles_backgroundColour_transparent__onxwju5g elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_3__onxwju5v sprinkles_lineHeight_3__onxwju5m sprinkles_fontWeight_bold__onxwju64 sprinkles_textWrap_nowrap__onxwju6b typography_color_light__yhjp339 Tab_styledTab__11wt3mu0 Tab_styledTab_appearance_underlined__11wt3mu1 Tab_styledTab_active_true__11wt3mu3 Tab_styledTab_compound_0__11wt3mu4"
+          class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 sprinkles_display_inline-flex_mobile__onxwju7r sprinkles_justifyContent_center_mobile__onxwjumz sprinkles_backgroundColour_transparent__onxwju5g elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_3__onxwju5v sprinkles_lineHeight_3__onxwju5m sprinkles_fontWeight_bold__onxwju64 sprinkles_textWrap_nowrap__onxwju6b typography_color_light__yhjp339 Tab_styledTab__11wt3mu0 Tab_styledTab_appearance_underlined__11wt3mu1 Tab_styledTab_active_true__11wt3mu4 Tab_styledTab_compound_0__11wt3mu5"
           data-controls="od-11-0-tab"
           role="tab"
         >
@@ -147,7 +147,7 @@ exports[`<Tabs /> > should allow rendering indications 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="Tab_item__11wt3mu6"
+                class="Tab_item__11wt3mu8"
               >
                 tab 1 title
               </span>
@@ -156,7 +156,7 @@ exports[`<Tabs /> > should allow rendering indications 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  sprinkles_display_block_mobile__onxwju6v elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_2__onxwju5u sprinkles_lineHeight_2__onxwju5l sprinkles_fontWeight_bold__onxwju64 sprinkles_textAlign_center_mobile__onxwju9j typography_color_white__yhjp336 Tab_indication__11wt3mu7 Tab_indication_appearance_underlined__11wt3mu8 Tab_indication_active_true__11wt3mua Tab_indication_compound_0__11wt3mub"
+                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  sprinkles_display_block_mobile__onxwju6v elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_2__onxwju5u sprinkles_lineHeight_2__onxwju5l sprinkles_fontWeight_bold__onxwju64 sprinkles_textAlign_center_mobile__onxwju9j typography_color_white__yhjp336 Tab_indication__11wt3mu9 Tab_indication_appearance_underlined__11wt3mua Tab_indication_active_true__11wt3mud Tab_indication_compound_0__11wt3mue"
               >
                 5
               </span>
@@ -178,7 +178,7 @@ exports[`<Tabs /> > should allow rendering indications 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="Tab_item__11wt3mu6"
+                class="Tab_item__11wt3mu8"
               >
                 tab 2 title
               </span>
@@ -187,7 +187,7 @@ exports[`<Tabs /> > should allow rendering indications 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  sprinkles_display_block_mobile__onxwju6v elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_2__onxwju5u sprinkles_lineHeight_2__onxwju5l sprinkles_fontWeight_bold__onxwju64 sprinkles_textAlign_center_mobile__onxwju9j typography_color_dark__yhjp335 Tab_indication__11wt3mu7 Tab_indication_appearance_underlined__11wt3mu8"
+                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  sprinkles_display_block_mobile__onxwju6v elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_2__onxwju5u sprinkles_lineHeight_2__onxwju5l sprinkles_fontWeight_bold__onxwju64 sprinkles_textAlign_center_mobile__onxwju9j typography_color_dark__yhjp335 Tab_indication__11wt3mu9 Tab_indication_appearance_underlined__11wt3mua"
               >
                 5
               </span>
@@ -209,7 +209,7 @@ exports[`<Tabs /> > should allow rendering indications 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="Tab_item__11wt3mu6"
+                class="Tab_item__11wt3mu8"
               >
                 tab 3 title
               </span>
@@ -218,7 +218,7 @@ exports[`<Tabs /> > should allow rendering indications 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  sprinkles_display_block_mobile__onxwju6v elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_2__onxwju5u sprinkles_lineHeight_2__onxwju5l sprinkles_fontWeight_bold__onxwju64 sprinkles_textAlign_center_mobile__onxwju9j typography_color_dark__yhjp335 Tab_indication__11wt3mu7 Tab_indication_appearance_underlined__11wt3mu8"
+                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  sprinkles_display_block_mobile__onxwju6v elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_2__onxwju5u sprinkles_lineHeight_2__onxwju5l sprinkles_fontWeight_bold__onxwju64 sprinkles_textAlign_center_mobile__onxwju9j typography_color_dark__yhjp335 Tab_indication__11wt3mu9 Tab_indication_appearance_underlined__11wt3mua"
               >
                 5
               </span>
@@ -279,7 +279,7 @@ exports[`<Tabs /> > should match snapshot (high level) 1`] = `
       >
         <button
           aria-selected="true"
-          class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 sprinkles_display_inline-flex_mobile__onxwju7r sprinkles_justifyContent_center_mobile__onxwjumz sprinkles_backgroundColour_transparent__onxwju5g elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_3__onxwju5v sprinkles_lineHeight_3__onxwju5m sprinkles_fontWeight_bold__onxwju64 sprinkles_textWrap_nowrap__onxwju6b typography_color_light__yhjp339 Tab_styledTab__11wt3mu0 Tab_styledTab_appearance_underlined__11wt3mu1 Tab_styledTab_active_true__11wt3mu3 Tab_styledTab_compound_0__11wt3mu4"
+          class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 sprinkles_display_inline-flex_mobile__onxwju7r sprinkles_justifyContent_center_mobile__onxwjumz sprinkles_backgroundColour_transparent__onxwju5g elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_3__onxwju5v sprinkles_lineHeight_3__onxwju5m sprinkles_fontWeight_bold__onxwju64 sprinkles_textWrap_nowrap__onxwju6b typography_color_light__yhjp339 Tab_styledTab__11wt3mu0 Tab_styledTab_appearance_underlined__11wt3mu1 Tab_styledTab_active_true__11wt3mu4 Tab_styledTab_compound_0__11wt3mu5"
           data-controls="od-1-0-tab"
           role="tab"
         >
@@ -291,7 +291,7 @@ exports[`<Tabs /> > should match snapshot (high level) 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="Tab_item__11wt3mu6"
+                class="Tab_item__11wt3mu8"
               >
                 tab 1 title
               </span>
@@ -313,7 +313,7 @@ exports[`<Tabs /> > should match snapshot (high level) 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="Tab_item__11wt3mu6"
+                class="Tab_item__11wt3mu8"
               >
                 tab 2 title
               </span>
@@ -335,7 +335,7 @@ exports[`<Tabs /> > should match snapshot (high level) 1`] = `
               class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwju73 sprinkles_useVar_gap__onxwju6q sprinkles_alignItems_center_mobile__onxwjulb sprinkles_flexWrap_nowrap_mobile__onxwjupf"
             >
               <span
-                class="Tab_item__11wt3mu6"
+                class="Tab_item__11wt3mu8"
               >
                 tab 3 title
               </span>


### PR DESCRIPTION
This pull request introduces a new `minimal` appearance setting for the `Tabs` component in the `@autoguru/overdrive` package. The changes include updates to styling, type definitions, and tests to support this new appearance variant.

### Tabs Appearance: `minimal` visual style

* Added a `minimal` appearance variant to the `Tabs` component, including new styles for inactive and active states, as well as spacing between tabs. (`lib/components/Tabs/Tab.css.ts`: [[1]](diffhunk://#diff-787547fa80265722c88654dfb8e977c86712421a2134ac5338ee18dd066383c5R46-R54) [[2]](diffhunk://#diff-787547fa80265722c88654dfb8e977c86712421a2134ac5338ee18dd066383c5R82-R91)
* Updated the `TabList` component to recognize the `minimal` appearance. (`lib/components/Tabs/TabList.css.ts`: [lib/components/Tabs/TabList.css.tsR14](diffhunk://#diff-610cbbcf4128eeecb7458b10908d527b57f5953fd9a415a06ff121eb6cd1ddc8R14))
* Defined new TypeScript types `TabVariants` and `TabAppearance` to streamline appearance handling, replacing hardcoded appearance strings in `Tabs` props and context. (`lib/components/Tabs/Tab.css.ts`: [[1]](diffhunk://#diff-787547fa80265722c88654dfb8e977c86712421a2134ac5338ee18dd066383c5R159-R161) `lib/components/Tabs/Tabs.tsx`: [[2]](diffhunk://#diff-af7f1df3623b2ea7aceb49e179401ba720451b553f4cba55c0acf3add96ec247L7-R12) [[3]](diffhunk://#diff-af7f1df3623b2ea7aceb49e179401ba720451b553f4cba55c0acf3add96ec247L20-R21)