### PR TITLE
chore: re-flag @autoguru/icons 2.0 peer-dep bump as a major release

### DIFF
--- a/.changeset/icons-2-peer-major.md
+++ b/.changeset/icons-2-peer-major.md
@@ -1,0 +1,27 @@
+---
+"@autoguru/overdrive": major
+---
+
+Raise the `@autoguru/icons` peer-dependency floor to `>=2.0.0`.
+
+**Breaking change.** Overdrive now requires `@autoguru/icons@>=2.0.0`. The icons
+2.x release (Phosphor redesign) renames and removes a number of icons, so any
+consumer importing icon components directly by their 1.x names must update those
+imports when upgrading.
+
+Internal usage across the library has been migrated to the new icon names:
+
+- `Chevron*` → `Caret*`
+- `Close` / `WindowClose` → `X`
+- `Magnify` → `MagnifyingGlass`
+- `Email` → `Envelope`
+- `Settings` → `Gear`
+- `Sort` → `ArrowsDownUp`
+- `StoreOutline` → `Storefront`
+- `TrashCanOutline` → `Trash`
+- `Alert` → `Warning`
+
+No public Overdrive component API changed.
+
+The `Foundation/Icon Set` story was rebuilt with live name search and icons
+grouped into the DS 2026 design-system categories.


### PR DESCRIPTION
## Summary
- Adds a `major` changeset for `@autoguru/overdrive` so the next release bumps to **5.0.0**.
- The `@autoguru/icons` 2.0 upgrade (#1343) shipped in **4.58.0** as a *minor*, but raising the `@autoguru/icons` peer-dependency floor to `>=2.0.0` is a breaking change for downstream consumers (icons 2.x renames/removes a number of icons).
- This re-flags that change as `major` with a clean, structured release note — replacing the original "Reviewers may wish to release this as a major bump…" note that was addressed to a person rather than written as a release note.

No source changes — this PR only adds `.changeset/icons-2-peer-major.md`.

## Breaking Changes
- Overdrive now requires `@autoguru/icons@>=2.0.0`. Consumers importing icon components directly by their 1.x names must update those imports (e.g. `Chevron*` → `Caret*`, `Close`/`WindowClose` → `X`, `Magnify` → `MagnifyingGlass`, `Email` → `Envelope`, `Settings` → `Gear`, `Sort` → `ArrowsDownUp`, `StoreOutline` → `Storefront`, `TrashCanOutline` → `Trash`, `Alert` → `Warning`). No public Overdrive component API changed.

## Note
The breaking change already went out under `4.58.0` (minor). This corrects the public record going forward via a `5.0.0` major. Separately consider deprecating `4.58.0` on npm to steer consumers to `5.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
