### PR TITLE
fix(Portal): carry tenant colour overrides into portalled surfaces (FPAY-200)

### DIFF
--- a/.changeset/portal-brand-colour.md
+++ b/.changeset/portal-brand-colour.md
@@ -1,0 +1,23 @@
+---
+'@autoguru/overdrive': patch
+---
+
+Portal: apply the provider's `colorOverrides` to the themed wrapper, alongside
+the theme class it already sets. Custom properties inherit down the DOM, not the
+React tree, so a portalled subtree — mounted as a child of `<body>`, outside
+`<div data-od-component="provider">` — was falling back to base-theme tokens. A
+branded tenant saw its colour on in-flow UI but not on any floating surface: the
+same component rendered branded in place and default mint once portalled.
+
+`overrideStyles` was already on the theme context and read by nothing; this is
+the first consumer.
+
+Blast radius: every portalled component — `Drawer`, `Modal`, `Toaster`/`Toast`,
+`Positioner` (so `DropDown` and popovers) and `AutoSuggest` — now inherits the
+brand. No-op for unbranded apps: `useColorOverrides` returns `{}` with no
+overrides and `assignInlineVars` drops undefined values, so React renders no
+`style` attribute at all. No new DOM node, no class change, and portals mount
+where they always did, so stacking and layering are untouched.
+
+`noThemedWrapper` (opt-in on `Modal` and `StandardModal`) renders no wrapper, so
+it still cannot carry the brand — documented on the prop.

--- a/lib/components/Portal/Portal.spec.jsx
+++ b/lib/components/Portal/Portal.spec.jsx
@@ -1,7 +1,12 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 
+import { OverdriveProvider } from '../OverdriveProvider';
+
 import { Portal } from './Portal';
+
+const portalWrapper = () =>
+	document.body.querySelector('[data-testid="portal-child"]')?.parentElement;
 
 describe('<Portal />', () => {
 	it('should not throw', () => {
@@ -10,5 +15,35 @@ describe('<Portal />', () => {
 
 	it('should match the snapshot', () => {
 		expect(render(<Portal />).container.firstChild).toMatchSnapshot();
+	});
+
+	it('carries the provider colour overrides onto its wrapper', () => {
+		render(
+			<OverdriveProvider
+				colorOverrides={{ primaryBackground: '#0e893c' }}
+			>
+				<Portal>
+					<div data-testid="portal-child" />
+				</Portal>
+			</OverdriveProvider>,
+		);
+
+		// Read the attribute rather than `.style.cssText` — jsdom omits custom
+		// properties from the latter.
+		expect(portalWrapper().getAttribute('style')).toContain(
+			'--od-color-brand-solid: #0e893c',
+		);
+	});
+
+	it('leaves the wrapper unstyled when no overrides are supplied', () => {
+		render(
+			<OverdriveProvider>
+				<Portal>
+					<div data-testid="portal-child" />
+				</Portal>
+			</OverdriveProvider>,
+		);
+
+		expect(portalWrapper().hasAttribute('style')).toBe(false);
 	});
 });

--- a/lib/components/Portal/Portal.tsx
+++ b/lib/components/Portal/Portal.tsx
@@ -7,6 +7,12 @@ import { useTheme } from '../OverdriveProvider';
 export interface PortalProps {
 	children?: React.ReactNode;
 	container?: HTMLElement;
+	/**
+	 * Renders the children with no wrapper element. The wrapper is what carries
+	 * the theme class and the provider's colour overrides, so opting out of it
+	 * also opts out of tenant branding — the portalled subtree falls back to
+	 * base-theme tokens.
+	 */
 	noThemedWrapper?: boolean;
 }
 
@@ -16,7 +22,7 @@ function Portal(
 	{ children, container, noThemedWrapper }: PortalProps,
 	ref: React.Ref<typeof container>,
 ) {
-	const { themeClass, portalMountPoint } = useTheme();
+	const { themeClass, overrideStyles, portalMountPoint } = useTheme();
 	const [mountPoint, setMountPoint] = useState<HTMLElement | null>(null);
 	const [mountNode, setMountNode] = useState<RefValue<typeof ref> | null>(
 		null,
@@ -55,9 +61,18 @@ function Portal(
 
 	if (!mountNode) return null;
 
+	// The wrapper carries the provider's colour overrides as well as its theme
+	// class: custom properties inherit down the DOM, and the portal mounts
+	// outside the provider div, so without them a branded tenant's drawers,
+	// modals, toasts and popovers fall back to base-theme tokens.
 	return noThemedWrapper
 		? createPortal(children, mountNode)
-		: createPortal(<div className={themeClass}>{children}</div>, mountNode);
+		: createPortal(
+				<div className={themeClass} style={overrideStyles}>
+					{children}
+				</div>,
+				mountNode,
+			);
 }
 
 const _Portal = forwardRef(Portal);


### PR DESCRIPTION
## Summary

`Portal` now applies the provider's `colorOverrides` to the wrapper div it already themes, so portalled surfaces inherit tenant branding.

CSS custom properties inherit down the **DOM** tree, not the React tree. `OverdriveProvider` writes `colorOverrides` as inline custom properties on a single `<div data-od-component="provider">`, and `Portal` mounts its subtree on `<body>` — outside that div. Portalled content therefore resolved every branded token against the base theme. A branded tenant saw its colour on in-flow UI and default AutoGuru mint on every floating surface; the clearest proof is one component behaving two ways — Portfolio's "Book now" trigger renders the tenant green while its own dropdown popover renders mint.

`overrideStyles` was already on the theme context (`OverdriveProvider.tsx:145`) and read by nothing in the library. This is its first consumer:

```diff
-	const { themeClass, portalMountPoint } = useTheme();
+	const { themeClass, overrideStyles, portalMountPoint } = useTheme();
…
-		: createPortal(<div className={themeClass}>{children}</div>, mountNode);
+		: createPortal(
+				<div className={themeClass} style={overrideStyles}>
+					{children}
+				</div>,
+				mountNode,
+			);
```

**Blast radius — fixed in one place:** `Drawer`, `Modal`, `Toaster`/`Toast`, `Positioner` (so `DropDown` and popovers) and `AutoSuggest`, for every branded tenant, with no per-app plumbing.

**Why this is a no-op for unbranded apps:** `useColorOverrides` returns `{}` when no overrides are supplied, and `assignInlineVars` drops `null`/`undefined` values, so the wrapper renders with no `style` attribute at all. No new DOM node, no class change, and portals still mount exactly where they did — stacking context, `z-index` and `overflow` are untouched.

**Rejected alternative:** passing `portalMountPoint` so portals mount inside the provider div. That moves them into the MFE subtree where they inherit its stacking context and overflow — the classic cause of clipped or invisible modals.

**Documented gap:** `noThemedWrapper` (opt-in on `Modal` and `StandardModal`) renders no wrapper element, so there is nowhere to hang the vars. Now noted in the `PortalProps` JSDoc rather than changing the flag's behaviour.

**Out of scope:** `linkColor` is never passed by the MFE-side `getTenantBrandingProps()`, so `TextLink` and focus rings stay unbranded regardless of this change — `TenantBranding` carries no link colour, which needs a design decision first.

## Testing

- Two new cases in `Portal.spec.jsx`: the wrapper carries `--od-color-brand-solid` when the provider has `colorOverrides`, and has no `style` attribute when it doesn't. Assertions read the `style` attribute rather than `style.cssText`, since jsdom omits custom properties from the latter.
- `yarn test run` — 928 passed / 93 files, existing Portal snapshot unchanged.
- `yarn lint` — exits 0.
- No new Storybook stories: the change is pixel-neutral for unbranded themes, so it would spend Chromatic snapshots for no signal.
- Not covered here: the on-tenant visual check, which needs the MFE monorepo with this build linked.

## Quality compliance

No new dependencies. No hardcoded values, inline styles or `globalStyle()` — the only style applied is the provider's own `assignInlineVars` output, passed through untouched. No component structure, token or Vanilla Extract changes.

## Breaking Changes

None. Additive, and released as a `patch` changeset — but it does change rendered colour for branded tenants on portalled surfaces, which is the point.

Ticket: https://autoguru.atlassian.net/browse/FPAY-200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
