### PR TITLE
fix(AG-19060): import I18nProvider from react-aria umbrella

### DIFF
--- a/.changeset/overdriveprovider-react-aria-i18n-import.md
+++ b/.changeset/overdriveprovider-react-aria-i18n-import.md
@@ -1,0 +1,7 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Import `I18nProvider` from the `react-aria` umbrella instead of the granular `@react-aria/i18n` package in `OverdriveProvider`.
+
+`react-aria` 3.46+ no longer pulls in `@react-aria/i18n` as a transitive dependency, so consumers on those versions had nothing to resolve the granular import to. Builds using Rolldown/Vite failed with `failed to resolve import "@react-aria/i18n"`, and setups that resolved a stale copy ended up with a duplicate `react-aria` instance, which surfaced as a runtime `Cannot read properties of undefined (reading 'useMemo')` crash on mount. Importing from the `react-aria` peer dependency we already declare keeps everything on a single instance.

--- a/lib/components/OverdriveProvider/OverdriveProvider.tsx
+++ b/lib/components/OverdriveProvider/OverdriveProvider.tsx
@@ -1,8 +1,8 @@
 import { invariant } from '@autoguru/utilities';
-import { I18nProvider as ReactAriaI18nProvider } from '@react-aria/i18n';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import { isEqual } from 'es-toolkit';
 import React, { createContext, useContext, useEffect, useMemo } from 'react';
+import { I18nProvider as ReactAriaI18nProvider } from 'react-aria';
 
 import type { BreakPoints } from '../../themes';
 import baseTheme from '../../themes/base';


### PR DESCRIPTION
## What

`OverdriveProvider` imports `I18nProvider` from the `react-aria` umbrella instead of the granular `@react-aria/i18n` package. Includes a patch changeset.

Related: [AG-19060](https://autoguru.atlassian.net/browse/AG-19060)

## Why

We import `I18nProvider` from `@react-aria/i18n`, but we only declare a peer dependency on the `react-aria` umbrella — never the granular package:

```ts
import { I18nProvider as ReactAriaI18nProvider } from '@react-aria/i18n';
```

`react-aria` 3.46+ stopped pulling `@react-aria/i18n` in as a transitive dependency. On older versions (we dev-pin 3.44.0) the granular package is present, so our own build is fine — but consumers on 3.46+ have nothing to resolve the import to. That shows up two ways downstream:

- **Build failure** — Rolldown/Vite errors with `failed to resolve import "@react-aria/i18n"`, so the consumer never produces an artifact.
- **Runtime crash** — trees that happen to resolve a stale `@react-aria/i18n` copy end up with a *duplicate* `react-aria` instance, which surfaces as `TypeError: Cannot read properties of undefined (reading 'useMemo')` on mount.

The AutoGuru MFE monorepo hit both after `react-aria` floated to 3.48.0 (AG-19060: sp-app-shell crashing on Auth0 callback in pre-prod 9.31).

## Fix

Import `I18nProvider` from `react-aria` — the peer we already declare. The umbrella re-exports the same `I18nProvider`, so behaviour is unchanged, and consumers stay on a single `react-aria` instance regardless of their installed minor.

## Changes

- `lib/components/OverdriveProvider/OverdriveProvider.tsx` — import `I18nProvider` from `react-aria`
- `.changeset/overdriveprovider-react-aria-i18n-import.md` — patch bump

## Verification

- `eslint` + `prettier` clean on the changed file
- `OverdriveProvider.spec.tsx` — 8/8 passing


[AG-19060]: https://autoguru.atlassian.net/browse/AG-19060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ