### PR TITLE
ci: auto-draft PRs on push to conserve CI capacity (AG-20963)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,16 @@ jobs:
             - name: Yarn install
               run: yarn --immutable
 
+            # For human PRs, Chromatic runs only on ready_for_review — pushes
+            # re-draft the PR (see pr-auto-draft.yml), so snapshots fire once
+            # per review round instead of once per push. Bot PRs (renovate)
+            # never fire ready_for_review, so they keep the old behaviour.
             - name: Chromatic
-              if: github.event.pull_request.draft == false
+              if: >-
+                  github.event_name != 'pull_request' ||
+                  (github.event.pull_request.draft == false &&
+                  (github.event.action == 'ready_for_review' ||
+                  contains(github.event.sender.login, '[bot]')))
               uses: chromaui/action@latest
               with:
                   projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
@@ -104,7 +112,11 @@ jobs:
                   skip: 'changeset-release/**'
 
             - name: Skip Chromatic
-              if: github.event.pull_request.draft == true
+              if: >-
+                  github.event_name == 'pull_request' &&
+                  (github.event.pull_request.draft == true ||
+                  (github.event.action != 'ready_for_review' &&
+                  !contains(github.event.sender.login, '[bot]')))
               uses: chromaui/action@latest
               with:
                   projectToken: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/pr-auto-draft.yml
+++ b/.github/workflows/pr-auto-draft.yml
@@ -66,6 +66,8 @@ jobs:
                     echo
                     echo "To conserve CI capacity (Chromatic snapshots, build minutes), PRs are auto-drafted. Chromatic runs when you click **Ready for review** — lint and tests still run on every push."
                     echo
+                    echo "> :warning: A green Chromatic check on this commit means the snapshot run was **skipped**, not that it passed — the real build runs once you mark the PR Ready for review."
+                    echo ">"
                     echo "> :warning: If you had enabled auto-merge, re-drafting **cancelled** it. Re-enable \"merge when ready\" after marking the PR Ready for review."
                   } > .auto-draft-notice.md
 

--- a/.github/workflows/pr-auto-draft.yml
+++ b/.github/workflows/pr-auto-draft.yml
@@ -1,0 +1,78 @@
+name: Auto-draft PRs
+
+# Mirrors mfe's pr-auto-draft workflow. Every PR funnels through draft → ready
+# so the expensive Chromatic snapshots (see ci.yml) fire exactly once, on a
+# known-ready head SHA:
+#   - synchronize: a push to a ready PR re-drafts it.
+#   - opened/reopened: a PR opened or reopened as ready is drafted so the author
+#     re-confirms readiness with "Ready for review" before CI spends minutes.
+# A PR opened as a draft is left alone (the `draft == false` guard below).
+# Bot PRs (renovate, changesets "Version Packages") are excluded — bots never
+# click "Ready for review", so drafting them would strand them without CI.
+on:
+    pull_request:
+        types: [synchronize, opened, reopened]
+
+concurrency:
+    group: auto-draft-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    convert-to-draft:
+        if: |
+            github.event.pull_request.draft == false &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            !contains(github.event.sender.login, '[bot]')
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+            issues: write
+        steps:
+            - name: Convert PR to draft
+              id: convert
+              env:
+                  GH_TOKEN: ${{ secrets.AUTO_COMMIT_TOKEN }}
+                  PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+              run: |
+                  if [ -z "$GH_TOKEN" ]; then
+                    echo "::warning::AUTO_COMMIT_TOKEN secret not configured; skipping draft conversion. The default GITHUB_TOKEN cannot perform convertPullRequestToDraft (FORBIDDEN). Ask an org admin to share the AUTO_COMMIT_TOKEN org secret with this repo, or provision a fine-grained PAT with 'Pull requests: Write' and store it as repo secret AUTO_COMMIT_TOKEN."
+                    echo "skipped=true" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+                  gh api graphql -f query='
+                    mutation($id: ID!) {
+                      convertPullRequestToDraft(input: { pullRequestId: $id }) {
+                        pullRequest { isDraft }
+                      }
+                    }' -f id="$PR_NODE_ID"
+
+            # Sticky (header `auto-draft`): rewritten in place on every push
+            # instead of posting a fresh comment, so the thread never grows.
+            # Wording is event-aware — quieter on open/reopen than on a push.
+            - name: Build draft notice
+              if: steps.convert.outputs.skipped != 'true'
+              env:
+                  EVENT_ACTION: ${{ github.event.action }}
+                  ACTOR: ${{ github.event.sender.login }}
+              run: |
+                  set -euo pipefail
+                  if [ "$EVENT_ACTION" = "synchronize" ]; then
+                    HEADLINE="🚧 Auto-converted back to **Draft** because a new commit was pushed by @${ACTOR}."
+                  else
+                    HEADLINE="🚧 Opened as a **Draft** to conserve CI capacity."
+                  fi
+                  {
+                    echo "$HEADLINE"
+                    echo
+                    echo "To conserve CI capacity (Chromatic snapshots, build minutes), PRs are auto-drafted. Chromatic runs when you click **Ready for review** — lint and tests still run on every push."
+                    echo
+                    echo "> :warning: If you had enabled auto-merge, re-drafting **cancelled** it. Re-enable \"merge when ready\" after marking the PR Ready for review."
+                  } > .auto-draft-notice.md
+
+            - name: Post sticky draft notice
+              if: steps.convert.outputs.skipped != 'true'
+              uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+              with:
+                  header: auto-draft
+                  number: ${{ github.event.pull_request.number }}
+                  path: .auto-draft-notice.md


### PR DESCRIPTION
## Summary

Ports mfe's `pr-auto-draft.yml` workflow to Overdrive so expensive CI (Chromatic snapshots) runs once per review round instead of on every push. Jira: [AG-20963](https://autoguru.atlassian.net/browse/AG-20963)

- **New `.github/workflows/pr-auto-draft.yml`**: a push (`synchronize`) to a ready-for-review PR converts it back to Draft via the `convertPullRequestToDraft` GraphQL mutation; PRs opened/reopened as ready are drafted so the author confirms readiness with **Ready for review** before CI spends resources. Bot PRs (renovate, changesets "Version Packages") and fork PRs are excluded — bots never click Ready for review, so drafting them would strand them without CI. A sticky comment (rewritten in place, never grows the thread) explains the conversion and warns that re-drafting cancels auto-merge.
- **Chromatic gate adjusted in `ci.yml`**: the `synchronize` payload still reports `draft: false` because the conversion happens afterwards, so without this change Chromatic would run on the push *and again* on `ready_for_review`, doubling the spend. For human PRs Chromatic now runs only on `ready_for_review`; pushes to `main`, `workflow_dispatch`, and bot PRs keep the current behaviour. Lint and tests still run on every push (unchanged).

### Developer impact

- Pushing to a ready PR re-drafts it; click **Ready for review** to run Chromatic and (re-)request review. If you had auto-merge enabled, re-enable it after marking ready.
- New PRs opened as ready are converted to Draft immediately.

### Dependency (blocking full functionality)

The draft conversion cannot use the default `GITHUB_TOKEN` (GraphQL mutation returns FORBIDDEN). mfe uses the org secret `AUTO_COMMIT_TOKEN`, which is **not shared with this repo**. An org admin needs to add `overdrive` to that secret's selected repositories (or provision a fine-grained PAT with "Pull requests: Write" as a repo secret with the same name). Until then the workflow logs a warning and skips conversion — **this PR should not be marked ready to merge before the secret is in place**, otherwise pushes to ready PRs would skip Chromatic without re-drafting, leaving no way to trigger snapshots for that head SHA short of manually cycling draft → ready.

### Note

Overlaps with `feature/AG-20962-chromatic-skip-renovate` (no PR yet), which edits the same Chromatic step to skip renovate branches unless a `visual-check` label is present. The two changes are compatible in intent (this PR's `if` gates *when* the step runs; AG-20962's `skip` expression makes it a no-op for renovate) but will conflict textually — whichever lands second needs a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AG-20963]: https://autoguru.atlassian.net/browse/AG-20963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ