### PR TITLE
feat: OptionGrid adds disabled style and loading state

### DIFF
--- a/.changeset/yummy-areas-attend.md
+++ b/.changeset/yummy-areas-attend.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+**OptionGrid**: style for disabled option items, loading state

--- a/lib/components/OptionGrid/OptionGrid.css.ts
+++ b/lib/components/OptionGrid/OptionGrid.css.ts
@@ -163,7 +163,7 @@ export const gridItemStyle = style([
 							backgroundColor: tokens.border.colours.light,
 							borderColor: tokens.border.colours.light,
 						},
-					'&[data-selected]:after': {
+					[`&[data-selected]:after`]: {
 						borderRadius: 'inherit',
 						content: '',
 						display: 'block',
@@ -176,10 +176,10 @@ export const gridItemStyle = style([
 						top: 0,
 						width: '100%',
 					},
-					'&[data-disabled]': {
+					[selectors.disabled]: {
 						backgroundColor: tokens.colours.gamut.gray100,
-						borderColor: tokens.colours.gamut.gray200,
-						color: tokens.colours.gamut.gray400,
+						borderColor: 'transparent',
+						color: tokens.colours.gamut.black500,
 						cursor: 'not-allowed',
 					},
 				},
@@ -227,10 +227,8 @@ export const checkboxStyle = style([
 							backgroundColor: tokens.colours.gamut.gray300,
 							color: tokens.colours.background.body,
 						},
-					'&[data-disabled]': {
-						backgroundColor: tokens.colours.gamut.gray100,
+					[selectors.disabled]: {
 						borderColor: tokens.colours.gamut.gray200,
-						color: tokens.colours.gamut.gray300,
 					},
 				},
 			},
@@ -289,7 +287,7 @@ export const radioButtonStyle = style([
 							backgroundColor: tokens.colours.gamut.gray300,
 							borderColor: tokens.colours.gamut.gray300,
 						},
-					'&[data-disabled]': {
+					[selectors.disabled]: {
 						backgroundColor: tokens.colours.gamut.gray100,
 						borderColor: tokens.colours.gamut.gray200,
 					},

--- a/lib/components/OptionGrid/OptionGrid.css.ts
+++ b/lib/components/OptionGrid/OptionGrid.css.ts
@@ -118,7 +118,7 @@ const optionTransition = style({
 	},
 });
 
-export const gridItemStyle = style([
+export const gridItemContainerStyle = style([
 	sprinkles({
 		alignItems: 'center',
 		borderRadius: 'md',
@@ -131,6 +131,19 @@ export const gridItemStyle = style([
 		position: 'relative',
 		userSelect: 'none',
 	}),
+	{
+		'@layer': {
+			[cssLayerComponent]: {
+				backgroundColor: tokens.colours.background.body,
+				borderColor: tokens.border.colours.gray,
+				minHeight: '80px',
+			},
+		},
+	},
+]);
+
+export const gridItemStyle = style([
+	gridItemContainerStyle,
 	{
 		'@layer': {
 			[cssLayerComponent]: {
@@ -162,6 +175,12 @@ export const gridItemStyle = style([
 						position: 'absolute',
 						top: 0,
 						width: '100%',
+					},
+					'&[data-disabled]': {
+						backgroundColor: tokens.colours.gamut.gray100,
+						borderColor: tokens.colours.gamut.gray200,
+						color: tokens.colours.gamut.gray400,
+						cursor: 'not-allowed',
 					},
 				},
 			},
@@ -208,6 +227,11 @@ export const checkboxStyle = style([
 							backgroundColor: tokens.colours.gamut.gray300,
 							color: tokens.colours.background.body,
 						},
+					'&[data-disabled]': {
+						backgroundColor: tokens.colours.gamut.gray100,
+						borderColor: tokens.colours.gamut.gray200,
+						color: tokens.colours.gamut.gray300,
+					},
 				},
 			},
 		},
@@ -265,6 +289,10 @@ export const radioButtonStyle = style([
 							backgroundColor: tokens.colours.gamut.gray300,
 							borderColor: tokens.colours.gamut.gray300,
 						},
+					'&[data-disabled]': {
+						backgroundColor: tokens.colours.gamut.gray100,
+						borderColor: tokens.colours.gamut.gray200,
+					},
 				},
 			},
 		},

--- a/lib/components/OptionGrid/OptionGrid.stories.tsx
+++ b/lib/components/OptionGrid/OptionGrid.stories.tsx
@@ -27,6 +27,7 @@ const serviceSchedule: OptionItem[] = [
 	{
 		label: '130,000km / 78 months',
 		name: '130km/78',
+		disabled: true,
 	},
 	{
 		label: '140,000km / 84 months',
@@ -43,10 +44,12 @@ const serviceSchedule: OptionItem[] = [
 	{
 		label: '170,000km / 104 months',
 		name: '170km/102',
+		disabled: true,
 	},
 	{
 		label: '180,000km / 110 months',
 		name: '180km/110',
+		disabled: true,
 	},
 	{
 		label: '190,000km / 116 months',
@@ -81,22 +84,23 @@ const alphaOptions: OptionItem[] = [
 	{
 		label: 'Option A',
 		name: 'a',
-		description: 'This is a description',
+		description: 'This is description A',
 	},
 	{
 		label: 'Option B',
 		name: 'b',
-		description: 'This is a description',
+		description: 'This is description B',
 	},
 	{
 		label: 'Option C',
 		name: 'c',
-		description: 'This is a description',
+		description: 'This is description C',
 	},
 ];
 
 const meta: Meta<typeof OptionGrid> = {
 	title: 'Forms & Input Fields/Option Grid',
+	tags: [],
 	component: OptionGrid,
 	args: {
 		label: 'Select car servicing options',
@@ -104,10 +108,10 @@ const meta: Meta<typeof OptionGrid> = {
 		columns: '2',
 		indicator: 'checkbox',
 		selectionMode: 'multiple',
-		testId: 'demo-option-grid',
 		onSelectionChange: fn(),
+		isLoading: false,
+		testId: 'demo-option-grid',
 	},
-	tags: ['beta'],
 };
 
 export default meta;
@@ -122,6 +126,7 @@ export const Simple: Story = {
 	play: async ({ args, canvasElement, step }) => {
 		const contentOptions = args.items;
 		const canvas = within(canvasElement);
+		const ARIA_SELECTED = 'aria-selected';
 
 		// add a small pause, because react-aria init :(
 		await new Promise((resolve) => setTimeout(resolve, 25));
@@ -143,16 +148,15 @@ export const Simple: Story = {
 				await expect(option).toHaveAttribute('data-key', content.name);
 			}
 		});
-
 		await step('Selected states and onChange event', async () => {
 			for (const idx of [0, 2]) {
 				const option = options[idx];
 				await userEvent.click(option);
 				await expect(args.onSelectionChange).toHaveBeenCalled();
-				await expect(option).toHaveAttribute('aria-selected', 'true');
+				await expect(option).toHaveAttribute(ARIA_SELECTED, 'true');
 			}
 
-			await expect(options[1]).toHaveAttribute('aria-selected', 'false');
+			await expect(options[1]).toHaveAttribute(ARIA_SELECTED, 'false');
 		});
 
 		await step('Keyboard interaction', async () => {
@@ -160,8 +164,8 @@ export const Simple: Story = {
 				'[ArrowLeft][ArrowLeft][Enter][ArrowRight][ArrowRight][Enter]',
 			);
 			await expect(args.onSelectionChange).toHaveBeenCalled();
-			await expect(options[0]).toHaveAttribute('aria-selected', 'false');
-			await expect(options[2]).toHaveAttribute('aria-selected', 'false');
+			await expect(options[0]).toHaveAttribute(ARIA_SELECTED, 'false');
+			await expect(options[2]).toHaveAttribute(ARIA_SELECTED, 'false');
 		});
 	},
 };
@@ -175,6 +179,7 @@ export const UncontrolledWithIcons: Story = {
 
 /**
  * Example of a controlled instance using an empty Set, logs selection to console. Indicator set to `radio`.
+ * This example also shows disabling of options.
  *
  * ```jsx
  * import type { Selection } from 'react-aria-components';

--- a/lib/components/OptionGrid/OptionGrid.stories.tsx
+++ b/lib/components/OptionGrid/OptionGrid.stories.tsx
@@ -179,7 +179,7 @@ export const UncontrolledWithIcons: Story = {
 
 /**
  * Example of a controlled instance using an empty Set, logs selection to console. Indicator set to `radio`.
- * This example also shows disabling of options.
+ * This example also demostrates disabling of options.
  *
  * ```jsx
  * import type { Selection } from 'react-aria-components';

--- a/lib/components/OptionGrid/OptionGrid.tsx
+++ b/lib/components/OptionGrid/OptionGrid.tsx
@@ -12,11 +12,13 @@ import { type SelectionMode } from 'react-stately';
 import type { TestIdProp } from '../../types';
 import { dataAttrs } from '../../utils/dataAttrs';
 import { Icon, type IconEl } from '../Icon';
+import { LoadingBox } from '../LoadingBox/LoadingBox';
 
 import {
 	checkboxStyle,
 	descriptionStyle,
 	gridContainerStyle,
+	gridItemContainerStyle,
 	gridItemStyle,
 	gridVariants,
 	indicatorStyle,
@@ -34,6 +36,10 @@ export interface OptionItem {
 	 */
 	icon?: IconEl;
 	description?: string;
+	/**
+	 * Whether this option should be disabled
+	 */
+	disabled?: boolean;
 }
 export interface OptionGridProps<T>
 	extends Omit<ListBoxProps<T>, 'items'>,
@@ -58,6 +64,10 @@ export interface OptionGridProps<T>
 	 * Number of columns to display the options in
 	 */
 	columns?: GridVariants['columns'];
+	/**
+	 * Loading state
+	 */
+	isLoading?: boolean;
 }
 
 /**
@@ -66,9 +76,9 @@ export interface OptionGridProps<T>
  * and implements a listbox behaviour without wrapping an input element. It supports controlled and uncontrolled usage.
  * Following ARIA guidelines, the arrow keys can be used to navigate withing the group of options.
  *
+ * The ListBox implementation provides a Set of selected keys to the `onSelectionChange` handler. To preselect options
+ * in uncontrolled usage, simply provide a default selection using the `defaultSelectedKeys` prop.
  * See more details on react-aria [ListBox props](https://react-spectrum.adobe.com/react-aria/ListBox.html#listbox-1).
- *
- * Not yet implemented: disabled appearance, empty state, loading state, error state.
  *
  * Accessibility note: The ARIA spec prohibits listbox items from including interactive content such as buttons,
  * tooltips, etc. For these cases a completely different implementation is required (e.g. react-aria [GridList](
@@ -78,6 +88,7 @@ export const OptionGrid = ({
 	className,
 	columns,
 	indicator = 'checkbox',
+	isLoading = false,
 	label,
 	layout = 'grid',
 	selectionMode = 'multiple',
@@ -85,6 +96,20 @@ export const OptionGrid = ({
 
 	...props
 }: OptionGridProps<OptionItem>) => {
+	if (isLoading) {
+		return (
+			<div className={gridContainerStyle}>
+				<div className={gridVariants({ columns })}>
+					{Array.from({ length: Number(columns) || 1 }, (_, idx) => (
+						<div key={idx} className={gridItemContainerStyle}>
+							<LoadingBox />
+						</div>
+					))}
+				</div>
+			</div>
+		);
+	}
+
 	return (
 		<div className={gridContainerStyle}>
 			<ListBox
@@ -95,11 +120,13 @@ export const OptionGrid = ({
 				{...dataAttrs({ testid: testId })}
 				{...props}
 			>
-				{({ description, icon, label, name }) => (
+				{({ description, disabled, icon, label, name }) => (
 					<ListBoxItem
 						className={gridItemStyle}
 						id={name}
+						isDisabled={disabled}
 						textValue={label}
+						{...dataAttrs({ disabled })}
 					>
 						{({ isFocusVisible, isHovered, isSelected }) => {
 							const hasIndicator = indicator !== 'none';
@@ -118,6 +145,7 @@ export const OptionGrid = ({
 									<div
 										className={styledIndicator}
 										{...dataAttrs({
+											disabled,
 											'focus-visible': isFocusVisible,
 											hover: isHovered,
 											selected: isSelected,
@@ -164,3 +192,5 @@ export const OptionGrid = ({
 		</div>
 	);
 };
+
+OptionGrid.displayName = 'OptionGrid';


### PR DESCRIPTION
## Summary
- **OptionGrid component enhancements**: Added support for disabled option items and loading state functionality
- **Disabled state styling**: Implemented visual styling for disabled options using design tokens with proper color contrast and cursor indicators
- **Loading state with LoadingBox**: Added `isLoading` prop that displays skeleton loading boxes matching the grid column layout
- **Enhanced Storybook stories**: Updated stories to demonstrate disabled options and improved interaction testing
- **Accessibility improvements**: Proper ARIA attributes and keyboard navigation support for disabled states
- **Type safety**: Extended `OptionItem` interface with optional `disabled` boolean property

## Test plan
- [x] All existing tests pass with no regressions
- [x] Lint and TypeScript checks pass
- [x] Storybook stories demonstrate new disabled and loading functionality
- [x] Keyboard navigation properly skips disabled items
- [x] Visual styling follows design system tokens
- [x] Loading state displays appropriate skeleton loaders
- [x] Changeset generated for release tracking

🤖 Generated with [Claude Code](https://claude.ai/code)