### PR TITLE
feat(AG-19154): ensure CSS layer order across bundler chunks

### DIFF
--- a/.changeset/ensure-layer-order.md
+++ b/.changeset/ensure-layer-order.md
@@ -1,0 +1,5 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Ensure CSS layer order declaration is emitted in each component's CSS output to prevent cascade ordering issues with bundler chunking

--- a/lib/components/Button/Button.css.ts
+++ b/lib/components/Button/Button.css.ts
@@ -1,12 +1,12 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 const intentColors = vars.colours.intent;
 const smallHeight = '36px';

--- a/lib/components/Button/Button.css.ts
+++ b/lib/components/Button/Button.css.ts
@@ -2,7 +2,9 @@ import { style } from '@vanilla-extract/css';
 import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';
 

--- a/lib/components/Calendar/Calendar.css.ts
+++ b/lib/components/Calendar/Calendar.css.ts
@@ -1,12 +1,12 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as tokens } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const calendarGridStyle = style({
 	'@layer': {

--- a/lib/components/Calendar/Calendar.css.ts
+++ b/lib/components/Calendar/Calendar.css.ts
@@ -1,7 +1,9 @@
 import { style } from '@vanilla-extract/css';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as tokens } from '../../themes/theme.css';

--- a/lib/components/Columns/Column.css.ts
+++ b/lib/components/Columns/Column.css.ts
@@ -1,10 +1,11 @@
+import { globalLayer } from '@vanilla-extract/css';
 import { recipe, type RecipeVariants } from '@vanilla-extract/recipes';
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { responsiveConditions, sprinkles } from '../../styles/sprinkles.css';
+
+globalLayer(LAYER_ORDER);
 
 const getSizeStyle = (scale: number) => `${scale * 100}%`;
 

--- a/lib/components/Columns/Column.css.ts
+++ b/lib/components/Columns/Column.css.ts
@@ -1,7 +1,9 @@
 import { recipe, type RecipeVariants } from '@vanilla-extract/recipes';
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
 
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { responsiveConditions, sprinkles } from '../../styles/sprinkles.css';
 
 const getSizeStyle = (scale: number) => `${scale * 100}%`;

--- a/lib/components/DateInput/DateInput.css.ts
+++ b/lib/components/DateInput/DateInput.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 

--- a/lib/components/DateInput/DateInput.css.ts
+++ b/lib/components/DateInput/DateInput.css.ts
@@ -1,10 +1,10 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
+
+globalLayer(LAYER_ORDER);
 
 export const segmentStyle = style({
 	'@layer': {

--- a/lib/components/DatePicker/DatePicker.css.ts
+++ b/lib/components/DatePicker/DatePicker.css.ts
@@ -1,9 +1,9 @@
-import { style, styleVariants } from '@vanilla-extract/css';
+import { globalLayer, style, styleVariants } from '@vanilla-extract/css';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const inputContainer = style({
 	'@layer': {

--- a/lib/components/DatePicker/DatePicker.css.ts
+++ b/lib/components/DatePicker/DatePicker.css.ts
@@ -1,6 +1,8 @@
 import { style, styleVariants } from '@vanilla-extract/css';
 
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { overdriveTokens as vars } from '../../themes/theme.css';
 
 export const inputContainer = style({

--- a/lib/components/DateTimeField/DateTimeField.css.ts
+++ b/lib/components/DateTimeField/DateTimeField.css.ts
@@ -2,7 +2,9 @@ import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { focusOutline, focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { textStyles } from '../../styles/typography';

--- a/lib/components/DateTimeField/DateTimeField.css.ts
+++ b/lib/components/DateTimeField/DateTimeField.css.ts
@@ -1,14 +1,14 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { focusOutline, focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { textStyles } from '../../styles/typography';
 import { overdriveTokens } from '../../themes';
+
+globalLayer(LAYER_ORDER);
 
 const baseFieldStyle = style([
 	sprinkles({

--- a/lib/components/EditableText/EditableText.css.ts
+++ b/lib/components/EditableText/EditableText.css.ts
@@ -1,9 +1,9 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const root = style({
 	'@layer': {

--- a/lib/components/EditableText/EditableText.css.ts
+++ b/lib/components/EditableText/EditableText.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { overdriveTokens as vars } from '../../themes/theme.css';
 
 export const root = style({

--- a/lib/components/MarkdownRenderer/MarkdownRenderer.css.ts
+++ b/lib/components/MarkdownRenderer/MarkdownRenderer.css.ts
@@ -1,10 +1,10 @@
-import { globalStyle, style } from '@vanilla-extract/css';
+import { globalLayer, globalStyle, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { overdriveTokens as tokens } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const rootBase = style({
 	'@layer': {

--- a/lib/components/MarkdownRenderer/MarkdownRenderer.css.ts
+++ b/lib/components/MarkdownRenderer/MarkdownRenderer.css.ts
@@ -1,7 +1,9 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { overdriveTokens as tokens } from '../../themes/theme.css';
 
 export const rootBase = style({

--- a/lib/components/MarkdownRenderer/components/MarkdownBlockquote.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownBlockquote.css.ts
@@ -1,9 +1,10 @@
+import { globalLayer } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../../styles/layers.css';
 import { overdriveTokens as tokens } from '../../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const blockquote = recipe({
 	base: {

--- a/lib/components/MarkdownRenderer/components/MarkdownBlockquote.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownBlockquote.css.ts
@@ -1,6 +1,8 @@
 import { recipe } from '@vanilla-extract/recipes';
 
-import { cssLayerComponent } from '../../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
+
+ensureLayerOrder();
 import { overdriveTokens as tokens } from '../../../themes/theme.css';
 
 export const blockquote = recipe({

--- a/lib/components/MarkdownRenderer/components/MarkdownCodeBlock.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownCodeBlock.css.ts
@@ -1,7 +1,9 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import { cssLayerComponent } from '../../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
+
+ensureLayerOrder();
 import { overdriveTokens as tokens } from '../../../themes/theme.css';
 
 export const codeBlock = recipe({

--- a/lib/components/MarkdownRenderer/components/MarkdownCodeBlock.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownCodeBlock.css.ts
@@ -1,10 +1,10 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../../styles/layers.css';
 import { overdriveTokens as tokens } from '../../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const codeBlock = recipe({
 	base: {

--- a/lib/components/MarkdownRenderer/components/MarkdownEmphasis.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownEmphasis.css.ts
@@ -1,8 +1,8 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
+import { LAYER_ORDER, cssLayerComponent } from '../../../styles/layers.css';
 
-ensureLayerOrder();
+globalLayer(LAYER_ORDER);
 
 export const emphasis = style({
 	'@layer': {

--- a/lib/components/MarkdownRenderer/components/MarkdownEmphasis.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownEmphasis.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 
-import { cssLayerComponent } from '../../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
+
+ensureLayerOrder();
 
 export const emphasis = style({
 	'@layer': {

--- a/lib/components/MarkdownRenderer/components/MarkdownImage.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownImage.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 
-import { cssLayerComponent } from '../../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
+
+ensureLayerOrder();
 import { overdriveTokens as tokens } from '../../../themes/theme.css';
 
 export const image = style({

--- a/lib/components/MarkdownRenderer/components/MarkdownImage.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownImage.css.ts
@@ -1,9 +1,9 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../../styles/layers.css';
 import { overdriveTokens as tokens } from '../../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const image = style({
 	'@layer': {

--- a/lib/components/MarkdownRenderer/components/MarkdownInlineCode.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownInlineCode.css.ts
@@ -1,6 +1,8 @@
 import { recipe } from '@vanilla-extract/recipes';
 
-import { cssLayerComponent } from '../../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
+
+ensureLayerOrder();
 import { overdriveTokens as tokens } from '../../../themes/theme.css';
 
 export const inlineCode = recipe({

--- a/lib/components/MarkdownRenderer/components/MarkdownInlineCode.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownInlineCode.css.ts
@@ -1,9 +1,10 @@
+import { globalLayer } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../../styles/layers.css';
 import { overdriveTokens as tokens } from '../../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const inlineCode = recipe({
 	base: {

--- a/lib/components/MarkdownRenderer/components/MarkdownStrikethrough.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownStrikethrough.css.ts
@@ -1,8 +1,8 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
+import { LAYER_ORDER, cssLayerComponent } from '../../../styles/layers.css';
 
-ensureLayerOrder();
+globalLayer(LAYER_ORDER);
 
 export const strikethrough = style({
 	'@layer': {

--- a/lib/components/MarkdownRenderer/components/MarkdownStrikethrough.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownStrikethrough.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 
-import { cssLayerComponent } from '../../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
+
+ensureLayerOrder();
 
 export const strikethrough = style({
 	'@layer': {

--- a/lib/components/MarkdownRenderer/components/MarkdownTable.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownTable.css.ts
@@ -1,7 +1,9 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import { cssLayerComponent } from '../../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
+
+ensureLayerOrder();
 import { overdriveTokens as tokens } from '../../../themes/theme.css';
 
 export const tableWrapper = recipe({

--- a/lib/components/MarkdownRenderer/components/MarkdownTable.css.ts
+++ b/lib/components/MarkdownRenderer/components/MarkdownTable.css.ts
@@ -1,10 +1,10 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../../styles/layers.css';
 import { overdriveTokens as tokens } from '../../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const tableWrapper = recipe({
 	base: {

--- a/lib/components/NumberBubble/NumberBubble.css.ts
+++ b/lib/components/NumberBubble/NumberBubble.css.ts
@@ -1,8 +1,8 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 
-ensureLayerOrder();
+globalLayer(LAYER_ORDER);
 
 export const numberStyle = style({
 	'@layer': {

--- a/lib/components/NumberBubble/NumberBubble.css.ts
+++ b/lib/components/NumberBubble/NumberBubble.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 
 export const numberStyle = style({
 	'@layer': {

--- a/lib/components/OptionGrid/OptionGrid.css.ts
+++ b/lib/components/OptionGrid/OptionGrid.css.ts
@@ -2,7 +2,9 @@ import { createContainer, style } from '@vanilla-extract/css';
 import { recipe, type RecipeVariants } from '@vanilla-extract/recipes';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { breakpoints } from '../../themes/makeTheme';

--- a/lib/components/OptionGrid/OptionGrid.css.ts
+++ b/lib/components/OptionGrid/OptionGrid.css.ts
@@ -1,14 +1,14 @@
-import { createContainer, style } from '@vanilla-extract/css';
+import { createContainer, globalLayer, style } from '@vanilla-extract/css';
 import { recipe, type RecipeVariants } from '@vanilla-extract/recipes';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { breakpoints } from '../../themes/makeTheme';
 import { overdriveTokens as tokens } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 // === Container styles
 

--- a/lib/components/OptionList/OptionList.css.ts
+++ b/lib/components/OptionList/OptionList.css.ts
@@ -1,12 +1,12 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as tokens } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 // === Group styles
 export const groupStyle = sprinkles({

--- a/lib/components/OptionList/OptionList.css.ts
+++ b/lib/components/OptionList/OptionList.css.ts
@@ -1,7 +1,9 @@
 import { style } from '@vanilla-extract/css';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as tokens } from '../../themes/theme.css';

--- a/lib/components/Popover/Popover.css.ts
+++ b/lib/components/Popover/Popover.css.ts
@@ -1,11 +1,11 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as tokens } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const overlayStyle = style([
 	sprinkles({

--- a/lib/components/Popover/Popover.css.ts
+++ b/lib/components/Popover/Popover.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as tokens } from '../../themes/theme.css';

--- a/lib/components/SearchBar/SearchBar.css.ts
+++ b/lib/components/SearchBar/SearchBar.css.ts
@@ -1,12 +1,12 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as tokens } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 const hideWebkitAppearance = style({
 	'@layer': {

--- a/lib/components/SearchBar/SearchBar.css.ts
+++ b/lib/components/SearchBar/SearchBar.css.ts
@@ -2,7 +2,9 @@ import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as tokens } from '../../themes/theme.css';
 

--- a/lib/components/Slider/Slider.css.ts
+++ b/lib/components/Slider/Slider.css.ts
@@ -1,7 +1,9 @@
 import { style } from '@vanilla-extract/css';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';

--- a/lib/components/Slider/Slider.css.ts
+++ b/lib/components/Slider/Slider.css.ts
@@ -1,12 +1,12 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const container = sprinkles({
 	display: 'flex',

--- a/lib/components/Stack/Stack.css.ts
+++ b/lib/components/Stack/Stack.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { gapVar } from '../../styles/vars.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';
 

--- a/lib/components/Stack/Stack.css.ts
+++ b/lib/components/Stack/Stack.css.ts
@@ -1,10 +1,10 @@
-import { style } from '@vanilla-extract/css';
+import { globalLayer, style } from '@vanilla-extract/css';
 
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { gapVar } from '../../styles/vars.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 export const hr = style({
 	'@layer': {

--- a/lib/components/Switch/Switch.css.ts
+++ b/lib/components/Switch/Switch.css.ts
@@ -1,7 +1,9 @@
 import { style, styleVariants } from '@vanilla-extract/css';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { overdriveTokens as vars } from '../../themes/theme.css';
 
 const colorAccent = vars.colours.foreground.body;

--- a/lib/components/Switch/Switch.css.ts
+++ b/lib/components/Switch/Switch.css.ts
@@ -1,10 +1,10 @@
-import { style, styleVariants } from '@vanilla-extract/css';
+import { globalLayer, style, styleVariants } from '@vanilla-extract/css';
 
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';
+
+globalLayer(LAYER_ORDER);
 
 const colorAccent = vars.colours.foreground.body;
 const colorContrast = vars.colours.background.body;

--- a/lib/components/ToggleButtons/ToggleButtons.css.ts
+++ b/lib/components/ToggleButtons/ToggleButtons.css.ts
@@ -1,16 +1,16 @@
-import { createContainer, style } from '@vanilla-extract/css';
+import { createContainer, globalLayer, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { elementReset } from '../../styles/elementReset.css';
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
-
-ensureLayerOrder();
+import { LAYER_ORDER, cssLayerComponent } from '../../styles/layers.css';
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';
 
 import { WIDTH_COMPACT_ORIENTATION } from './constants';
+
+globalLayer(LAYER_ORDER);
 
 const TOGGLE_BUTTON_HEIGHT = '40px';
 

--- a/lib/components/ToggleButtons/ToggleButtons.css.ts
+++ b/lib/components/ToggleButtons/ToggleButtons.css.ts
@@ -3,7 +3,9 @@ import { recipe } from '@vanilla-extract/recipes';
 
 import { elementReset } from '../../styles/elementReset.css';
 import { focusOutlineStyle } from '../../styles/focusOutline.css';
-import { cssLayerComponent } from '../../styles/layers.css';
+import { cssLayerComponent, ensureLayerOrder } from '../../styles/layers.css';
+
+ensureLayerOrder();
 import { selectors } from '../../styles/selectors';
 import { sprinkles } from '../../styles/sprinkles.css';
 import { overdriveTokens as vars } from '../../themes/theme.css';

--- a/lib/styles/index.ts
+++ b/lib/styles/index.ts
@@ -1,4 +1,4 @@
-export { cssLayerComponent, cssLayerTheme, ensureLayerOrder } from './layers.css';
+export { cssLayerComponent, cssLayerTheme, LAYER_ORDER } from './layers.css';
 export { resetVariants, type ResetVariantProps } from './elementReset.css';
 export {
 	elementStyles,

--- a/lib/styles/index.ts
+++ b/lib/styles/index.ts
@@ -1,4 +1,4 @@
-export { cssLayerComponent, cssLayerTheme } from './layers.css';
+export { cssLayerComponent, cssLayerTheme, ensureLayerOrder } from './layers.css';
 export { resetVariants, type ResetVariantProps } from './elementReset.css';
 export {
 	elementStyles,

--- a/lib/styles/layers.css.ts
+++ b/lib/styles/layers.css.ts
@@ -1,6 +1,22 @@
 import { globalLayer } from '@vanilla-extract/css';
 
-globalLayer('ag, reset, theme, styleprops, component, util');
+const LAYER_ORDER = 'ag, reset, theme, styleprops, component, util';
+globalLayer(LAYER_ORDER);
+
+/**
+ * Call in any `.css.ts` file that uses cascade layers to guarantee the
+ * `@layer` order declaration is emitted *inside that file's CSS output*.
+ *
+ * Vanilla Extract guarantees `@layer` declarations appear before `@layer`
+ * blocks **within a single file**, but not across files.  Without this,
+ * a bundler that loads `Button.css.js` before `layers.css.js` would see
+ * `@layer component { … }` first, establishing `component` as the
+ * lowest-priority layer and breaking the cascade.
+ *
+ * The call is idempotent — multiple invocations produce a single
+ * `@layer ag, reset, theme, styleprops, component, util;` line.
+ */
+export const ensureLayerOrder = () => globalLayer(LAYER_ORDER);
 
 export const cssLayerReset = globalLayer('reset');
 export const cssLayerTheme = globalLayer('theme');

--- a/lib/styles/layers.css.ts
+++ b/lib/styles/layers.css.ts
@@ -1,22 +1,16 @@
 import { globalLayer } from '@vanilla-extract/css';
 
-const LAYER_ORDER = 'ag, reset, theme, styleprops, component, util';
-globalLayer(LAYER_ORDER);
-
 /**
- * Call in any `.css.ts` file that uses cascade layers to guarantee the
- * `@layer` order declaration is emitted *inside that file's CSS output*.
+ * The canonical layer-order declaration for the Overdrive design system.
  *
- * Vanilla Extract guarantees `@layer` declarations appear before `@layer`
- * blocks **within a single file**, but not across files.  Without this,
- * a bundler that loads `Button.css.js` before `layers.css.js` would see
- * `@layer component { … }` first, establishing `component` as the
- * lowest-priority layer and breaking the cascade.
- *
- * The call is idempotent — multiple invocations produce a single
- * `@layer ag, reset, theme, styleprops, component, util;` line.
+ * Import this constant and call `globalLayer(LAYER_ORDER)` at the top of
+ * any `.css.ts` file that uses cascade layers.  This guarantees the
+ * `@layer` order declaration is emitted *inside that file's CSS output*,
+ * so the ordering is correct regardless of how the bundler chunks and
+ * loads the files.
  */
-export const ensureLayerOrder = () => globalLayer(LAYER_ORDER);
+export const LAYER_ORDER = 'ag, reset, theme, styleprops, component, util';
+globalLayer(LAYER_ORDER);
 
 export const cssLayerReset = globalLayer('reset');
 export const cssLayerTheme = globalLayer('theme');


### PR DESCRIPTION
## Summary
- Exports `LAYER_ORDER` constant from `layers.css.ts` and adds a `globalLayer(LAYER_ORDER)` call at the top of every component `.css.ts` file
- This ensures the `@layer ag, reset, theme, styleprops, component, util;` order declaration is emitted **inside each file's CSS output**, so the cascade ordering is correct regardless of how the bundler chunks and loads files
- Without this, a bundler that loads e.g. `Button.css.js` before `layers.css.js` would see `@layer component { … }` first, establishing `component` as the lowest-priority layer and breaking the cascade
- Replaces the original `ensureLayerOrder()` function approach which was incompatible with Vanilla Extract's serialization constraints (`.css.ts` files can only export plain values, not functions)

## Components affected
Button, Calendar, Column, DateInput, DatePicker, DateTimeField, EditableText, MarkdownRenderer (+ 7 sub-components), NumberBubble, OptionGrid, OptionList, Popover, SearchBar, Slider, Stack, Switch, ToggleButtons

🤖 Generated with [Claude Code](https://claude.com/claude-code)