### PR TITLE
ci: configure git identity so publish workflow creates release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,11 @@ jobs:
             - name: Yarn install
               run: yarn --immutable
 
+            - name: Configure git identity for tag creation
+              run: |
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git config user.name "github-actions[bot]"
+
             - name: Save existing tags
               run: git tag -l | sort > /tmp/tags-before
 


### PR DESCRIPTION
## Summary

- Configures `github-actions[bot]` git identity in `publish.yml` before `yarn changeset publish` runs, so that annotated tag creation (`git tag <v> -m <v>`) stops silently failing on the runner.
- Restores the `Publish Storybook` job's gate: with tags now landing correctly, the `comm -13` comparison resolves `published=true` on real releases and the post-merge Storybook deploy runs again.

## Why

After the OIDC Trusted Publishers migration (#1319) the workflow stopped using `changesets/action@v1` — which configures git identity internally — in favour of a direct `yarn changeset publish` call plus a shell tag-diff to detect releases. The runner has no default `user.email` / `user.name`, so `git tag -m …` exits non-zero. `@changesets/git`'s `tag()` helper returns that exit code but the caller in `@changesets/cli` ignores it, so the failure never surfaced.

Evidence from the 2026-04-17 run (`24550253845`):

\`\`\`
🦋  success packages published successfully:
🦋  @autoguru/overdrive@4.55.0
🦋  Creating git tag...
🦋  New tag:  v4.55.0
…
No new tags created — nothing to release
\`\`\`

npm received the release but the repo never got a `v4.55.0` tag, so `Publish Storybook` was skipped. Same pattern applied to the 4.54.x publish. This is why https://overdrive.autoguru.io/ has been stale and is missing the new `DataTable` component.

## Follow-ups (not in this PR)

- Run the existing manual `buildStorybook.yml` workflow once against `main` to bring the deployed Storybook back in sync with 4.55.0 immediately (already kicked off).
- `v4.54.x` and `v4.55.0` tags never landed on the remote — if we want GitHub releases / tag history to stay consistent we can backfill them in a separate change.

## Test plan

- [ ] Merge, then on the next `Version Packages` → `main` merge, confirm `Publish to npm` creates tag `vX.Y.Z`, pushes it to origin, creates the GitHub release, and `Publish Storybook` runs (no longer skipped).
- [ ] Confirm overdrive.autoguru.io updates to the newly released version after the run completes.