### PR TITLE
fix: mark hooks as side-effectful to avoid Rolldown deferred-init bug

### DIFF
--- a/.changeset/hooks-side-effects-rolldown.md
+++ b/.changeset/hooks-side-effects-rolldown.md
@@ -1,0 +1,7 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Mark the `hooks/` subtree as side-effectful so bundlers evaluate it eagerly instead of deferring module init.
+
+Why: Rolldown (the bundler under Vite 8) applies a deferred-init pattern to modules it considers side-effect-free. When a hook file is split into its own chunk and a consumer imports the hook function without also triggering the chunk's init wrapper, internal references (e.g. `React.useMemo` inside `useResponsiveValue`) resolve to `undefined` at call time and throw `Cannot read properties of undefined (reading 'useMemo')`. Adding the hooks paths to `sideEffects` forces eager evaluation and sidesteps the chunk-linking bug. CSS- and theme-side-effect entries are unchanged; tree-shaking of components and utils is not affected.

--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
 		"./dist/styles/global/*",
 		"./dist/themes/**/*",
 		"./dist/**/*.css.js",
-		"./lib/**/*.css.ts"
+		"./lib/**/*.css.ts",
+		"./lib/hooks/**/*",
+		"./dist/hooks/**/*"
 	],
 	"files": [
 		"dist"


### PR DESCRIPTION
## Summary

- Adds `./lib/hooks/**/*` and `./dist/hooks/**/*` to the package's `sideEffects` array.
- Forces bundlers (Vite 8 / Rolldown specifically) to evaluate hook modules eagerly instead of using the deferred-init wrapper.
- No code or API changes; tree-shaking of components and utilities is unaffected.

## Why this exists

Consumers on Vite 8 (Rolldown) have started hitting `TypeError: Cannot read properties of undefined (reading 'useMemo')` originating in `useResponsiveValue`. The compiled chunk follows this shape:

```js
import { a as e, n as t } from "./rolldown-runtime-*.js";
import { n as i } from "./jsx-runtime-*.js"; // React, namespaced

function l(/* args */) {
  // ...
  return (0, u.useMemo)(/* ... */);  // <-- uses u.useMemo synchronously
}

var u, d = t(() => { u = e(i()); /* ...other inits */ });
export { l as n, d as t };
```

`u` (the React namespace) is only assigned inside `d`, the chunk's deferred-init wrapper. If a consumer imports `{ n as fn }` without also pulling in and invoking `t` (the init), `u` stays `undefined` and `u.useMemo` throws on first call.

Reproduced today in the `fls-booking` MFE on `dev_au`: the consumer chunk `asset-resolver-*.js` imports only `{ n as w }` from `useResponsiveValue-*.js` — the init export is dropped — and the page crashes when the asset details panel renders.

Marking the hook files as having side effects opts them out of Rolldown's lazy-chunk treatment, so the assignments run at import time rather than inside a never-triggered wrapper. This is consistent with how the package already declares CSS and theme files as side-effectful.

## Scope of the workaround

| Path | Treatment | Notes |
|---|---|---|
| `./lib/hooks/**/*` + `./dist/hooks/**/*` | Side-effectful (this PR) | Covers all 13 hooks (`useResponsiveValue`, `useMedia`, `useContainerWidth`, `useDeepCompareMemo`, …). |
| Components | Tree-shaken (unchanged) | Components are eagerly imported as JSX, so the deferred-init class of bug doesn't bite them in practice. |
| Utilities | Tree-shaken (unchanged) | Plain functions without React/runtime imports — not vulnerable. |

If we see the same crash signature surface in non-hook exports, we can expand the list incrementally.

## Long-term

This is a workaround. The underlying bug is in Rolldown's chunk-linking — consumers should always receive the chunk's init export alongside the value exports they pull. Worth raising upstream with a minimal repro; happy to file a follow-up issue if useful.

## Test plan

- [ ] CI green
- [ ] Re-publish or yarn-link the patched build, rebuild a consumer on Vite 8, and confirm `useResponsiveValue` no longer throws `useMemo of undefined`
- [ ] Confirm webpack-based consumers see no behavioural change (the additional `sideEffects` entries just disable tree-shaking for hooks, which webpack already handled this way)