### PR TITLE
feat: expose per-component default-export companions via exports map

### DIFF
--- a/.changeset/expose-component-default-exports.md
+++ b/.changeset/expose-component-default-exports.md
@@ -1,0 +1,9 @@
+---
+'@autoguru/overdrive': minor
+---
+
+Expose per-component default-export companion entries via the package `exports` map. Consumers can now `import('@autoguru/overdrive/components/X/default')` (or `import Component from '@autoguru/overdrive/components/X/default'`) and receive the named component as the module's default export.
+
+This unlocks reliable code splitting under `React.lazy()` for downstream apps. The previous `import('@autoguru/overdrive/components/X').then(m => ({ default: m.X }))` pattern is fragile under Rollup's named-export tracking through dynamic-import namespaces — combined with the `sideEffects` allow-list and the `/*#__PURE__*/`-annotated `forwardRef` calls in component sources, Rollup can tree-shake the implementation file out of the lazy chunk, leaving callers with `default: undefined` at runtime. Importing the existing `default.js` companion via `/components/X/default` gives Rollup a direct default-export reference to track, eliminating that failure mode.
+
+The change is purely additive — no existing import paths or behaviours change, and no component file's `sideEffects` status is altered.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
 			"types": "./dist/components/*/index.d.ts",
 			"default": "./dist/components/*/index.js"
 		},
+		"./components/*/default": {
+			"types": "./dist/components/*/default.d.ts",
+			"default": "./dist/components/*/default.js"
+		},
 		"./hooks": {
 			"types": "./dist/hooks/index.d.ts",
 			"default": "./dist/hooks/index.js"


### PR DESCRIPTION
## Summary

Surface the existing `dist/components/X/default.js` companion files (which re-export each component as the module's default) through the package `exports` map under `./components/*/default`.

## Why

Consumers using `React.lazy()` against components had to write:

\`\`\`ts
const TextLink = lazy(() =>
  import('@autoguru/overdrive/components/TextLink').then((m) => ({ default: m.TextLink }))
);
\`\`\`

This is fragile under Rollup's named-export tracking through dynamic-import namespaces. Combined with this package's \`sideEffects\` allow-list and the \`/*#__PURE__*/\`-annotated \`forwardRef\` calls in the component sources, Rollup can tree-shake the implementation file out of the lazy chunk entirely. The consumer's lazy then resolves with \`{ default: undefined }\` at runtime, and React throws **Minified error #130** with \`args[]=undefined&args[]=\` from \`createFiberFromElement\`.

This was the root cause of the AutoGuru NZ supplier-portal incident (1,353 React #130 errors over 7 days against an unchanged Vite-built bundle on \`release/9.24.0\`). Confirmed: \`grep -c TextLink\` against the deployed \`sp-global-notification\` main bundle returns **0**, despite the source mapping every \`<a>\` HAST node to a lazy \`TextLink\`.

After this change, the consumer can write:

\`\`\`ts
const TextLink = lazy(() => import('@autoguru/overdrive/components/TextLink/default'));
\`\`\`

Rollup tracks default exports trivially, the implementation file is preserved, and code splitting still works.

## Scope

- **Purely additive.** No existing exports path, behaviour, or file's \`sideEffects\` status is changed. Existing \`./components/X\` imports continue to work identically.
- **No new files.** Every \`default.js\` companion already exists in \`dist/\` — built by the existing \`babel\`-based build. We're only exposing them through the \`exports\` field.
- Tree-shaking is fully preserved for the existing \`./components/X\` path; consumers that don't use \`/default\` are unaffected.

## Test plan

- [x] \`./dist/components/X/default.js\` and \`./dist/components/X/default.d.ts\` exist for every component (verified via \`ls\`).
- [ ] \`npm pack\` and inspect the resulting tarball — confirm \`exports['./components/*/default']\` resolves correctly.
- [ ] Downstream MFE smoke test — switch a single \`hastMapperSPA\` lazy in the AutoGuru MFE monorepo to use \`/default\` and confirm the chunk graph now contains the implementation file.

## Follow-ups

- AutoGuru MFE PR #3139 will bump this minor version and migrate \`packages/cms/HastRenderer/hastMapperSPA.tsx\` to use the \`/default\` paths.