### PR TITLE
feat: support custom Tooltip content

### DIFF
--- a/.changeset/bright-tooltips-compose.md
+++ b/.changeset/bright-tooltips-compose.md
@@ -1,0 +1,6 @@
+---
+'@autoguru/overdrive': minor
+---
+
+Add custom React content support to Tooltip while preserving the standard label
+surface, and allow Button triggers to expose tooltip descriptions.

--- a/lib/components/Button/Button.spec.tsx
+++ b/lib/components/Button/Button.spec.tsx
@@ -125,6 +125,19 @@ describe('<Button />', () => {
 		expect(button).toBeInTheDocument();
 	});
 
+	it('supports an accessible description', () => {
+		render(
+			<>
+				<Button aria-describedby="button-description">Button</Button>
+				<span id="button-description">Button description</span>
+			</>,
+		);
+
+		expect(
+			screen.getByRole('button', { name: 'Button' }),
+		).toHaveAccessibleDescription('Button description');
+	});
+
 	it('is keyboard accessible', async () => {
 		const user = userEvent.setup();
 		const handleClick = vi.fn();

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -53,7 +53,11 @@ export interface ButtonProps
 		>,
 		Pick<
 			AriaAttributes,
-			'aria-label' | 'aria-controls' | 'aria-expanded' | 'aria-haspopup'
+			| 'aria-label'
+			| 'aria-controls'
+			| 'aria-describedby'
+			| 'aria-expanded'
+			| 'aria-haspopup'
 		>,
 		StyledButtonProps,
 		TestIdProp {
@@ -146,6 +150,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 			'aria-label': ariaLabel,
 			'aria-controls': ariaControls,
+			'aria-describedby': ariaDescribedBy,
 			'aria-expanded': ariaExpanded,
 			'aria-haspopup': ariaHasPopup,
 		},
@@ -200,6 +205,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 			'aria-label': isLoading ? language.loading : ariaLabel,
 			'aria-controls': ariaControls,
+			'aria-describedby': ariaDescribedBy,
 			'aria-expanded': ariaExpanded,
 			'aria-haspopup': ariaHasPopup,
 			'data-loading': isLoading ? '' : undefined,

--- a/lib/components/Tooltip/Tooltip.spec.tsx
+++ b/lib/components/Tooltip/Tooltip.spec.tsx
@@ -213,6 +213,28 @@ describe('<Tooltip />', () => {
 		});
 	});
 
+	describe('custom content', () => {
+		it('should render a custom tooltip surface', () => {
+			const { getByRole, getByText } = render(
+				<Tooltip
+					content={
+						<div>
+							<strong>Custom title</strong>
+							<p>Custom body</p>
+						</div>
+					}
+					isOpen
+				>
+					<button type="button">trigger</button>
+				</Tooltip>,
+			);
+
+			expect(getByRole('tooltip')).toBeInTheDocument();
+			expect(getByText('Custom title').tagName).toBe('STRONG');
+			expect(getByText('Custom body').tagName).toBe('P');
+		});
+	});
+
 	describe('no label handling', () => {
 		it('should not render tooltip when label is empty', () => {
 			const { container } = render(
@@ -251,8 +273,9 @@ describe('<Tooltip /> with interactive child', () => {
 			expect(button).toHaveTextContent('Interactive Button');
 
 			fireEvent.mouseEnter(button);
-			// Use a more reliable way to check for tooltip content
-			expect(document.body).toHaveTextContent('Button tooltip');
+			const tooltip = getByRole('tooltip');
+			expect(tooltip).toHaveTextContent('Button tooltip');
+			expect(button).toHaveAttribute('aria-describedby', tooltip.id);
 		});
 
 		it('should preserve button functionality', () => {

--- a/lib/components/Tooltip/Tooltip.spec.tsx
+++ b/lib/components/Tooltip/Tooltip.spec.tsx
@@ -7,7 +7,7 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 import { TextInput } from '../TextInput';
 
-import { Tooltip } from './Tooltip';
+import { Tooltip, type TooltipProps } from './Tooltip';
 
 describe('<Tooltip />', () => {
 	const tooltipContentText = 'tooltip content';
@@ -214,6 +214,38 @@ describe('<Tooltip />', () => {
 	});
 
 	describe('custom content', () => {
+		it('should require exactly one content mode in its public props', () => {
+			type AcceptsLabel = {
+				children: React.ReactNode;
+				label: string;
+			} extends TooltipProps
+				? true
+				: false;
+			type AcceptsContent = {
+				children: React.ReactNode;
+				content: React.ReactNode;
+			} extends TooltipProps
+				? true
+				: false;
+			type AcceptsBoth = {
+				children: React.ReactNode;
+				content: React.ReactNode;
+				label: string;
+			} extends TooltipProps
+				? true
+				: false;
+			type AcceptsNeither = {
+				children: React.ReactNode;
+			} extends TooltipProps
+				? true
+				: false;
+
+			expectTypeOf<AcceptsLabel>().toEqualTypeOf<true>();
+			expectTypeOf<AcceptsContent>().toEqualTypeOf<true>();
+			expectTypeOf<AcceptsBoth>().toEqualTypeOf<false>();
+			expectTypeOf<AcceptsNeither>().toEqualTypeOf<false>();
+		});
+
 		it('should render a custom tooltip surface', () => {
 			const { getByRole, getByText } = render(
 				<Tooltip
@@ -232,6 +264,23 @@ describe('<Tooltip />', () => {
 			expect(getByRole('tooltip')).toBeInTheDocument();
 			expect(getByText('Custom title').tagName).toBe('STRONG');
 			expect(getByText('Custom body').tagName).toBe('P');
+		});
+
+		it('should reject label and content together at runtime', () => {
+			const invalidProps = {
+				content: <div>Custom content</div>,
+				label: tooltipContentText,
+			} as unknown as TooltipProps;
+
+			expect(() => {
+				render(
+					<Tooltip {...invalidProps}>
+						<button type="button">trigger</button>
+					</Tooltip>,
+				);
+			}).toThrow(
+				'Tooltip accepts either `label` or `content`, not both',
+			);
 		});
 	});
 

--- a/lib/components/Tooltip/Tooltip.stories.tsx
+++ b/lib/components/Tooltip/Tooltip.stories.tsx
@@ -2,9 +2,11 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React, { type ComponentProps } from 'react';
 import { userEvent, within, expect, waitFor } from 'storybook/test';
 
+import { Box } from '../Box';
 import { Button } from '../Button';
 import { FlexInline } from '../Flex/FlexInline';
 import { EAlignment } from '../Positioner/alignment';
+import { Stack } from '../Stack';
 import { Text } from '../Text/Text';
 import { TextInput } from '../TextInput';
 
@@ -120,6 +122,33 @@ export const WithLongText: Story = {
 	args: {
 		label: 'Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts.',
 		alignment: EAlignment.TOP,
+		wrapper: true,
+	},
+};
+
+export const WithCustomContent: Story = {
+	args: {
+		content: (
+			<Box
+				backgroundColor="white"
+				borderColor="default"
+				borderRadius="md"
+				borderWidth="1"
+				boxShadow="5"
+				padding="5"
+			>
+				<Stack space="2">
+					<Text size="3" weight="bold">
+						Custom tooltip title
+					</Text>
+					<Text size="2">
+						Custom tooltip content can compose any non-interactive
+						Overdrive primitives.
+					</Text>
+				</Stack>
+			</Box>
+		),
+		alignment: EAlignment.BOTTOM,
 		wrapper: true,
 	},
 };

--- a/lib/components/Tooltip/Tooltip.tsx
+++ b/lib/components/Tooltip/Tooltip.tsx
@@ -13,7 +13,7 @@ import { EAlignment } from '../Positioner/alignment';
 import * as styles from './Tooltip.css';
 import {
 	useTooltip,
-	type PositionedTooltipProps,
+	type PositionedTooltipContentProps,
 	type ToolTipSize,
 } from './useTooltip/useTooltip';
 
@@ -32,8 +32,7 @@ interface TooltipBaseProps extends TestIdProp {
 	wrapper?: boolean | keyof React.JSX.IntrinsicElements;
 }
 
-export type TooltipProps = TooltipBaseProps &
-	Pick<PositionedTooltipProps, 'content' | 'label'>;
+export type TooltipProps = TooltipBaseProps & PositionedTooltipContentProps;
 
 /**
  * Renders a tooltip that appears when the user hovers over or focuses on the trigger element.
@@ -61,13 +60,19 @@ export const Tooltip = ({
 		closeAfter,
 	});
 
-	// return early if no label provided
-	if (!label && content === undefined) return <>{children}</>;
+	invariant(
+		label === undefined || content === undefined,
+		'Tooltip accepts either `label` or `content`, not both',
+	);
 
-	const positionedTooltipContent =
-		content === undefined
-			? { label, content: undefined }
-			: { content, label: undefined };
+	let positionedTooltipContent: PositionedTooltipContentProps;
+	if (content === undefined) {
+		// Return children unchanged when the text label is empty.
+		if (!label) return <>{children}</>;
+		positionedTooltipContent = { label };
+	} else {
+		positionedTooltipContent = { content };
+	}
 
 	// return wrapped output
 	if (wrapper) {

--- a/lib/components/Tooltip/Tooltip.tsx
+++ b/lib/components/Tooltip/Tooltip.tsx
@@ -11,15 +11,17 @@ import { dataAttrs } from '../../utils/dataAttrs';
 import { EAlignment } from '../Positioner/alignment';
 
 import * as styles from './Tooltip.css';
-import { useTooltip, type ToolTipSize } from './useTooltip/useTooltip';
+import {
+	useTooltip,
+	type PositionedTooltipProps,
+	type ToolTipSize,
+} from './useTooltip/useTooltip';
 
-export interface TooltipProps extends TestIdProp {
+interface TooltipBaseProps extends TestIdProp {
 	/** Size of the tooltip text */
 	size?: ToolTipSize;
 	/** Whether the tooltip is open. When provided, the tooltip becomes controlled */
 	isOpen?: boolean;
-	/** Text content displayed in the tooltip */
-	label: string;
 	/** Position of the tooltip relative to the trigger element */
 	alignment?: EAlignment;
 	/** The element(s) that trigger the tooltip on hover or focus */
@@ -29,6 +31,9 @@ export interface TooltipProps extends TestIdProp {
 	/** An HTML tag to wrap the tooltip trigger with if children do not contain a keyboard focusable element */
 	wrapper?: boolean | keyof React.JSX.IntrinsicElements;
 }
+
+export type TooltipProps = TooltipBaseProps &
+	Pick<PositionedTooltipProps, 'content' | 'label'>;
 
 /**
  * Renders a tooltip that appears when the user hovers over or focuses on the trigger element.
@@ -42,6 +47,7 @@ export interface TooltipProps extends TestIdProp {
  */
 export const Tooltip = ({
 	alignment = EAlignment.RIGHT,
+	content,
 	isOpen,
 	label,
 	children,
@@ -56,7 +62,12 @@ export const Tooltip = ({
 	});
 
 	// return early if no label provided
-	if (!label) return <>{children}</>;
+	if (!label && content === undefined) return <>{children}</>;
+
+	const positionedTooltipContent =
+		content === undefined
+			? { label, content: undefined }
+			: { content, label: undefined };
 
 	// return wrapped output
 	if (wrapper) {
@@ -75,9 +86,9 @@ export const Tooltip = ({
 					{children}
 				</TagName>
 				<PositionedTooltip
+					{...positionedTooltipContent}
 					alignment={alignment}
 					className={styles.root}
-					label={label}
 					size={size}
 				/>
 			</>
@@ -98,9 +109,9 @@ export const Tooltip = ({
 				ref: triggerRef,
 			})}
 			<PositionedTooltip
+				{...positionedTooltipContent}
 				alignment={alignment}
 				className={styles.root}
-				label={label}
 				size={size}
 			/>
 		</>

--- a/lib/components/Tooltip/index.ts
+++ b/lib/components/Tooltip/index.ts
@@ -1,6 +1,7 @@
 export { Tooltip, type TooltipProps } from './Tooltip';
 export {
 	useTooltip,
+	type PositionedTooltipProps,
 	type UseTooltipProps,
 	type ToolTipSize,
 } from './useTooltip/useTooltip';

--- a/lib/components/Tooltip/useTooltip/useTooltip.spec.tsx
+++ b/lib/components/Tooltip/useTooltip/useTooltip.spec.tsx
@@ -180,6 +180,28 @@ describe('useTooltip', () => {
 		expect(tooltip).toHaveClass('custom-class');
 	});
 
+	it('should render custom tooltip content without the standard text wrapper', () => {
+		const CustomContentTestComponent = () => {
+			const { PositionedTooltip } = useTooltip({ isOpen: true });
+			return (
+				<PositionedTooltip
+					content={
+						<div>
+							<strong>Custom title</strong>
+							<p>Custom body</p>
+						</div>
+					}
+				/>
+			);
+		};
+
+		const { getByRole, getByText } = render(<CustomContentTestComponent />);
+
+		expect(getByRole('tooltip')).toBeInTheDocument();
+		expect(getByText('Custom title').tagName).toBe('STRONG');
+		expect(getByText('Custom body').tagName).toBe('P');
+	});
+
 	it('should handle mouse leave with delay', () => {
 		vi.useFakeTimers();
 

--- a/lib/components/Tooltip/useTooltip/useTooltip.tsx
+++ b/lib/components/Tooltip/useTooltip/useTooltip.tsx
@@ -35,7 +35,7 @@ interface PositionedTooltipBaseProps {
 	size?: ToolTipSize;
 }
 
-type PositionedTooltipContentProps =
+export type PositionedTooltipContentProps =
 	| {
 			/** Text rendered with the standard tooltip surface */
 			label: string;

--- a/lib/components/Tooltip/useTooltip/useTooltip.tsx
+++ b/lib/components/Tooltip/useTooltip/useTooltip.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState, useId } from 'react';
+import React, {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useId,
+	useRef,
+	useState,
+} from 'react';
 
 import { Box } from '../../Box/Box';
 import { Positioner } from '../../Positioner/Positioner';
@@ -21,6 +28,27 @@ export interface UseTooltipProps {
 	 */
 	onOpenChange?: (isOpen: boolean) => void;
 }
+
+interface PositionedTooltipBaseProps {
+	alignment?: EAlignment;
+	className?: string;
+	size?: ToolTipSize;
+}
+
+type PositionedTooltipContentProps =
+	| {
+			/** Text rendered with the standard tooltip surface */
+			label: string;
+			content?: never;
+	  }
+	| {
+			/** Custom tooltip surface and content */
+			content: ReactNode;
+			label?: never;
+	  };
+
+export type PositionedTooltipProps = PositionedTooltipBaseProps &
+	PositionedTooltipContentProps;
 
 const sizeMap: Record<ToolTipSize, TextProps['size']> = {
 	medium: '2',
@@ -115,15 +143,12 @@ export const useTooltip = ({
 		({
 			alignment = EAlignment.RIGHT,
 			className,
+			content,
 			label,
 			size = 'medium',
-		}: {
-			alignment?: EAlignment;
-			className?: string;
-			label: string;
-			size?: ToolTipSize;
-		}) => {
+		}: PositionedTooltipProps) => {
 			const textSize = sizeMap[size];
+			const hasCustomContent = content !== undefined;
 
 			return (
 				<Positioner
@@ -135,20 +160,26 @@ export const useTooltip = ({
 						className={className}
 						id={tooltipId}
 						ref={tooltipRef}
-						width="full"
+						width={hasCustomContent ? undefined : 'full'}
 						pointerEvents="none"
 						userSelect="none"
-						overflow="hidden"
-						borderRadius="1"
-						boxShadow="4"
-						backgroundColor="gray900"
-						paddingY="2"
-						paddingX="3"
+						overflow={hasCustomContent ? undefined : 'hidden'}
+						borderRadius={hasCustomContent ? undefined : '1'}
+						boxShadow={hasCustomContent ? undefined : '4'}
+						backgroundColor={
+							hasCustomContent ? undefined : 'gray900'
+						}
+						paddingY={hasCustomContent ? undefined : '2'}
+						paddingX={hasCustomContent ? undefined : '3'}
 						role="tooltip"
 					>
-						<Text size={textSize} color="white">
-							{label}
-						</Text>
+						{hasCustomContent ? (
+							content
+						) : (
+							<Text size={textSize} color="white">
+								{label}
+							</Text>
+						)}
 					</Box>
 				</Positioner>
 			);


### PR DESCRIPTION
## Summary
- add mutually exclusive standard `label` and custom React `content` APIs to `Tooltip` and `useTooltip`
- preserve the existing dark tooltip surface while allowing consumers to own custom card styling
- forward `aria-describedby` through `Button` for accessible tooltip triggers
- add unit coverage, a Storybook example, and a minor changeset

## Validation
- `yarn run lint`
- `yarn vitest run lib/components/Button/Button.spec.tsx lib/components/Tooltip/Tooltip.spec.tsx lib/components/Tooltip/useTooltip/useTooltip.spec.tsx --project=unit-tests`
- `yarn build`
- `yarn typeEmit`