### PR TITLE
feat(StickyFooterModal): add modal with sticky footer CTAs

### DIFF
--- a/.changeset/sticky-footer-modal.md
+++ b/.changeset/sticky-footer-modal.md
@@ -1,0 +1,19 @@
+---
+'@autoguru/overdrive': minor
+---
+
+Add `StickyFooterModal`, a modal variant with a fixed header, scrollable body,
+and sticky footer containing one or two CTAs. Supports `dual-cta` (default) and
+`single-cta` layouts, auto-close on CTA click (opt out via `closeOnPrimary` /
+`closeOnSecondary`), a scroll-shadow hint on the header when the body overflows,
+and dialog a11y — focus trap, escape-to-close, `aria-labelledby` /
+`aria-describedby`, `"Close dialog"` label, and a 48×48 close-× hit area.
+
+Base `Modal` gains a document-level Escape handler (fires
+`onRequestClose('escapeKeyDown')`), a symmetric enter/exit scale animation
+(`styles.entry` now applies during `CLOSING` as well as `OPENING`),
+`prefers-reduced-motion` gating on the whole transition rather than just the
+transform, and unified 200ms timings.
+
+`StandardModal` `min-height` bumped to 400px so short-body modals still look
+intentional.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -82,6 +82,7 @@ const preview: Preview = {
 						'Modal',
 						'Modal: Minimal',
 						'Modal: Standard with Title',
+						'Modal: Sticky footer CTAs',
 					],
 				],
 			},

--- a/lib/components/Modal/Modal.css.ts
+++ b/lib/components/Modal/Modal.css.ts
@@ -11,7 +11,12 @@ export const root = style({
 });
 
 export const transition = style({
-	transition: `transform .175s ${vars.animation.easing.standard}, opacity 0.3s ${vars.animation.easing.standard}`,
+	transition: `transform .2s ${vars.animation.easing.standard}, opacity .2s ${vars.animation.easing.standard}`,
+	'@media': {
+		'screen and (prefers-reduced-motion)': {
+			transition: 'none !important',
+		},
+	},
 });
 
 export const entry = style({

--- a/lib/components/Modal/Modal.tsx
+++ b/lib/components/Modal/Modal.tsx
@@ -118,12 +118,25 @@ export const Modal: FunctionComponent<ModalProps> = ({
 		if (state === 'CLOSING') {
 			const timer = setTimeout(() => {
 				dispatch('ANIMATION_COMPLETE');
-			}, 300);
+			}, 200);
 			return () => clearTimeout(timer);
 		}
 
 		return () => {};
 	}, [state]);
+
+	useEffect(() => {
+		if (!isOpen) return;
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key !== 'Escape') return;
+			if (typeof onRequestClose === 'function') {
+				event.stopPropagation();
+				onRequestClose('escapeKeyDown');
+			}
+		};
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, [isOpen, onRequestClose]);
 
 	return (
 		<Portal
@@ -168,7 +181,8 @@ export const Modal: FunctionComponent<ModalProps> = ({
 						className={[
 							styles.root,
 							styles.transition,
-							state === 'OPENING' && styles.entry,
+							(state === 'OPENING' || state === 'CLOSING') &&
+								styles.entry,
 						]}
 					>
 						{children}

--- a/lib/components/Modal/Modal.tsx
+++ b/lib/components/Modal/Modal.tsx
@@ -6,10 +6,10 @@ import type {
 	Reducer,
 } from 'react';
 import * as React from 'react';
-import { ReactNode, useEffect, useReducer } from 'react';
+import { ReactNode, useEffect, useLayoutEffect, useReducer } from 'react';
 import FocusLock from 'react-focus-lock';
 
-import { useEventCallback } from '../../utils';
+import { isBrowser, useEventCallback } from '../../utils';
 import { Box } from '../Box/Box';
 import { Portal } from '../Portal/Portal';
 
@@ -99,6 +99,20 @@ export const Modal: FunctionComponent<ModalProps> = ({
 	useEffect(() => {
 		dispatch(isOpen ? 'OPEN_MODAL' : 'CLOSE_MODAL');
 	}, [isOpen]);
+
+	if (isBrowser) {
+		useLayoutEffect(() => {
+			if (!isOpen) return;
+			const prevHtml = document.documentElement.style.overflow;
+			const prevBody = document.body.style.overflow;
+			document.documentElement.style.overflow = 'hidden';
+			document.body.style.overflow = 'hidden';
+			return () => {
+				document.documentElement.style.overflow = prevHtml;
+				document.body.style.overflow = prevBody;
+			};
+		}, [isOpen]);
+	}
 
 	useEffect(() => {
 		if (state === 'CLOSING') {

--- a/lib/components/Modal/__snapshots__/Modal.spec.jsx.snap
+++ b/lib/components/Modal/__snapshots__/Modal.spec.jsx.snap
@@ -3,6 +3,7 @@
 exports[`<Modal /> > should match snapshot 1`] = `
 <body
   class="theme_OD_Base__j49br80"
+  style="overflow: hidden;"
 >
   <div>
     <div

--- a/lib/components/StickyFooterModal/StickyFooterModal.css.ts
+++ b/lib/components/StickyFooterModal/StickyFooterModal.css.ts
@@ -76,3 +76,7 @@ export const content = style({
 	overflowY: 'auto',
 	overscrollBehavior: 'contain',
 });
+
+export const headerScrolled = style({
+	boxShadow: '0 4px 6px -4px rgba(0, 0, 0, 0.1)',
+});

--- a/lib/components/StickyFooterModal/StickyFooterModal.spec.jsx
+++ b/lib/components/StickyFooterModal/StickyFooterModal.spec.jsx
@@ -1,0 +1,92 @@
+import { fireEvent, render } from '@testing-library/react';
+import * as React from 'react';
+
+import { StickyFooterModal } from './StickyFooterModal';
+
+describe('<StickyFooterModal />', () => {
+	const testTitle = 'Hello World!';
+	const testBodyText = 'Body content';
+
+	it('should not throw', () =>
+		expect(() =>
+			render(<StickyFooterModal title={testTitle} />),
+		).not.toThrow());
+
+	it('should match snapshot with dual-cta footer (default)', () => {
+		expect(
+			render(
+				<StickyFooterModal isOpen title={testTitle}>
+					<p>{testBodyText}</p>
+				</StickyFooterModal>,
+			).baseElement,
+		).toMatchSnapshot();
+	});
+
+	it('should match snapshot with single-cta footer', () => {
+		expect(
+			render(
+				<StickyFooterModal isOpen title={testTitle} footer="single-cta">
+					<p>{testBodyText}</p>
+				</StickyFooterModal>,
+			).baseElement,
+		).toMatchSnapshot();
+	});
+
+	it('should call onRequestClose when the close button is clicked', () => {
+		const mockCloseReq = vi.fn();
+
+		const { getByLabelText } = render(
+			<StickyFooterModal
+				isOpen
+				title={testTitle}
+				onRequestClose={mockCloseReq}
+			>
+				<p>{testBodyText}</p>
+			</StickyFooterModal>,
+		);
+
+		fireEvent.click(getByLabelText('Close dialog'));
+
+		expect(mockCloseReq).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call onPrimaryClick when the primary CTA is clicked', () => {
+		const onPrimaryClick = vi.fn();
+
+		const { getByText } = render(
+			<StickyFooterModal
+				isOpen
+				title={testTitle}
+				footer="single-cta"
+				primaryLabel="Confirm"
+				onPrimaryClick={onPrimaryClick}
+			>
+				<p>{testBodyText}</p>
+			</StickyFooterModal>,
+		);
+
+		fireEvent.click(getByText('Confirm'));
+
+		expect(onPrimaryClick).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call onSecondaryClick when the secondary CTA is clicked', () => {
+		const onSecondaryClick = vi.fn();
+
+		const { getByText } = render(
+			<StickyFooterModal
+				isOpen
+				title={testTitle}
+				footer="dual-cta"
+				secondaryLabel="Cancel"
+				onSecondaryClick={onSecondaryClick}
+			>
+				<p>{testBodyText}</p>
+			</StickyFooterModal>,
+		);
+
+		fireEvent.click(getByText('Cancel'));
+
+		expect(onSecondaryClick).toHaveBeenCalledTimes(1);
+	});
+});

--- a/lib/components/StickyFooterModal/StickyFooterModal.stories.tsx
+++ b/lib/components/StickyFooterModal/StickyFooterModal.stories.tsx
@@ -1,0 +1,206 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { action } from 'storybook/actions';
+
+import { Box } from '../Box/Box';
+import { Text } from '../Text/Text';
+
+import { StickyFooterModal } from './StickyFooterModal';
+
+const GUIDE = `
+A modal shell with a fixed header, a scrollable body, and a sticky footer of
+CTAs. The title and CTAs stay in view while the body scrolls, so the user
+never loses sight of what they're about to confirm — even in a long form
+or list.
+
+> ⚠️ **This is not a lightweight modal.** If the content fits without scrolling,
+> or there is nothing to commit, reach for [Modal: Minimal](/docs/components-modal-modal-minimal--docs)
+> or [Modal: Standard with Title](/docs/components-modal-standard-with-title--docs)
+> instead.
+
+## Choosing a footer layout
+
+| \`footer\` | Shows | Use it for |
+| --- | --- | --- |
+| \`dual-cta\` *(default)* | secondary + primary, right-aligned with a 12px gap | The usual case — the user can commit or cancel |
+| \`single-cta\` | one primary, right-aligned | A task with only one meaningful action, where dismiss is enough of a "no" |
+
+Reach for \`dual-cta\` whenever the primary action is destructive or irreversible,
+so cancel is a first-class option rather than something the user has to hunt
+for. Use \`single-cta\` only when a plain dismiss (backdrop, Escape, close ×) is
+a safe "back out".
+
+## Anatomy
+
+Three regions in a fixed vertical stack.
+
+**Header** — the title in \`H2\` weight and a 32×32 close × icon on the right,
+with a 1px \`color/border/default\` divider along the bottom. 32px horizontal
+padding, 24px vertical.
+
+**Body** — full width, flexible height, scrolls vertically. 24px horizontal
+padding, 16px vertical. A soft shadow appears at the top edge as soon as
+the body has scrolled, so the header reads as floating above the content.
+
+**Sticky footer** — buttons right-aligned with a 12px gap and a 1px
+\`color/border/default\` divider along the top. 32px horizontal padding, 24px
+vertical. In \`dual-cta\` the secondary sits before the primary; in \`single-cta\`
+the primary sits alone.
+
+The shell has \`border/radius/xlarge\` corners, sits on top of a semi-transparent
+backdrop, and never shrinks below 400px tall.
+
+## What the handlers decide
+
+Consumers pass one \`onRequestClose\` and, optionally, the primary/secondary
+click handlers. \`onRequestClose\` fires with a reason so a single handler can
+route every exit path.
+
+| Reason | Fired when |
+| --- | --- |
+| \`'button'\` | The close × is clicked |
+| \`'backdrop'\` | The backdrop overlay is clicked |
+| \`'escapeKeyDown'\` | The user presses Escape |
+| \`'primary'\` | The primary CTA is clicked (after \`onPrimaryClick\`) |
+| \`'secondary'\` | The secondary CTA is clicked (after \`onSecondaryClick\`) |
+
+Primary and secondary clicks auto-close by default. Opt out with
+\`closeOnPrimary={false}\` / \`closeOnSecondary={false}\` when the CTA validates
+or performs async work and you want to keep the modal open until it's done.
+
+\`primaryDisabled\` disables the primary CTA — it still owns focus order and
+keyboard events, but click and Enter/Space no longer fire.
+
+## States
+
+Two: default and scrolled.
+
+At rest the header sits flush against the body with just the 1px divider. As
+soon as the body has scrolled below its top edge, a soft drop-shadow appears
+under the header so it reads as floating above the content. The shadow
+disappears again once the body is scrolled back to the top. There is no
+separate story for it — scroll the Dual or Single CTA examples to see it.
+
+## Interactions
+
+**Opening.** Backdrop fades in and the modal scales from 95% → 100% while
+fading in (200ms ease-out). Focus jumps into the modal and stays trapped
+there; body scroll on the page underneath is locked.
+
+**Closing.** From every exit path (×, backdrop, Escape, primary, secondary)
+the modal fades out and scales back to 95% while the backdrop fades out.
+Focus returns to the element that opened the modal.
+
+**Scrolling.** The body scrolls vertically. Header and footer stay put. A top
+shadow appears on the body as a scroll hint, and disappears when the body
+scrolls back to the top.
+
+## Do and don't
+
+| ✓ Do | ✗ Don't |
+| --- | --- |
+| Use a clear, action-oriented title that describes the task | Use vague titles like *"Are you sure?"* or *"Confirm"* |
+| Keep primary CTA text short and specific (e.g. *"Add asset"*) | Stack more than two buttons in the footer |
+| Use \`dual-cta\` when the action is destructive or irreversible | Nest modals inside other modals |
+| Allow Escape key and backdrop click to dismiss | Use \`single-cta\` without an alternative dismiss path |
+| Return focus to the trigger element on close | Place navigation or complex multi-step flows inside the modal |
+| Show a scroll shadow when body content overflows | Disable backdrop dismiss without clear visual feedback |
+
+## Accessibility
+
+The modal must be fully operable without a mouse and announce correctly to
+screen readers.
+
+**Keyboard.** \`Tab\` and \`Shift+Tab\` move focus between interactive elements
+inside the modal, and focus is trapped there while it is open. \`Escape\` closes
+the modal and fires \`onRequestClose('escapeKeyDown')\`. \`Enter\` and \`Space\`
+activate the focused CTA. Arrow keys navigate within body content.
+
+**ARIA.** The dialog is announced with \`role="dialog"\` and \`aria-modal="true"\`,
+and \`aria-labelledby\` points at the title so the screen reader reads it on
+open. Pass \`aria-describedby\` with the id of a description element in the
+body if there is extra context worth reading out. The close × is a real
+\`<button>\` with \`aria-label="Close dialog"\`.
+
+**Visual.** Focus ring is drawn in \`color/info/foreground\` at 2px, with a
+minimum 44×44 touch target on the close × and both CTAs (WCAG 2.5.5 Target
+Size Enhanced). Text meets 4.5:1 contrast, and the scroll shadow is a visible
+overflow cue. Screen readers announce the modal on open and dismiss on close.
+
+**Motion.** Entry runs at 200ms ease-out; exit at 200ms with the same easing.
+Focus trap activates immediately on open. Under \`prefers-reduced-motion\` all
+transitions are skipped, including the 95% → 100% scale on the modal panel.
+There is no auto-dismiss or timeout.
+
+## Responsive
+
+From tablet up the modal centres in the viewport with a max-width and equal
+margin from the edges. On mobile it docks to the bottom of the screen, top
+corners rounded, filling the viewport width — so the CTAs sit within thumb
+reach.
+`;
+
+const meta = {
+	title: 'Components/Modal: Sticky footer CTAs',
+	tags: ['skip-themes'],
+	component: StickyFooterModal,
+	argTypes: {
+		children: { control: false },
+	},
+	parameters: {
+		docs: {
+			description: { component: GUIDE },
+			story: { inline: false, iframeHeight: 620 },
+		},
+	},
+} satisfies Meta<typeof StickyFooterModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const longBody = (
+	<Box paddingX="5" paddingY="7">
+		{Array.from({ length: 8 }).map((_, i) => (
+			<React.Fragment key={i}>
+				<Text size="p1" color="secondary">
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+					Duis convallis neque a laoreet maximus. Vestibulum
+					hendrerit quam at mi venenatis faucibus at vel nisi. In ut
+					risus et ipsum tincidunt tempor. Suspendisse potenti.
+					Praesent faucibus posuere risus, at congue mauris porttitor
+					ut. Donec sit amet elit vitae purus dictum aliquet quis ut
+					ligula. Orci varius natoque penatibus et magnis dis
+					parturient montes, nascetur ridiculus mus. Vestibulum dui
+					sapien, porttitor ac erat vel, malesuada rutrum mauris.
+				</Text>
+				<br />
+			</React.Fragment>
+		))}
+	</Box>
+);
+
+export const DualCTA: Story = {
+	args: {
+		title: 'Heading',
+		isOpen: true,
+		onRequestClose: action('onRequestClose'),
+		footer: 'dual-cta',
+		primaryLabel: 'Primary',
+		secondaryLabel: 'Secondary',
+		onPrimaryClick: action('onPrimaryClick'),
+		onSecondaryClick: action('onSecondaryClick'),
+		children: longBody,
+	},
+};
+
+export const SingleCTA: Story = {
+	args: {
+		title: 'Heading',
+		isOpen: true,
+		onRequestClose: action('onRequestClose'),
+		footer: 'single-cta',
+		primaryLabel: 'Primary',
+		onPrimaryClick: action('onPrimaryClick'),
+		children: longBody,
+	},
+};

--- a/lib/components/StickyFooterModal/StickyFooterModal.tsx
+++ b/lib/components/StickyFooterModal/StickyFooterModal.tsx
@@ -1,0 +1,252 @@
+import { XIcon } from '@autoguru/icons';
+import clsx from 'clsx';
+import type {
+	ComponentProps,
+	FunctionComponent,
+	MouseEventHandler,
+} from 'react';
+import * as React from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
+
+import { textStyles } from '../../styles/typography';
+import { isBrowser, useEventCallback, useId } from '../../utils';
+import { Box } from '../Box/Box';
+import { Button } from '../Button/Button';
+import { Heading } from '../Heading/Heading';
+import { Icon } from '../Icon/Icon';
+import { Modal } from '../Modal/Modal';
+
+import * as styles from './StickyFooterModal.css';
+
+export enum ESize {
+	Skinny = 'skinny', // 420px wide
+	Narrow = 'narrow', // 600px wide
+	Standard = 'standard', // 800px wide
+}
+
+type Size = 'skinny' | 'narrow' | 'standard';
+
+export type StickyFooterModalVariant = 'single-cta' | 'dual-cta';
+
+export interface StickyFooterModalProps extends ComponentProps<typeof Modal> {
+	size?: ESize | Size;
+	className?: string;
+	title: string;
+	/**
+	 * Footer button layout.
+	 *
+	 * - `'single-cta'` — one primary action, right-aligned.
+	 * - `'dual-cta'` — secondary + primary actions, right-aligned.
+	 */
+	footer?: StickyFooterModalVariant;
+	/** Primary CTA label. Defaults to `'Confirm'`. */
+	primaryLabel?: string;
+	/** Secondary CTA label (dual-cta only). Defaults to `'Cancel'`. */
+	secondaryLabel?: string;
+	/** Primary CTA click handler. Modal auto-closes after invocation unless `closeOnPrimary` is `false`. */
+	onPrimaryClick?: () => void;
+	/** Secondary CTA click handler (dual-cta only). Modal auto-closes after invocation unless `closeOnSecondary` is `false`. */
+	onSecondaryClick?: () => void;
+	/** Disables the primary CTA. */
+	primaryDisabled?: boolean;
+	/** Auto-close after the primary CTA fires. Defaults to `true`. */
+	closeOnPrimary?: boolean;
+	/** Auto-close after the secondary CTA fires. Defaults to `true`. */
+	closeOnSecondary?: boolean;
+	/** ID of an element that describes the modal for assistive tech. */
+	'aria-describedby'?: string;
+}
+
+export const StickyFooterModal: FunctionComponent<StickyFooterModalProps> = ({
+	isOpen,
+	size = 'standard',
+	className = '',
+	title,
+	container,
+	noThemedWrapper,
+	ref,
+	onRequestClose,
+	footer = 'dual-cta',
+	primaryLabel = 'Confirm',
+	secondaryLabel = 'Cancel',
+	onPrimaryClick,
+	onSecondaryClick,
+	primaryDisabled = false,
+	closeOnPrimary = true,
+	closeOnSecondary = true,
+	'aria-describedby': ariaDescribedBy,
+	children,
+}) => {
+	const titleId = useId();
+	const locked = useRef<boolean>(true);
+	const bodyRef = useRef<HTMLElement>(null);
+	const [isScrolled, setIsScrolled] = useState(false);
+
+	const closeButtonHandler = useEventCallback<
+		MouseEventHandler<HTMLButtonElement>
+	>(() => {
+		if (typeof onRequestClose === 'function') onRequestClose('button');
+	});
+
+	const primaryClickHandler = useEventCallback(() => {
+		if (typeof onPrimaryClick === 'function') onPrimaryClick();
+		if (closeOnPrimary && typeof onRequestClose === 'function')
+			onRequestClose('primary');
+	});
+
+	const secondaryClickHandler = useEventCallback(() => {
+		if (typeof onSecondaryClick === 'function') onSecondaryClick();
+		if (closeOnSecondary && typeof onRequestClose === 'function')
+			onRequestClose('secondary');
+	});
+
+	const handleBodyScroll = useEventCallback(() => {
+		const node = bodyRef.current;
+		if (!node) return;
+		const scrolled = node.scrollTop > 0;
+		setIsScrolled((prev) => (prev === scrolled ? prev : scrolled));
+	});
+
+	const unlockModal = useEventCallback<MouseEventHandler<HTMLDivElement>>(
+		(event) => {
+			locked.current = event.target !== event.currentTarget;
+		},
+	);
+
+	const backdropHandler = useEventCallback<MouseEventHandler<HTMLDivElement>>(
+		(event) => {
+			if (locked.current || event.target !== event.currentTarget) return;
+			if (typeof onRequestClose === 'function')
+				onRequestClose('backdrop');
+		},
+	);
+
+	if (isBrowser) {
+		useLayoutEffect(() => {
+			document.body.style.overflow = isOpen ? 'hidden' : '';
+
+			return () => {
+				document.body.style.overflow = '';
+			};
+		}, [isOpen]);
+	}
+
+	return (
+		<Modal
+			isOpen={isOpen}
+			ref={ref}
+			noThemedWrapper={noThemedWrapper}
+			container={container}
+			onRequestClose={onRequestClose}
+		>
+			<Box
+				className={styles.container}
+				height="full"
+				display="flex"
+				alignItems="center"
+				justifyContent="center"
+				aria-hidden={isOpen ? 'false' : 'true'}
+				role="none presentation"
+				onMouseDown={unlockModal}
+				onClick={backdropHandler}
+			>
+				<Box
+					as="article"
+					overflow="hidden"
+					role="dialog"
+					aria-modal="true"
+					aria-labelledby={titleId!}
+					aria-describedby={ariaDescribedBy}
+					display="flex"
+					flexDirection="column"
+					backgroundColor="default"
+					marginTop="9"
+					className={clsx([
+						styles.modal,
+						{ [styles.modalSizeStandard]: size === 'standard' },
+						{ [styles.modalSizeNarrow]: size === 'narrow' },
+						{ [styles.modalSizeSkinny]: size === 'skinny' },
+						className,
+					])}
+				>
+					<Box
+						as="header"
+						flexShrink="0"
+						position="relative"
+						display="flex"
+						alignItems="center"
+						justifyContent="space-between"
+						width="full"
+						paddingY="3"
+						paddingLeft="5"
+						paddingRight="2"
+						borderWidthBottom="1"
+						borderColor="muted"
+						className={clsx(isScrolled && styles.headerScrolled)}
+					>
+						<Box flexGrow="0" id={titleId!}>
+							<Heading as="h2" color="primary">{title}</Heading>
+						</Box>
+						<Button
+							minimal
+							rounded
+							variant="secondary"
+							size="medium"
+							aria-label="Close dialog"
+							onClick={closeButtonHandler}
+						>
+							<Icon
+								className={textStyles({ color: 'tertiary' })}
+								icon={XIcon}
+								size="medium"
+							/>
+						</Button>
+					</Box>
+					<Box
+						as="main"
+						ref={bodyRef}
+						display="flex"
+						flexDirection="column"
+						flexGrow="1"
+						height="full"
+						className={styles.content}
+						onScroll={handleBodyScroll}
+					>
+						{children}
+					</Box>
+					<Box
+						as="footer"
+						flexShrink="0"
+						display="flex"
+						alignItems="center"
+						justifyContent="flexEnd"
+						gap="3"
+						width="full"
+						paddingY="5"
+						paddingX="5"
+						borderWidthTop="1"
+						borderColor="muted"
+					>
+						{footer === 'dual-cta' ? (
+							<Button
+								variant="secondary"
+								size="medium"
+								onClick={secondaryClickHandler}
+							>
+								{secondaryLabel}
+							</Button>
+						) : null}
+						<Button
+							variant="primary"
+							size="medium"
+							disabled={primaryDisabled}
+							onClick={primaryClickHandler}
+						>
+							{primaryLabel}
+						</Button>
+					</Box>
+				</Box>
+			</Box>
+		</Modal>
+	);
+};

--- a/lib/components/StickyFooterModal/__snapshots__/StickyFooterModal.spec.jsx.snap
+++ b/lib/components/StickyFooterModal/__snapshots__/StickyFooterModal.spec.jsx.snap
@@ -1,0 +1,223 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<StickyFooterModal /> > should match snapshot with dual-cta footer (default) 1`] = `
+<body
+  class="theme_OD_Base__j49br80"
+  style="overflow: hidden;"
+>
+  <div>
+    <div
+      class="theme_OD_Base__j49br80"
+      data-od-component="provider"
+    />
+  </div>
+  <div
+    class="theme_OD_Base__j49br80"
+  >
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        aria-hidden="true"
+        class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_position_fixed_mobile__onxwjuhi sprinkles_backgroundColour_neutral__onxwjucq Modal_backdrop_root__1psykzh4 Modal_transition__1psykzh1"
+      />
+      <div
+        class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_overflow_hidden_mobile__onxwjuga sprinkles_position_fixed_mobile__onxwjuhi Modal_root__1psykzh0 Modal_transition__1psykzh1"
+        role="presentation"
+      >
+        <div
+          aria-hidden="false"
+          class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwjufe sprinkles_height_full_mobile__onxwjur6 sprinkles_alignItems_center_mobile__onxwju106 sprinkles_justifyContent_center_mobile__onxwju11u StickyFooterModal_container__11wyhv90"
+          role="none presentation"
+        >
+          <article
+            aria-labelledby="od-3"
+            aria-modal="true"
+            class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_article__18vhvlio elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwjufe sprinkles_overflow_hidden_mobile__onxwjuga sprinkles_backgroundColor_default__onxwjuav sprinkles_flexDirection_column_mobile__onxwju13a sprinkles_marginTop_9_mobile__onxwju1iq StickyFooterModal_modal__11wyhv91 StickyFooterModal_modalSizeStandard__11wyhv94"
+            role="dialog"
+          >
+            <header
+              class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_header__18vhvliu elementReset_block__18vhvli4 elementReset_resetVariants_hasBorder_true__18vhvli1f elementReset_borderReset__18vhvli1 sprinkles_borderBottomColor_muted__onxwju4 sprinkles_borderLeftColor_muted__onxwju1t sprinkles_borderRightColor_muted__onxwju3i sprinkles_borderTopColor_muted__onxwju57 sprinkles_borderBottomWidth_1_mobile__onxwjuo2 sprinkles_paddingTop_3_mobile__onxwju1bm sprinkles_paddingBottom_3_mobile__onxwju16y sprinkles_display_flex_mobile__onxwjufe sprinkles_position_relative_mobile__onxwjuha sprinkles_width_full_mobile__onxwjut6 sprinkles_alignItems_center_mobile__onxwju106 sprinkles_flexShrink_0_mobile__onxwju142 sprinkles_justifyContent_space-between_mobile__onxwju12y sprinkles_paddingLeft_5_mobile__onxwju18q sprinkles_paddingRight_2_mobile__onxwju19y"
+            >
+              <div
+                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_flexGrow_0_mobile__onxwju13q"
+                id="od-3"
+              >
+                <h2
+                  class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_h2__18vhvlih elementReset_trimmedElement__18vhvli0 elementReset_heading__18vhvli6 typography_common__yhjp33f sprinkles_fontSize_7_mobile__onxwjuka sprinkles_lineHeight_7_mobile__onxwjuie sprinkles_color_primary__onxwju8j sprinkles_fontWeight_bold__onxwjueb"
+                >
+                  Hello World!
+                </h2>
+              </div>
+              <button
+                aria-label="Close dialog"
+                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 Button_button__p2yon56 Button__p2yon53 sprinkles_borderBottomStyle_none__onxwju86 sprinkles_borderLeftStyle_none__onxwju84 sprinkles_borderRightStyle_none__onxwju88 sprinkles_borderTopStyle_none__onxwju8a sprinkles_alignItems_center_mobile__onxwju106 sprinkles_borderRadius_md_mobile__onxwjume sprinkles_fontWeight_medium__onxwjue9 sprinkles_gap_1_mobile__onxwjuua sprinkles_justifyContent_center_mobile__onxwju11u sprinkles_position_relative_mobile__onxwjuha sprinkles_width_fit-content_mobile__onxwjusu focusOutline_focusOutlineStyle__tq83zq0 Button_button_size_medium__p2yon58 Button_button_shape_iconOnly__p2yon5c Button_button_intent_secondary__p2yon5f Button_button_minimal_true__p2yon5k Button_button_rounded_true__p2yon5m Button__p2yon54 sprinkles_borderRadius_pill_mobile__onxwjumu Button_button_compound_5__p2yon5v Button_button_compound_8__p2yon5y"
+                type="button"
+              >
+                <span
+                  class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  sprinkles_display_block_mobile__onxwjuf6 Icon_makeResponsiveStyle_key_bp__1gy3ire4 elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_4_mobile__onxwjujy sprinkles_lineHeight_4_mobile__onxwjui2 sprinkles_color_tertiary__onxwju8m sprinkles_fontWeight_normal__onxwjue8"
+                  data-od-component="icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_block_mobile__onxwjuf6 sprinkles_width_full_mobile__onxwjut6 sprinkles_height_full_mobile__onxwjur6"
+                    fill="currentColor"
+                    focusable="false"
+                    viewBox="0 0 256 256"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M205.66 194.34a8 8 0 0 1-11.32 11.32L128 139.31l-66.34 66.35a8 8 0 0 1-11.32-11.32L116.69 128 50.34 61.66a8 8 0 0 1 11.32-11.32L128 116.69l66.34-66.35a8 8 0 0 1 11.32 11.32L139.31 128z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </header>
+            <main
+              class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwjufe sprinkles_height_full_mobile__onxwjur6 sprinkles_flexDirection_column_mobile__onxwju13a sprinkles_flexGrow_1_mobile__onxwju13u StickyFooterModal_content__11wyhv96"
+            >
+              <p>
+                Body content
+              </p>
+            </main>
+            <footer
+              class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_footer__18vhvlit elementReset_block__18vhvli4 elementReset_resetVariants_hasBorder_true__18vhvli1f elementReset_borderReset__18vhvli1 sprinkles_borderBottomColor_muted__onxwju4 sprinkles_borderLeftColor_muted__onxwju1t sprinkles_borderRightColor_muted__onxwju3i sprinkles_borderTopColor_muted__onxwju57 sprinkles_borderTopWidth_1_mobile__onxwjuoy sprinkles_paddingLeft_5_mobile__onxwju18q sprinkles_paddingRight_5_mobile__onxwju1aa sprinkles_paddingTop_5_mobile__onxwju1bu sprinkles_paddingBottom_5_mobile__onxwju176 sprinkles_display_flex_mobile__onxwjufe sprinkles_width_full_mobile__onxwjut6 sprinkles_alignItems_center_mobile__onxwju106 sprinkles_flexShrink_0_mobile__onxwju142 sprinkles_gap_3_mobile__onxwjuui sprinkles_justifyContent_flexEnd_mobile__onxwju126"
+            >
+              <button
+                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 Button_button__p2yon56 Button__p2yon53 sprinkles_borderBottomStyle_none__onxwju86 sprinkles_borderLeftStyle_none__onxwju84 sprinkles_borderRightStyle_none__onxwju88 sprinkles_borderTopStyle_none__onxwju8a sprinkles_alignItems_center_mobile__onxwju106 sprinkles_borderRadius_md_mobile__onxwjume sprinkles_fontWeight_medium__onxwjue9 sprinkles_gap_1_mobile__onxwjuua sprinkles_justifyContent_center_mobile__onxwju11u sprinkles_position_relative_mobile__onxwjuha sprinkles_width_fit-content_mobile__onxwjusu focusOutline_focusOutlineStyle__tq83zq0 Button_button_size_medium__p2yon58 Button_button_shape_default__p2yon5a Button_button_intent_secondary__p2yon5f Button_button_minimal_false__p2yon5l Button_button_compound_3__p2yon5t"
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 Button_button__p2yon56 Button__p2yon53 sprinkles_borderBottomStyle_none__onxwju86 sprinkles_borderLeftStyle_none__onxwju84 sprinkles_borderRightStyle_none__onxwju88 sprinkles_borderTopStyle_none__onxwju8a sprinkles_alignItems_center_mobile__onxwju106 sprinkles_borderRadius_md_mobile__onxwjume sprinkles_fontWeight_medium__onxwjue9 sprinkles_gap_1_mobile__onxwjuua sprinkles_justifyContent_center_mobile__onxwju11u sprinkles_position_relative_mobile__onxwjuha sprinkles_width_fit-content_mobile__onxwjusu focusOutline_focusOutlineStyle__tq83zq0 Button_button_size_medium__p2yon58 Button_button_shape_default__p2yon5a Button_button_intent_primary__p2yon5d Button_button_minimal_false__p2yon5l Button_button_compound_3__p2yon5t"
+                type="button"
+              >
+                Confirm
+              </button>
+            </footer>
+          </article>
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`<StickyFooterModal /> > should match snapshot with single-cta footer 1`] = `
+<body
+  class="theme_OD_Base__j49br80"
+  style="overflow: hidden;"
+>
+  <div>
+    <div
+      class="theme_OD_Base__j49br80"
+      data-od-component="provider"
+    />
+  </div>
+  <div
+    class="theme_OD_Base__j49br80"
+  >
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        aria-hidden="true"
+        class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_position_fixed_mobile__onxwjuhi sprinkles_backgroundColour_neutral__onxwjucq Modal_backdrop_root__1psykzh4 Modal_transition__1psykzh1"
+      />
+      <div
+        class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_overflow_hidden_mobile__onxwjuga sprinkles_position_fixed_mobile__onxwjuhi Modal_root__1psykzh0 Modal_transition__1psykzh1"
+        role="presentation"
+      >
+        <div
+          aria-hidden="false"
+          class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwjufe sprinkles_height_full_mobile__onxwjur6 sprinkles_alignItems_center_mobile__onxwju106 sprinkles_justifyContent_center_mobile__onxwju11u StickyFooterModal_container__11wyhv90"
+          role="none presentation"
+        >
+          <article
+            aria-labelledby="od-4"
+            aria-modal="true"
+            class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_article__18vhvlio elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwjufe sprinkles_overflow_hidden_mobile__onxwjuga sprinkles_backgroundColor_default__onxwjuav sprinkles_flexDirection_column_mobile__onxwju13a sprinkles_marginTop_9_mobile__onxwju1iq StickyFooterModal_modal__11wyhv91 StickyFooterModal_modalSizeStandard__11wyhv94"
+            role="dialog"
+          >
+            <header
+              class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_header__18vhvliu elementReset_block__18vhvli4 elementReset_resetVariants_hasBorder_true__18vhvli1f elementReset_borderReset__18vhvli1 sprinkles_borderBottomColor_muted__onxwju4 sprinkles_borderLeftColor_muted__onxwju1t sprinkles_borderRightColor_muted__onxwju3i sprinkles_borderTopColor_muted__onxwju57 sprinkles_borderBottomWidth_1_mobile__onxwjuo2 sprinkles_paddingTop_3_mobile__onxwju1bm sprinkles_paddingBottom_3_mobile__onxwju16y sprinkles_display_flex_mobile__onxwjufe sprinkles_position_relative_mobile__onxwjuha sprinkles_width_full_mobile__onxwjut6 sprinkles_alignItems_center_mobile__onxwju106 sprinkles_flexShrink_0_mobile__onxwju142 sprinkles_justifyContent_space-between_mobile__onxwju12y sprinkles_paddingLeft_5_mobile__onxwju18q sprinkles_paddingRight_2_mobile__onxwju19y"
+            >
+              <div
+                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_flexGrow_0_mobile__onxwju13q"
+                id="od-4"
+              >
+                <h2
+                  class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_h2__18vhvlih elementReset_trimmedElement__18vhvli0 elementReset_heading__18vhvli6 typography_common__yhjp33f sprinkles_fontSize_7_mobile__onxwjuka sprinkles_lineHeight_7_mobile__onxwjuie sprinkles_color_primary__onxwju8j sprinkles_fontWeight_bold__onxwjueb"
+                >
+                  Hello World!
+                </h2>
+              </div>
+              <button
+                aria-label="Close dialog"
+                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 Button_button__p2yon56 Button__p2yon53 sprinkles_borderBottomStyle_none__onxwju86 sprinkles_borderLeftStyle_none__onxwju84 sprinkles_borderRightStyle_none__onxwju88 sprinkles_borderTopStyle_none__onxwju8a sprinkles_alignItems_center_mobile__onxwju106 sprinkles_borderRadius_md_mobile__onxwjume sprinkles_fontWeight_medium__onxwjue9 sprinkles_gap_1_mobile__onxwjuua sprinkles_justifyContent_center_mobile__onxwju11u sprinkles_position_relative_mobile__onxwjuha sprinkles_width_fit-content_mobile__onxwjusu focusOutline_focusOutlineStyle__tq83zq0 Button_button_size_medium__p2yon58 Button_button_shape_iconOnly__p2yon5c Button_button_intent_secondary__p2yon5f Button_button_minimal_true__p2yon5k Button_button_rounded_true__p2yon5m Button__p2yon54 sprinkles_borderRadius_pill_mobile__onxwjumu Button_button_compound_5__p2yon5v Button_button_compound_8__p2yon5y"
+                type="button"
+              >
+                <span
+                  class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  sprinkles_display_block_mobile__onxwjuf6 Icon_makeResponsiveStyle_key_bp__1gy3ire4 elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_span__18vhvlim  typography_common__yhjp33f sprinkles_fontSize_4_mobile__onxwjujy sprinkles_lineHeight_4_mobile__onxwjui2 sprinkles_color_tertiary__onxwju8m sprinkles_fontWeight_normal__onxwjue8"
+                  data-od-component="icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_block_mobile__onxwjuf6 sprinkles_width_full_mobile__onxwjut6 sprinkles_height_full_mobile__onxwjur6"
+                    fill="currentColor"
+                    focusable="false"
+                    viewBox="0 0 256 256"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M205.66 194.34a8 8 0 0 1-11.32 11.32L128 139.31l-66.34 66.35a8 8 0 0 1-11.32-11.32L116.69 128 50.34 61.66a8 8 0 0 1 11.32-11.32L128 116.69l66.34-66.35a8 8 0 0 1 11.32 11.32L139.31 128z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </header>
+            <main
+              class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_div__18vhvlie elementReset_block__18vhvli4 sprinkles_display_flex_mobile__onxwjufe sprinkles_height_full_mobile__onxwjur6 sprinkles_flexDirection_column_mobile__onxwju13a sprinkles_flexGrow_1_mobile__onxwju13u StickyFooterModal_content__11wyhv96"
+            >
+              <p>
+                Body content
+              </p>
+            </main>
+            <footer
+              class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_footer__18vhvlit elementReset_block__18vhvli4 elementReset_resetVariants_hasBorder_true__18vhvli1f elementReset_borderReset__18vhvli1 sprinkles_borderBottomColor_muted__onxwju4 sprinkles_borderLeftColor_muted__onxwju1t sprinkles_borderRightColor_muted__onxwju3i sprinkles_borderTopColor_muted__onxwju57 sprinkles_borderTopWidth_1_mobile__onxwjuoy sprinkles_paddingLeft_5_mobile__onxwju18q sprinkles_paddingRight_5_mobile__onxwju1aa sprinkles_paddingTop_5_mobile__onxwju1bu sprinkles_paddingBottom_5_mobile__onxwju176 sprinkles_display_flex_mobile__onxwjufe sprinkles_width_full_mobile__onxwjut6 sprinkles_alignItems_center_mobile__onxwju106 sprinkles_flexShrink_0_mobile__onxwju142 sprinkles_gap_3_mobile__onxwjuui sprinkles_justifyContent_flexEnd_mobile__onxwju126"
+            >
+              <button
+                class="elementReset_resetVariants__18vhvlid elementReset_resetVariants_as_button__18vhvli12 elementReset_trimmedElement__18vhvli0 elementReset_button__18vhvli5 Button_button__p2yon56 Button__p2yon53 sprinkles_borderBottomStyle_none__onxwju86 sprinkles_borderLeftStyle_none__onxwju84 sprinkles_borderRightStyle_none__onxwju88 sprinkles_borderTopStyle_none__onxwju8a sprinkles_alignItems_center_mobile__onxwju106 sprinkles_borderRadius_md_mobile__onxwjume sprinkles_fontWeight_medium__onxwjue9 sprinkles_gap_1_mobile__onxwjuua sprinkles_justifyContent_center_mobile__onxwju11u sprinkles_position_relative_mobile__onxwjuha sprinkles_width_fit-content_mobile__onxwjusu focusOutline_focusOutlineStyle__tq83zq0 Button_button_size_medium__p2yon58 Button_button_shape_default__p2yon5a Button_button_intent_primary__p2yon5d Button_button_minimal_false__p2yon5l Button_button_compound_3__p2yon5t"
+                type="button"
+              >
+                Confirm
+              </button>
+            </footer>
+          </article>
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;

--- a/lib/components/StickyFooterModal/default.ts
+++ b/lib/components/StickyFooterModal/default.ts
@@ -1,0 +1,1 @@
+export { StickyFooterModal as default } from './StickyFooterModal';

--- a/lib/components/StickyFooterModal/index.ts
+++ b/lib/components/StickyFooterModal/index.ts
@@ -1,0 +1,8 @@
+export {
+	StickyFooterModal,
+	ESize as EStickyFooterModalSize,
+} from './StickyFooterModal';
+export type {
+	StickyFooterModalProps,
+	StickyFooterModalVariant,
+} from './StickyFooterModal';

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -108,6 +108,10 @@ export { StandardModal, EStandardModalSize } from './StandardModal';
 export { StarRating, EStarRatingSize } from './StarRating';
 export { Stepper } from './Stepper';
 export { StickyBox } from './StickyBox';
+export {
+	StickyFooterModal,
+	EStickyFooterModalSize,
+} from './StickyFooterModal';
 export { Switch } from './Switch';
 export {
 	Table,


### PR DESCRIPTION
## Summary
- New `StickyFooterModal` variant: fixed header + scrollable body + sticky footer with one (`single-cta`) or two (`dual-cta`, default) CTAs
- Baked-in dialog a11y: focus trap, Escape-to-close, `role="dialog"` / `aria-modal` / `aria-labelledby` / `aria-describedby`, `"Close dialog"` label, 48×48 close-× hit area, scroll-shadow hint
- Auto-close on primary/secondary click, opt-out via `closeOnPrimary` / `closeOnSecondary`
- Base `Modal` upgraded: Escape dispatches `onRequestClose('escapeKeyDown')`, symmetric enter/exit scale animation, `prefers-reduced-motion` now disables the whole transition, timings unified to 200ms
- `StandardModal` `min-height` bumped to 400px to match

Content of the Storybook Docs page (intro, anatomy, tokens, transitions, do/don't, a11y, responsive) is sourced from the DS-2026 Figma spec.

## Test plan
- [ ] `yarn test run StickyFooterModal StandardModal Modal MinimalModal` — all pass (19/19 on my box)
- [ ] `yarn lint` clean
- [ ] Storybook → **Components → Modal: Sticky footer CTAs** → verify Dual CTA, Single CTA, and Docs page render
- [ ] Scroll the body → header should show a soft drop-shadow; scroll back → shadow disappears
- [ ] Escape / backdrop / × / primary / secondary all fire `onRequestClose` with the correct reason
- [ ] Tab / Shift+Tab traps focus inside the modal; close returns focus to trigger
- [ ] Toggle `prefers-reduced-motion` at the OS level → entry/exit animations are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)