### PR TITLE
feat(tokens): change link colours from blue to green

### DIFF
--- a/.changeset/textlink-colour-green.md
+++ b/.changeset/textlink-colour-green.md
@@ -1,0 +1,7 @@
+---
+'@autoguru/overdrive': minor
+---
+
+Update TextLink and other link-coloured tokens from blue to green to match the AutoGuru brand. The `interactive.link` (modern), `foreground.link` (legacy), and `typography.colour.link` tokens now resolve to `colourMap.green['600']`; `interactive.linkVisited` resolves to `colourMap.green['700']`.
+
+This is a visual change that affects every consumer using `TextLink` or any text styled with `colour="link"` / the `info`-derived link tokens. Components that intentionally need the old blue link colour can opt out by overriding the `colour` prop or applying a local style.

--- a/lib/themes/base/tokens.ts
+++ b/lib/themes/base/tokens.ts
@@ -1,5 +1,5 @@
 import { buildColourGamut } from '../makeTheme';
-import { overdriveTokens, type ThemeTokens } from '../theme.css';
+import { type ThemeTokens } from '../theme.css';
 
 import {
 	colourMap,

--- a/lib/themes/base/tokens.ts
+++ b/lib/themes/base/tokens.ts
@@ -60,8 +60,8 @@ export const tokens = {
 			borderDisabled: colourMap.gray['100'],
 			surfaceDisabled: colourMap.gray['400'],
 			contentDisabled: colourMap.gray['600'],
-			link: `${overdriveTokens.color.content.info}`,
-			linkVisited: `${overdriveTokens.color.interactive.link}`,
+			link: colourMap.green['600'],
+			linkVisited: colourMap.green['700'],
 			overlayBg: colourMap.gray['300'],
 			overlayContainer: colourMap.white,
 			placeholder: colourMap.gray['700'],
@@ -75,7 +75,7 @@ export const tokens = {
 		},
 		foreground: {
 			body: colourMap.gray['900'],
-			link: colourMap.blue['500'],
+			link: colourMap.green['600'],
 		},
 		background: {
 			body: colourMap.white,
@@ -244,7 +244,7 @@ export const tokens = {
 			secondary: colourMap.gray['700'],
 			brand: colourMap.green['600'],
 			shine: colourMap.yellow['500'],
-			link: colourMap.blue['500'],
+			link: colourMap.green['600'],
 			dark: colourMap.gray['900'],
 			white: colourMap.white,
 			muted: colourMap.gray['400'],


### PR DESCRIPTION
## Summary

Switches the link-related design tokens from blue to green to match the AutoGuru brand.

| Token | Before | After |
|---|---|---|
| \`interactive.link\` (modern) | \`overdriveTokens.color.content.info\` (blue 600) | \`colourMap.green['600']\` |
| \`interactive.linkVisited\` (modern) | \`overdriveTokens.color.interactive.link\` | \`colourMap.green['700']\` |
| \`foreground.link\` (legacy) | \`colourMap.blue['500']\` | \`colourMap.green['600']\` |
| \`typography.colour.link\` | \`colourMap.blue['500']\` | \`colourMap.green['600']\` |

\`TextLink\` reads from \`vars.typography.colour.link\` so the visual change flows through automatically.

## Why

Aligns with the latest dashboard QA review for the Fleet Client Portal — the "View all Bookings" link was redesigned as a green text link rather than a bordered button. To keep the design system as the source of truth (rather than overriding per-instance), the brand-correct green is applied to the link token globally.

## Visual impact

Every consumer rendering \`TextLink\`, or any text styled with \`colour="link"\`, now resolves to green 600. Components that intentionally need the previous blue can override per-instance via the \`colour\` prop or a local style.

## Changeset

Included — \`.changeset/textlink-colour-green.md\` (minor bump).

## Test plan

- [x] TextLink unit tests pass (\`bun vitest run --project=unit-tests TextLink\`)
- [ ] Chromatic visual diff review
- [ ] Spot-check downstream consumers (mfe FCP dashboard "View all Bookings"; supplier portal; FMO)