### PR TITLE
fix(AG-18446): add React Aria locale context to OverdriveProvider

### DIFF
--- a/.changeset/fix-dateinput-locale.md
+++ b/.changeset/fix-dateinput-locale.md
@@ -1,0 +1,5 @@
+---
+"@autoguru/overdrive": patch
+---
+
+Fix DateInput, Calendar, and DateTimeField showing US date format (MM/DD/YYYY) instead of locale-appropriate format. OverdriveProvider now wraps children with React Aria's I18nProvider, auto-detecting locale from i18next or accepting an explicit `locale` prop.

--- a/lib/components/OverdriveProvider/OverdriveProvider.spec.tsx
+++ b/lib/components/OverdriveProvider/OverdriveProvider.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { useLocale } from 'react-aria';
 import { describe, expect, it } from 'vitest';
 
 import { OverdriveProvider, useTheme } from './OverdriveProvider';
@@ -69,5 +70,58 @@ describe('<OverdriveProvider />', () => {
 
 		const element = screen.getByTestId('no-body-theming');
 		expect(element).toBeInTheDocument();
+	});
+
+	it('should provide locale to React Aria context when locale prop is set', () => {
+		const LocaleDisplay = () => {
+			const { locale } = useLocale();
+			return <div data-testid="locale-display">{locale}</div>;
+		};
+
+		render(
+			<OverdriveProvider locale="en-AU">
+				<LocaleDisplay />
+			</OverdriveProvider>,
+		);
+
+		expect(screen.getByTestId('locale-display')).toHaveTextContent('en-AU');
+	});
+
+	it('should auto-detect locale from window.i18next when no prop is passed', () => {
+		const LocaleDisplay = () => {
+			const { locale } = useLocale();
+			return <div data-testid="locale-display">{locale}</div>;
+		};
+
+		(window as any).i18next = { language: 'en' };
+
+		render(
+			<OverdriveProvider>
+				<LocaleDisplay />
+			</OverdriveProvider>,
+		);
+
+		expect(screen.getByTestId('locale-display')).toHaveTextContent('en-AU');
+
+		delete (window as any).i18next;
+	});
+
+	it('should fall back to browser default when no locale prop and no i18next', () => {
+		const LocaleDisplay = () => {
+			const { locale } = useLocale();
+			return <div data-testid="locale-display">{locale}</div>;
+		};
+
+		delete (window as any).i18next;
+
+		render(
+			<OverdriveProvider>
+				<LocaleDisplay />
+			</OverdriveProvider>,
+		);
+
+		expect(screen.getByTestId('locale-display')).toHaveTextContent(
+			navigator.language,
+		);
 	});
 });

--- a/lib/components/OverdriveProvider/OverdriveProvider.tsx
+++ b/lib/components/OverdriveProvider/OverdriveProvider.tsx
@@ -1,4 +1,5 @@
 import { invariant } from '@autoguru/utilities';
+import { I18nProvider as ReactAriaI18nProvider } from '@react-aria/i18n';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import { isEqual } from 'es-toolkit';
 import React, { createContext, useContext, useEffect, useMemo } from 'react';
@@ -14,6 +15,41 @@ import { useColorOverrides, type ColorOverrides } from './useColorOverrides';
 type ThemeContract = typeof overdriveTokens;
 type PortalMountPoint = React.RefObject<HTMLElement | null>;
 
+/**
+ * Maps 2-letter language codes to full BCP47 locale codes.
+ * English defaults to Australian locale (DD/MM/YYYY format).
+ */
+const LANGUAGE_TO_LOCALE: Record<string, string> = {
+	en: 'en-AU',
+	de: 'de-DE',
+	fr: 'fr-FR',
+	es: 'es-ES',
+	it: 'it-IT',
+	nl: 'nl-NL',
+	pl: 'pl-PL',
+	sv: 'sv-SE',
+	ja: 'ja-JP',
+};
+
+/**
+ * Resolves the locale for React Aria components.
+ * Priority: explicit prop > i18next language (mapped to full locale) > undefined (React Aria browser default)
+ */
+function resolveLocale(localeProp?: string): string | undefined {
+	if (localeProp) return localeProp;
+	if (!isBrowser) return undefined;
+
+	const i18nextLang = (
+		window as unknown as { i18next?: { language?: string } }
+	).i18next?.language;
+
+	if (i18nextLang) {
+		return LANGUAGE_TO_LOCALE[i18nextLang] || i18nextLang;
+	}
+
+	return undefined;
+}
+
 export interface ProviderProps {
 	/** The theme object to be used throughout the application */
 	theme?: typeof baseTheme;
@@ -25,6 +61,15 @@ export interface ProviderProps {
 	colorOverrides?: Partial<ColorOverrides>;
 	/** Reference to an HTML element where portals should be mounted */
 	portalMountPoint?: PortalMountPoint;
+	/**
+	 * BCP47 locale string for React Aria components (DateInput, Calendar, etc.).
+	 * Controls date segment ordering, number formatting, and text direction.
+	 *
+	 * @example "en-AU" for Australian English (DD/MM/YYYY)
+	 * @example "de-DE" for German
+	 * @default Falls back to browser's navigator.language
+	 */
+	locale?: string;
 	children?: React.ReactNode;
 }
 
@@ -64,6 +109,7 @@ export const Provider = ({
 	breakpoints,
 	children,
 	colorOverrides,
+	locale,
 	noBodyLevelTheming = false,
 	portalMountPoint,
 	theme = baseTheme,
@@ -111,16 +157,20 @@ export const Provider = ({
 		}
 	}, [portalMountPoint]);
 
+	const resolvedLocale = resolveLocale(locale);
+
 	return (
 		<OverdriveContext.Provider value={themeValues}>
 			<RuntimeTokensContext.Provider value={runtimeTokens}>
-				<div
-					className={theme.themeRef}
-					style={styles}
-					data-od-component="provider"
-				>
-					{children}
-				</div>
+				<ReactAriaI18nProvider locale={resolvedLocale}>
+					<div
+						className={theme.themeRef}
+						style={styles}
+						data-od-component="provider"
+					>
+						{children}
+					</div>
+				</ReactAriaI18nProvider>
 			</RuntimeTokensContext.Provider>
 		</OverdriveContext.Provider>
 	);


### PR DESCRIPTION
## Summary

- DateInput/Calendar/DateTimeField show US date format (MM/DD/YYYY) instead of Australian (DD/MM/YYYY) because React Aria's `useLocale()` falls back to `navigator.language` (`en-US` on many AU macOS browsers)
- OverdriveProvider now wraps children with React Aria's `I18nProvider`, auto-detecting locale from `window.i18next.language` (mapped to full BCP47, e.g. `en` → `en-AU`)
- Optional `locale` prop added for explicit override; no consumer changes required for the fix to take effect

## Test plan

- [x] All 8 OverdriveProvider tests pass (5 existing + 3 new locale tests)
- [ ] Verify DateInput in fmo-booking "Submit For Approval" modal shows DD/MM/YYYY after Overdrive version bump

[AG-18446](https://autoguru.atlassian.net/browse/AG-18446)

[AG-18446]: https://autoguru.atlassian.net/browse/AG-18446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ