### PR TITLE
feat(OverdriveProvider): derive linkColor per surface (FPAY-202)

### DIFF
--- a/.changeset/link-colour-per-surface.md
+++ b/.changeset/link-colour-per-surface.md
@@ -1,0 +1,30 @@
+---
+'@autoguru/overdrive': minor
+---
+
+Derive the tenant `linkColor` per surface instead of writing it verbatim.
+
+`colorOverrides.linkColor` reaches the app as a single inline CSS var on the
+provider, so one value had to serve both a white page and a `gray900` header —
+and no colour clears 4.5:1 on both. A brand supplied as a button fill (a colour
+picked to sit *behind* white text) could land as low as 1.6:1 as link text.
+Because `focusOutline` reads the same token, that also took every focus ring in
+the library below WCAG 1.4.11.
+
+`useColorOverrides` now shades the supplied colour away from each surface until
+it clears 4.5:1, preserving hue: a light brand darkens for pale surfaces and is
+left alone for dark ones, a dark brand does the reverse. A brand already legible
+on a surface is passed through untouched. If a hue cannot get there without
+ceasing to be the brand, that side keeps the theme's own link colour and warns
+in development.
+
+New `color.interactive.linkOnDark` token holds the dark-surface value; its base
+value is the current link colour, so unbranded consumers are unchanged.
+
+New `darkSurface` class (exported from `@autoguru/overdrive/styles`) opts a
+dark-filled region into that value for its subtree — links and focus rings both
+follow:
+
+```tsx
+<Box as="header" backgroundColor="gray900" color="white" className={darkSurface}>
+```

--- a/lib/components/OverdriveProvider/useColorOverrides.spec.ts
+++ b/lib/components/OverdriveProvider/useColorOverrides.spec.ts
@@ -257,6 +257,75 @@ describe('useColorOverrides', () => {
 				).toBe(BRAND);
 			});
 
+			// The notations `isValidColor` accepts and the old parser did not.
+			// Each used to measure as black: it cleared AA on sight, so the raw
+			// brand shipped unshaded and the feature no-opped without a word.
+			it.each([
+				['hsl()', 'hsl(45, 100%, 50%)'],
+				['a named colour', 'gold'],
+				['8-digit hex', '#ffc001aa'],
+			])(
+				'shades a brand supplied as %s, rather than passing it through',
+				(_label, supplied) => {
+					const link = vars({ linkColor: supplied })[
+						'--od-colours-foreground-link'
+					];
+
+					expect(link).toBeDefined();
+					expect(link).not.toBe(supplied);
+					expect(legibleOn(link, PALE_SURFACE)).toBe(true);
+				},
+			);
+
+			// Each derived value has to clear AA on the *hardest* surface its
+			// bucket covers, not merely on the one it was pointed at — otherwise
+			// `backgroundColor="gray300"` gets a colour tuned for gray200.
+			it('clears AA on every surface its bucket claims, not just one', () => {
+				const result = vars({ linkColor: LIGHT_BRAND });
+				const onLight = result['--od-colours-foreground-link'];
+				const onDark = result['--od-color-interactive-link-on-dark'];
+
+				// worst case of each list: the darkest pale, the lightest dark
+				for (const surface of ['#ffffff', '#eef0f2', '#d4d9dd'])
+					expect(legibleOn(onLight, surface)).toBe(true);
+
+				for (const surface of ['#212338', '#34384c', '#484c5f'])
+					expect(legibleOn(onDark, surface)).toBe(true);
+			});
+
+			// The loop used to accumulate `intensity += 0.01` and stop at 0.59,
+			// so the last step the cap advertised was never tried.
+			it('spends every step the cap advertises before giving up', () => {
+				// clears AA on gray300 only at step 60 of 60 — under the old
+				// float loop this fell through and lost its brand entirely
+				const EDGE = '#fff0f0';
+
+				const link = vars({ linkColor: EDGE })[
+					'--od-colours-foreground-link'
+				];
+
+				expect(link).toBeDefined();
+				expect(legibleOn(link, '#d4d9dd')).toBe(true);
+			});
+
+			it('refuses to guess about a colour it cannot measure, and warns', () => {
+				const warn = vi
+					.spyOn(console, 'warn')
+					.mockImplementation(() => {});
+
+				// `isValidColor` accepts this — the DOM does — but no contrast
+				// decision about it can be measured.
+				const result = vars({ linkColor: 'currentColor' });
+
+				expect(result['--od-colours-foreground-link']).toBeUndefined();
+				expect(
+					result['--od-color-interactive-link-on-dark'],
+				).toBeUndefined();
+				expect(warn).toHaveBeenCalledWith(
+					expect.stringContaining('not a colour this can measure'),
+				);
+			});
+
 			it('keeps the theme default on the side a hue cannot reach, and warns', () => {
 				const warn = vi
 					.spyOn(console, 'warn')

--- a/lib/components/OverdriveProvider/useColorOverrides.spec.ts
+++ b/lib/components/OverdriveProvider/useColorOverrides.spec.ts
@@ -230,7 +230,7 @@ describe('useColorOverrides', () => {
 
 				expect(link).not.toBe(LIGHT_BRAND);
 				expect(legibleOn(link, PALE_SURFACE)).toBe(true);
-				expect(hue(link)).toBeCloseTo(hue(LIGHT_BRAND), -1);
+				expect(hue(link)).toBeCloseTo(hue(LIGHT_BRAND), 0);
 			});
 
 			it('leaves a light brand untouched for dark surfaces', () => {
@@ -248,7 +248,7 @@ describe('useColorOverrides', () => {
 
 				expect(link).not.toBe(BRAND);
 				expect(legibleOn(link, DARK_SURFACE)).toBe(true);
-				expect(hue(link)).toBeCloseTo(hue(BRAND), -1);
+				expect(hue(link)).toBeCloseTo(hue(BRAND), 0);
 			});
 
 			it('leaves a dark brand untouched on pale surfaces', () => {

--- a/lib/components/OverdriveProvider/useColorOverrides.spec.ts
+++ b/lib/components/OverdriveProvider/useColorOverrides.spec.ts
@@ -1,14 +1,22 @@
 import { renderHook } from '@testing-library/react';
+import { colord } from 'colord';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { colourMap } from '../../themes/base/colours';
 import { tokens as baseTokens } from '../../themes/base/tokens';
-import { getColourLuminance, getRGBValues } from '../../themes/helpers';
+import {
+	getColourLuminance,
+	getRGBValues,
+	passesAccessibilityContrast,
+} from '../../themes/helpers';
 
 import { useColorOverrides } from './useColorOverrides';
 
 const BRAND = '#6d39a8'; // Merchant Finder's purple — dark, wants white on it
 const BRIGHT = '#e5bc01'; // a bright yellow — wants dark ink on it
+const LIGHT_BRAND = '#ffc001'; // AutoGuru yellow — 1.6:1 on white, 9.4:1 on navy
+const PALE_SURFACE = baseTokens.color.background.emphasisInactive; // gray200
+const DARK_SURFACE = baseTokens.color.background.reverse; // gray900
 
 const vars = (
 	overrides?: Parameters<typeof useColorOverrides>[0],
@@ -18,6 +26,16 @@ const vars = (
 		.current as Record<string, string>;
 
 const luminance = (colour: string) => getColourLuminance(getRGBValues(colour));
+
+const legibleOn = (colour: string, surface: string) =>
+	passesAccessibilityContrast({
+		colour1: colour,
+		colour2: surface,
+		level: 'AA',
+		textSize: 'SMALL',
+	});
+
+const hue = (colour: string) => colord(colour).toHsl().h;
 
 describe('useColorOverrides', () => {
 	beforeEach(() => {
@@ -188,6 +206,9 @@ describe('useColorOverrides', () => {
 			const result = vars({ primaryBackground: BRAND });
 			expect(result['--od-colours-foreground-link']).toBeUndefined();
 			expect(result['--od-typography-colour-link']).toBeUndefined();
+			expect(
+				result['--od-color-interactive-link-on-dark'],
+			).toBeUndefined();
 		});
 
 		it('brands them only when linkColor is passed explicitly', () => {
@@ -197,6 +218,65 @@ describe('useColorOverrides', () => {
 			});
 			expect(result['--od-colours-foreground-link']).toBe(BRAND);
 			expect(result['--od-typography-colour-link']).toBe(BRAND);
+		});
+
+		// One inline var serves every surface, so a brand legible on a white
+		// page can still be invisible on a gray-900 header, and vice versa.
+		describe('deriving one colour per surface', () => {
+			it('darkens a light brand until it clears AA on the palest card', () => {
+				const link = vars({ linkColor: LIGHT_BRAND })[
+					'--od-colours-foreground-link'
+				];
+
+				expect(link).not.toBe(LIGHT_BRAND);
+				expect(legibleOn(link, PALE_SURFACE)).toBe(true);
+				expect(hue(link)).toBeCloseTo(hue(LIGHT_BRAND), -1);
+			});
+
+			it('leaves a light brand untouched for dark surfaces', () => {
+				expect(
+					vars({ linkColor: LIGHT_BRAND })[
+						'--od-color-interactive-link-on-dark'
+					],
+				).toBe(LIGHT_BRAND);
+			});
+
+			it('lightens a dark brand until it clears AA on a dark surface', () => {
+				const link = vars({ linkColor: BRAND })[
+					'--od-color-interactive-link-on-dark'
+				];
+
+				expect(link).not.toBe(BRAND);
+				expect(legibleOn(link, DARK_SURFACE)).toBe(true);
+				expect(hue(link)).toBeCloseTo(hue(BRAND), -1);
+			});
+
+			it('leaves a dark brand untouched on pale surfaces', () => {
+				expect(
+					vars({ linkColor: BRAND })['--od-colours-foreground-link'],
+				).toBe(BRAND);
+			});
+
+			it('keeps the theme default on the side a hue cannot reach, and warns', () => {
+				const warn = vi
+					.spyOn(console, 'warn')
+					.mockImplementation(() => {});
+				// a pale pastel: no amount of darkening short of abandoning the
+				// hue clears 4.5:1 on a gray-200 card, but it is already legible
+				// on gray-900 — so only the light side falls back
+				const PASTEL = '#affff5';
+
+				const result = vars({ linkColor: PASTEL });
+
+				expect(result['--od-colours-foreground-link']).toBeUndefined();
+				expect(result['--od-typography-colour-link']).toBeUndefined();
+				expect(result['--od-color-interactive-link-on-dark']).toBe(
+					PASTEL,
+				);
+				expect(warn).toHaveBeenCalledWith(
+					expect.stringContaining('without losing the brand'),
+				);
+			});
 		});
 	});
 

--- a/lib/components/OverdriveProvider/useColorOverrides.ts
+++ b/lib/components/OverdriveProvider/useColorOverrides.ts
@@ -150,9 +150,13 @@ const clearsAA = (colour: string, surface: string): boolean =>
 		textSize: 'SMALL',
 	});
 
+/** The ends of the luminance scale, not theme colours — the poles a surface is measured against. */
+const luminancePole = { light: '#ffffff', dark: '#000000' } as const;
+
 /** `getContrastRatio` is `min/max`, so the SMALLER value is the greater contrast. */
 const isDarkSurface = (surface: string): boolean =>
-	getContrastRatio(surface, '#ffffff') < getContrastRatio(surface, '#000000');
+	getContrastRatio(surface, luminancePole.light) <
+	getContrastRatio(surface, luminancePole.dark);
 
 /**
  * The supplied colour if it is already legible on `surface`, otherwise the same

--- a/lib/components/OverdriveProvider/useColorOverrides.ts
+++ b/lib/components/OverdriveProvider/useColorOverrides.ts
@@ -2,7 +2,14 @@ import { assignInlineVars } from '@vanilla-extract/dynamic';
 import { useMemo } from 'react';
 
 import {
+	darkSurfaceValues,
+	lightSurfaceValues,
+} from '../../styles/surfaceLinkVars';
+import {
+	canMeasureContrast,
+	darkenColour,
 	getContrastRatio,
+	lightenColour,
 	passesAccessibilityContrast,
 	shadedColour,
 } from '../../themes/helpers';
@@ -17,14 +24,76 @@ interface ThemeContext {
 	darkSurface: string;
 }
 
+/** The ends of the luminance scale, not theme colours — the poles a surface is measured against. */
+const luminancePole = { light: '#ffffff', dark: '#000000' } as const;
+
+/**
+ * The live value behind a `backgroundColor` sprinkle value name. `color.gamut`
+ * holds var() references at this point, so the ramp comes off the legacy gamut,
+ * which carries literals.
+ */
+const surfaceValue = (
+	name: string,
+	tokens: ThemeTokens,
+): string | undefined => {
+	// eslint-disable-next-line no-restricted-syntax -- RETAINED: color.gamut resolves to var() references; colours.gamut is the only gamut carrying literals, and a literal is what a contrast measurement needs.
+	const { gamut } = tokens.colours;
+	const byName: Record<string, string> = {
+		...tokens.color.surface,
+		...tokens.color.background,
+		...gamut,
+		black900: gamut.gray900,
+	};
+	return byName[name];
+};
+
+/** `getContrastRatio` is `min/max`, so the SMALLER value is the greater contrast. */
+const isDarkSurface = (surface: string): boolean =>
+	getContrastRatio(surface, luminancePole.light) <
+	getContrastRatio(surface, luminancePole.dark);
+
+/**
+ * The hardest surface in a bucket to be legible on: the darkest of the pale
+ * ones, the lightest of the dark ones. Tuning against the worst case is what
+ * lets `surfaceLinkVars` promise 4.5:1 on every surface it declares, rather
+ * than only on whichever one the derivation was pointed at.
+ */
+const worstCaseSurface = (
+	names: readonly string[],
+	tokens: ThemeTokens,
+	pole: 'light' | 'dark',
+): string => {
+	// Membership is by name, but names can lie: a theme is free to repoint
+	// `reverse` at something pale. Measure each member and keep only those
+	// actually on the bucket's side of the scale, so the target is never a
+	// colour from the wrong half.
+	const measurable = names
+		.map((name) => surfaceValue(name, tokens))
+		.filter((value): value is string => typeof value === 'string')
+		.filter((value) => canMeasureContrast(value))
+		.filter((value) => isDarkSurface(value) === (pole === 'dark'));
+
+	// A theme so inverted that a bucket has no members on its own side gets
+	// the pole itself — the strictest possible target, never a wrong one.
+	if (measurable.length === 0) return luminancePole[pole];
+
+	// `getContrastRatio` is min/max, so the SMALLEST value is the greatest
+	// contrast. The member furthest from its own pole — the darkest pale
+	// surface, the lightest dark one — is the one a link struggles most on.
+	return measurable.reduce((worst, value) =>
+		getContrastRatio(value, luminancePole[pole]) <
+		getContrastRatio(worst, luminancePole[pole])
+			? value
+			: worst,
+	);
+};
+
 const themeContext = (tokens: ThemeTokens): ThemeContext => ({
 	mode: String(tokens.mode),
 	pageBackground: tokens.color.background.default,
 	bodyInk: tokens.color.foreground.primary,
-	// The darkest of the pale surfaces, not the page background — a link tuned
-	// against white alone still fails on a gray-200 card.
-	lightSurface: tokens.color.background.emphasisInactive,
-	darkSurface: tokens.color.background.reverse,
+	lightSurface: worstCaseSurface(lightSurfaceValues, tokens, 'light'),
+	darkSurface: worstCaseSurface(darkSurfaceValues, tokens, 'dark'),
 });
 
 /** valid colour override keys */
@@ -126,8 +195,12 @@ const warnOnLowContrast = (
 /**
  * Past this, a brand has been shaded so far it is no longer the brand; fall back
  * to the theme's own link colour rather than ship an unrecognisable one.
+ *
+ * Counted in whole steps rather than accumulated as a float: `intensity += 0.01`
+ * from 0.01 drifts, and stopped at 0.59 — one step short of the cap the constant
+ * advertised.
  */
-const maxShadeIntensity = 0.6;
+const maxShadeSteps = 60;
 const shadeStep = 0.01;
 
 const shade = (
@@ -135,12 +208,9 @@ const shade = (
 	towards: 'darker' | 'lighter',
 	intensity: number,
 ): string =>
-	shadedColour({
-		colour,
-		isDarkTheme: false,
-		direction: towards === 'darker' ? 'backward' : 'forward',
-		intensity,
-	});
+	towards === 'darker'
+		? darkenColour(colour, intensity)
+		: lightenColour(colour, intensity);
 
 const clearsAA = (colour: string, surface: string): boolean =>
 	passesAccessibilityContrast({
@@ -149,14 +219,6 @@ const clearsAA = (colour: string, surface: string): boolean =>
 		level: 'AA',
 		textSize: 'SMALL',
 	});
-
-/** The ends of the luminance scale, not theme colours — the poles a surface is measured against. */
-const luminancePole = { light: '#ffffff', dark: '#000000' } as const;
-
-/** `getContrastRatio` is `min/max`, so the SMALLER value is the greater contrast. */
-const isDarkSurface = (surface: string): boolean =>
-	getContrastRatio(surface, luminancePole.light) <
-	getContrastRatio(surface, luminancePole.dark);
 
 /**
  * The supplied colour if it is already legible on `surface`, otherwise the same
@@ -167,16 +229,17 @@ const deriveLinkForSurface = (
 	brand: string,
 	surface: string,
 ): string | null => {
+	// Every branch below is a luminance comparison. On a colour we cannot parse
+	// those all resolve against black, so the brand would clear AA on sight and
+	// ship unshaded — the feature silently doing nothing.
+	if (!canMeasureContrast(brand)) return null;
+
 	if (clearsAA(brand, surface)) return brand;
 
 	const towards = isDarkSurface(surface) ? 'lighter' : 'darker';
 
-	for (
-		let intensity = shadeStep;
-		intensity <= maxShadeIntensity;
-		intensity += shadeStep
-	) {
-		const candidate = shade(brand, towards, intensity);
+	for (let step = 1; step <= maxShadeSteps; step++) {
+		const candidate = shade(brand, towards, step * shadeStep);
 		if (clearsAA(candidate, surface)) return candidate;
 	}
 
@@ -193,6 +256,13 @@ const warnOnLinkDerivation = (
 	onDark: string | null,
 	theme: ThemeContext,
 ) => {
+	if (!canMeasureContrast(supplied)) {
+		warnOnce(
+			`Overdrive Provider: linkColor (${supplied}) is not a colour this can measure — contrast against it cannot be checked, so links and focus rings keep the theme's own colour. Supply a hex, rgb(), hsl() or CSS named colour.`,
+		);
+		return;
+	}
+
 	if (onLight === null)
 		warnOnce(
 			`Overdrive Provider: linkColor (${supplied}) cannot reach WCAG AA (4.5:1) against ${theme.lightSurface} without losing the brand. Links and focus rings on light surfaces keep the theme's own link colour.`,
@@ -204,11 +274,11 @@ const warnOnLinkDerivation = (
 
 	if (onDark === null)
 		warnOnce(
-			`Overdrive Provider: linkColor (${supplied}) cannot reach WCAG AA (4.5:1) against ${theme.darkSurface} without losing the brand. Links inside a darkSurface scope keep the theme's own link colour.`,
+			`Overdrive Provider: linkColor (${supplied}) cannot reach WCAG AA (4.5:1) against ${theme.darkSurface} without losing the brand. Links on dark surfaces keep the theme's own link colour.`,
 		);
 	else if (changedFrom(supplied, onDark))
 		warnOnce(
-			`Overdrive Provider: linkColor (${supplied}) does not meet WCAG AA (4.5:1) on dark surfaces. Using ${onDark} inside a darkSurface scope instead.`,
+			`Overdrive Provider: linkColor (${supplied}) does not meet WCAG AA (4.5:1) on dark surfaces. Using ${onDark} there instead.`,
 		);
 };
 
@@ -293,7 +363,8 @@ export const useColorOverrides = (
 
 		// One inline var serves every surface, so a single link colour cannot be
 		// right on both a white page and a gray-900 header. Derive one for each
-		// and let a `darkSurface` scope opt into the second.
+		// and let each painted surface point at the one that suits its fill —
+		// see `withSurfaceLinkVars` in sprinkles.
 		const linkOnLight = linkColor
 			? deriveLinkForSurface(linkColor, theme.lightSurface)
 			: null;
@@ -318,10 +389,18 @@ export const useColorOverrides = (
 					onSolid: onBrand ?? undefined,
 				},
 				interactive: {
-					// read by the `darkSurface` scope, which repoints the link
-					// vars to it for its subtree
+					// The two surface buckets. Every painted surface points the
+					// vars links read at one of these, so the derived pair has
+					// to live somewhere a surface can reference.
+					//@ts-expect-error no undefined
+					linkOnLight: linkOnLight ?? undefined,
 					//@ts-expect-error no undefined
 					linkOnDark: linkOnDark ?? undefined,
+					// The page root is not a painted surface, so it never gets a
+					// surface class. Without this, a semantic-link consumer saw
+					// the brand only inside a Box and the theme default outside.
+					//@ts-expect-error no undefined
+					link: linkOnLight ?? undefined,
 				},
 				button: {
 					primary: {

--- a/lib/components/OverdriveProvider/useColorOverrides.ts
+++ b/lib/components/OverdriveProvider/useColorOverrides.ts
@@ -13,12 +13,18 @@ interface ThemeContext {
 	mode: string;
 	pageBackground: string;
 	bodyInk: string;
+	lightSurface: string;
+	darkSurface: string;
 }
 
 const themeContext = (tokens: ThemeTokens): ThemeContext => ({
 	mode: String(tokens.mode),
 	pageBackground: tokens.color.background.default,
 	bodyInk: tokens.color.foreground.primary,
+	// The darkest of the pale surfaces, not the page background — a link tuned
+	// against white alone still fails on a gray-200 card.
+	lightSurface: tokens.color.background.emphasisInactive,
+	darkSurface: tokens.color.background.reverse,
 });
 
 /** valid colour override keys */
@@ -117,6 +123,91 @@ const warnOnLowContrast = (
 	}
 };
 
+/**
+ * Past this, a brand has been shaded so far it is no longer the brand; fall back
+ * to the theme's own link colour rather than ship an unrecognisable one.
+ */
+const maxShadeIntensity = 0.6;
+const shadeStep = 0.01;
+
+const shade = (
+	colour: string,
+	towards: 'darker' | 'lighter',
+	intensity: number,
+): string =>
+	shadedColour({
+		colour,
+		isDarkTheme: false,
+		direction: towards === 'darker' ? 'backward' : 'forward',
+		intensity,
+	});
+
+const clearsAA = (colour: string, surface: string): boolean =>
+	passesAccessibilityContrast({
+		colour1: colour,
+		colour2: surface,
+		level: 'AA',
+		textSize: 'SMALL',
+	});
+
+/** `getContrastRatio` is `min/max`, so the SMALLER value is the greater contrast. */
+const isDarkSurface = (surface: string): boolean =>
+	getContrastRatio(surface, '#ffffff') < getContrastRatio(surface, '#000000');
+
+/**
+ * The supplied colour if it is already legible on `surface`, otherwise the same
+ * hue shaded away from that surface until it clears 4.5:1. `null` when the hue
+ * cannot get there inside `maxShadeIntensity`.
+ */
+const deriveLinkForSurface = (
+	brand: string,
+	surface: string,
+): string | null => {
+	if (clearsAA(brand, surface)) return brand;
+
+	const towards = isDarkSurface(surface) ? 'lighter' : 'darker';
+
+	for (
+		let intensity = shadeStep;
+		intensity <= maxShadeIntensity;
+		intensity += shadeStep
+	) {
+		const candidate = shade(brand, towards, intensity);
+		if (clearsAA(candidate, surface)) return candidate;
+	}
+
+	return null;
+};
+
+const changedFrom = (supplied: string, derived: string | null): boolean =>
+	derived !== null && derived.toLowerCase() !== supplied.toLowerCase();
+
+/** Dev-only account of what the supplied link colour actually became. */
+const warnOnLinkDerivation = (
+	supplied: string,
+	onLight: string | null,
+	onDark: string | null,
+	theme: ThemeContext,
+) => {
+	if (onLight === null)
+		warnOnce(
+			`Overdrive Provider: linkColor (${supplied}) cannot reach WCAG AA (4.5:1) against ${theme.lightSurface} without losing the brand. Links and focus rings on light surfaces keep the theme's own link colour.`,
+		);
+	else if (changedFrom(supplied, onLight))
+		warnOnce(
+			`Overdrive Provider: linkColor (${supplied}) does not meet WCAG AA (4.5:1) on light surfaces. Using ${onLight} for links and focus rings there instead.`,
+		);
+
+	if (onDark === null)
+		warnOnce(
+			`Overdrive Provider: linkColor (${supplied}) cannot reach WCAG AA (4.5:1) against ${theme.darkSurface} without losing the brand. Links inside a darkSurface scope keep the theme's own link colour.`,
+		);
+	else if (changedFrom(supplied, onDark))
+		warnOnce(
+			`Overdrive Provider: linkColor (${supplied}) does not meet WCAG AA (4.5:1) on dark surfaces. Using ${onDark} inside a darkSurface scope instead.`,
+		);
+};
+
 export const useColorOverrides = (
 	overrides: Partial<ColorOverrides> | undefined,
 	tokens: ThemeTokens,
@@ -196,9 +287,20 @@ export const useColorOverrides = (
 			});
 		}
 
+		// One inline var serves every surface, so a single link colour cannot be
+		// right on both a white page and a gray-900 header. Derive one for each
+		// and let a `darkSurface` scope opt into the second.
+		const linkOnLight = linkColor
+			? deriveLinkForSurface(linkColor, theme.lightSurface)
+			: null;
+		const linkOnDark = linkColor
+			? deriveLinkForSurface(linkColor, theme.darkSurface)
+			: null;
+
 		if (process.env.NODE_ENV !== 'production') {
 			warnOnLowContrast(primaryBackground, 'primaryBackground', theme);
-			warnOnLowContrast(linkColor, 'linkColor', theme);
+			if (linkColor)
+				warnOnLinkDerivation(linkColor, linkOnLight, linkOnDark, theme);
 		}
 
 		// slightly messy use of ts-expect-error but assignInlineVars only generates css vars to apply to a container
@@ -210,6 +312,12 @@ export const useColorOverrides = (
 					solid: primaryBackground ?? undefined,
 					//@ts-expect-error no undefined
 					onSolid: onBrand ?? undefined,
+				},
+				interactive: {
+					// read by the `darkSurface` scope, which repoints the link
+					// vars to it for its subtree
+					//@ts-expect-error no undefined
+					linkOnDark: linkOnDark ?? undefined,
 				},
 				button: {
 					primary: {
@@ -231,7 +339,7 @@ export const useColorOverrides = (
 				foreground: {
 					// also brands every focus ring, via focusOutline.css.ts
 					//@ts-expect-error no undefined
-					link: linkColor ?? undefined,
+					link: linkOnLight ?? undefined,
 				},
 				intent: {
 					primary: {
@@ -258,7 +366,7 @@ export const useColorOverrides = (
 					primary: primaryBackground ?? undefined,
 					// read by TextLink and by the `colour="link"` sprinkle
 					//@ts-expect-error no undefined
-					link: linkColor ?? undefined,
+					link: linkOnLight ?? undefined,
 				},
 			},
 		});

--- a/lib/components/TextLink/TextLink.css.ts
+++ b/lib/components/TextLink/TextLink.css.ts
@@ -30,6 +30,10 @@ export const body = sprinkles({
 export const muted = style({
 	':hover': {
 		boxShadow: `inset 0 -1.6em 0 0 ${vars.typography.colour.link}`,
-		color: 'white',
+		// The hover floods the whole line with the link colour, so the label is
+		// sitting on it. `white` was fine while the link was always dark; on a
+		// dark surface the derived link is deliberately light, and white on it
+		// is 1.64:1. This token tracks whichever the nearest surface declared.
+		color: vars.color.interactive.onLink,
 	},
 });

--- a/lib/stories/branding.stories.tsx
+++ b/lib/stories/branding.stories.tsx
@@ -15,7 +15,6 @@ import { Stack } from '../components/Stack';
 import { Switch } from '../components/Switch';
 import { Text } from '../components/Text/Text';
 import { TextLink } from '../components/TextLink';
-import { darkSurface } from '../styles/darkSurface.css';
 
 /* -------------------------------------------------------------------------
  * The brands shown side by side
@@ -112,8 +111,10 @@ const SelectionControls = ({ idPrefix }: { idPrefix: string }) => (
 /**
  * Only moves when `linkColor` is passed. The supplied colour is not used
  * verbatim: one inline var serves every surface, so it is shaded per surface
- * until it clears 4.5:1 — darker for the page, lighter inside a `darkSurface`
- * scope. The same token drives every focus ring in the library, so both follow.
+ * until it clears 4.5:1 — darker for a pale card, lighter for a dark fill. The
+ * dark Box below carries no extra class; `backgroundColor` picks the surface's
+ * link colour on its own. The same token drives every focus ring in the
+ * library, so both follow.
  */
 const OptInGroup = () => (
 	<Stack space="2">
@@ -122,15 +123,22 @@ const OptInGroup = () => (
 			<TextLink href="#branding">A link</TextLink>
 			<Text colour="primary">colour=&quot;primary&quot;</Text>
 		</FlexInline>
-		<Box
-			backgroundColor="gray900"
-			borderRadius="1"
-			className={darkSurface}
-			padding="3"
-		>
+		<Box backgroundColor="gray900" borderRadius="1" padding="3">
 			<FlexInline gap="4" justify="center">
 				<TextLink href="#branding">A link on a dark surface</TextLink>
 			</FlexInline>
+			<Box
+				backgroundColor="white"
+				borderRadius="1"
+				marginTop="3"
+				padding="3"
+			>
+				<FlexInline gap="4" justify="center">
+					<TextLink href="#branding">
+						A link on a card inside it
+					</TextLink>
+				</FlexInline>
+			</Box>
 		</Box>
 	</Stack>
 );

--- a/lib/stories/branding.stories.tsx
+++ b/lib/stories/branding.stories.tsx
@@ -15,6 +15,7 @@ import { Stack } from '../components/Stack';
 import { Switch } from '../components/Switch';
 import { Text } from '../components/Text/Text';
 import { TextLink } from '../components/TextLink';
+import { darkSurface } from '../styles/darkSurface.css';
 
 /* -------------------------------------------------------------------------
  * The brands shown side by side
@@ -47,9 +48,9 @@ const BRANDS: Brand[] = [
 		name: 'Amber',
 		overrides: {
 			primaryBackground: '#e5bc01',
-			linkColor: '#8a6f00',
+			linkColor: '#e5bc01',
 		},
-		note: 'A bright brand, with on-brand content derived as dark ink.',
+		note: 'A bright brand: on-brand content derives as dark ink, and the link darkens to stay legible on pale surfaces.',
 	},
 ];
 
@@ -109,10 +110,10 @@ const SelectionControls = ({ idPrefix }: { idPrefix: string }) => (
 );
 
 /**
- * Only moves when `linkColor` is passed. Deliberately not derived from
- * `primaryBackground`: this same token drives every focus ring in the library,
- * and a colour picked as a fill behind white text is often illegible as link
- * text on the page background.
+ * Only moves when `linkColor` is passed. The supplied colour is not used
+ * verbatim: one inline var serves every surface, so it is shaded per surface
+ * until it clears 4.5:1 — darker for the page, lighter inside a `darkSurface`
+ * scope. The same token drives every focus ring in the library, so both follow.
  */
 const OptInGroup = () => (
 	<Stack space="2">
@@ -121,6 +122,16 @@ const OptInGroup = () => (
 			<TextLink href="#branding">A link</TextLink>
 			<Text colour="primary">colour=&quot;primary&quot;</Text>
 		</FlexInline>
+		<Box
+			backgroundColor="gray900"
+			borderRadius="1"
+			className={darkSurface}
+			padding="3"
+		>
+			<FlexInline gap="4" justify="center">
+				<TextLink href="#branding">A link on a dark surface</TextLink>
+			</FlexInline>
+		</Box>
 	</Stack>
 );
 

--- a/lib/styles/darkSurface.css.ts
+++ b/lib/styles/darkSurface.css.ts
@@ -1,29 +1,23 @@
 import { style } from '@vanilla-extract/css';
 
-import { overdriveTokens as tokens } from '../themes/theme.css';
+import { darkSurfaceLinkVars } from './surfaceLinkVars';
 
 /**
  * Opt a dark-filled region into the dark-surface link colour.
  *
- * A tenant brand reaches the app as one inline CSS var on the provider, so a
- * single link colour has to serve both a white page and a gray-900 header —
- * and no value clears 4.5:1 on both. `useColorOverrides` derives two from the
- * same hue; applying this class repoints the link vars for its subtree to the
- * second.
+ * Escape hatch only. Any element painted through the `backgroundColor`
+ * sprinkle already carries the right link vars for its own fill, so a
+ * `<Box backgroundColor="gray900">` needs nothing. Reach for this when the
+ * dark fill comes from somewhere sprinkles cannot see — a raw `background`
+ * declaration, a gradient, or a photographic image.
  *
  * Focus rings follow without any change to `focusOutline`, which reads
  * `colours.foreground.link` and so resolves against whatever the nearest scope
  * declares.
  *
  * @example
- * <Box as="header" backgroundColor="gray900" color="white" className={darkSurface}>
+ * <Box as="header" className={darkSurface} style={{ background: 'url(hero.jpg)' }}>
  */
 export const darkSurface = style({
-	vars: {
-		// eslint-disable-next-line no-restricted-syntax -- RETAINED: these are the vars today's links and `focusOutline` actually read; the scope has to redeclare them until C-final deletes the legacy contract (docs/ds2026-plan/track-c.md §1.9).
-		[tokens.colours.foreground.link]: tokens.color.interactive.linkOnDark,
-		// eslint-disable-next-line no-restricted-syntax -- RETAINED: same as above; read by TextLink and the `colour="link"` sprinkle.
-		[tokens.typography.colour.link]: tokens.color.interactive.linkOnDark,
-		[tokens.color.interactive.link]: tokens.color.interactive.linkOnDark,
-	},
+	vars: darkSurfaceLinkVars,
 });

--- a/lib/styles/darkSurface.css.ts
+++ b/lib/styles/darkSurface.css.ts
@@ -1,0 +1,29 @@
+import { style } from '@vanilla-extract/css';
+
+import { overdriveTokens as tokens } from '../themes/theme.css';
+
+/**
+ * Opt a dark-filled region into the dark-surface link colour.
+ *
+ * A tenant brand reaches the app as one inline CSS var on the provider, so a
+ * single link colour has to serve both a white page and a gray-900 header —
+ * and no value clears 4.5:1 on both. `useColorOverrides` derives two from the
+ * same hue; applying this class repoints the link vars for its subtree to the
+ * second.
+ *
+ * Focus rings follow without any change to `focusOutline`, which reads
+ * `colours.foreground.link` and so resolves against whatever the nearest scope
+ * declares.
+ *
+ * @example
+ * <Box as="header" backgroundColor="gray900" color="white" className={darkSurface}>
+ */
+export const darkSurface = style({
+	vars: {
+		// eslint-disable-next-line no-restricted-syntax -- RETAINED: these are the vars today's links and `focusOutline` actually read; the scope has to redeclare them until C-final deletes the legacy contract (docs/ds2026-plan/track-c.md §1.9).
+		[tokens.colours.foreground.link]: tokens.color.interactive.linkOnDark,
+		// eslint-disable-next-line no-restricted-syntax -- RETAINED: same as above; read by TextLink and the `colour="link"` sprinkle.
+		[tokens.typography.colour.link]: tokens.color.interactive.linkOnDark,
+		[tokens.color.interactive.link]: tokens.color.interactive.linkOnDark,
+	},
+});

--- a/lib/styles/darkSurface.spec.ts
+++ b/lib/styles/darkSurface.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { darkSurface } from './darkSurface.css';
+
+describe('darkSurface', () => {
+	// The scope assigns to theme-contract vars rather than declaring its own.
+	// Vanilla-extract rejects that at compile time if a key is not a real
+	// contract var, and the failure would surface as a consumer build break
+	// rather than a test failure — so importing it at all is the assertion.
+	it('compiles to a class', () => {
+		expect(typeof darkSurface).toBe('string');
+		expect(darkSurface.length).toBeGreaterThan(0);
+	});
+});

--- a/lib/styles/index.ts
+++ b/lib/styles/index.ts
@@ -1,4 +1,5 @@
 export { cssLayerComponent, cssLayerTheme, LAYER_ORDER } from './layers.css';
+export { darkSurface } from './darkSurface.css';
 export { resetVariants, type ResetVariantProps } from './elementReset.css';
 export {
 	elementStyles,

--- a/lib/styles/sprinkles.css.ts
+++ b/lib/styles/sprinkles.css.ts
@@ -7,6 +7,7 @@ import { overdriveTokens as tokens } from '../themes/theme.css';
 import { arrayFromKeys } from '../utils/object';
 
 import { cssLayerStyleprops } from './layers.css';
+import { withSurfaceLinkVars } from './surfaceLinkVars';
 import { gapVar } from './vars.css';
 
 const { space } = tokens;
@@ -206,7 +207,7 @@ const baseProperties = defineProperties({
 		color: semanticColor,
 		/** @deprecated Use color — removed in v5 (DS-2026 major). */
 		colour: mappedColours,
-		backgroundColor: semanticBackgroundColor,
+		backgroundColor: withSurfaceLinkVars(semanticBackgroundColor),
 		/** @deprecated Use backgroundColor — removed in v5 (DS-2026 major). */
 		backgroundColour: mappedBackgroundColours,
 		opacity: [0, '1', '0'],

--- a/lib/styles/surfaceLinkVars.spec.ts
+++ b/lib/styles/surfaceLinkVars.spec.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import { themes } from '../themes';
+import { colourMap } from '../themes/base/colours';
+import { tokens as baseTokens } from '../themes/base/tokens';
+import { getContrastRatio } from '../themes/helpers';
+import { overdriveTokens } from '../themes/theme.css';
+
+import {
+	darkSurfaceLinkVars,
+	darkSurfaceValues,
+	lightSurfaceLinkVars,
+	lightSurfaceValues,
+	withSurfaceLinkVars,
+} from './surfaceLinkVars';
+
+/** Mirrors `isDarkSurface` in useColorOverrides — `getContrastRatio` is min/max. */
+const isDark = (colour: string) =>
+	getContrastRatio(colour, '#ffffff') < getContrastRatio(colour, '#000000');
+
+/**
+ * The base theme's real hex for a `backgroundColor` value name. `color.gamut`
+ * holds var() references, so the ramp comes from the colour map itself; the
+ * semantic surfaces already carry literals.
+ */
+const resolve = (name: string): string => {
+	const gray = Object.fromEntries(
+		Object.entries(colourMap.gray).map(([step, hex]) => [
+			`gray${step}`,
+			hex,
+		]),
+	);
+	const byName: Record<string, string> = {
+		...baseTokens.color.surface,
+		...baseTokens.color.background,
+		...gray,
+		white: colourMap.white,
+		black900: colourMap.gray['900'],
+	};
+	const hex = byName[name];
+	if (!/^#[0-9a-f]{6}$/i.test(hex ?? ''))
+		throw new Error(`${name} did not resolve to a plain hex: ${hex}`);
+	return hex;
+};
+
+const linkVarsOf = (map: Record<string, string>) =>
+	Object.entries(map)
+		.filter(([name]) => name !== overdriveTokens.color.interactive.onLink)
+		.map(([, value]) => value);
+
+describe('surface-aware link vars', () => {
+	it('points every link var a dark surface owns at linkOnDark', () => {
+		const { interactive } = overdriveTokens.color;
+		expect(linkVarsOf(darkSurfaceLinkVars)).toEqual([
+			interactive.linkOnDark,
+			interactive.linkOnDark,
+			interactive.linkOnDark,
+		]);
+	});
+
+	it('points every link var a light surface owns at linkOnLight', () => {
+		const { interactive } = overdriveTokens.color;
+		expect(linkVarsOf(lightSurfaceLinkVars)).toEqual([
+			interactive.linkOnLight,
+			interactive.linkOnLight,
+			interactive.linkOnLight,
+		]);
+	});
+
+	it('covers every var links and focus rings actually read', () => {
+		expect(Object.keys(darkSurfaceLinkVars)).toEqual([
+			overdriveTokens.colours.foreground.link,
+			overdriveTokens.typography.colour.link,
+			overdriveTokens.color.interactive.link,
+			overdriveTokens.color.interactive.onLink,
+		]);
+	});
+
+	// TextLink `muted` floods its line with the link colour and draws the label
+	// on top. The link is shaded away from its surface, so the label has to be
+	// drawn back towards it — the opposite pole, not always white.
+	it('draws on-link content towards the surface it sits on', () => {
+		const { onLink } = overdriveTokens.color.interactive;
+		expect(lightSurfaceLinkVars[onLink]).toBe(
+			overdriveTokens.color.foreground.reverse,
+		);
+		expect(darkSurfaceLinkVars[onLink]).toBe(
+			overdriveTokens.color.foreground.primary,
+		);
+	});
+
+	// The mid greys are why each list is bounded. A link tuned to clear AA on
+	// gray400 goes almost black; one tuned for gray500 goes almost white.
+	it.each(['gray400', 'gray500', 'gray600'])(
+		'leaves %s unclaimed rather than serving a value tuned elsewhere',
+		(name) => {
+			expect(darkSurfaceValues).not.toContain(name);
+			expect(lightSurfaceValues).not.toContain(name);
+		},
+	);
+
+	// The lists are hand-written because a sprinkle value name is static while
+	// its colour is not. These pin them to the values the base theme ships, so
+	// repointing `soft` to a pale grey fails here rather than in production.
+	it.each(darkSurfaceValues)('classifies %s as a dark surface', (name) => {
+		expect(isDark(resolve(name))).toBe(true);
+	});
+
+	it.each(lightSurfaceValues)('classifies %s as a light surface', (name) => {
+		expect(isDark(resolve(name))).toBe(false);
+	});
+
+	it('never puts a value in both lists', () => {
+		const overlap = darkSurfaceValues.filter((name) =>
+			(lightSurfaceValues as readonly string[]).includes(name),
+		);
+		expect(overlap).toEqual([]);
+	});
+
+	describe('what a Box actually gets', () => {
+		const applied = withSurfaceLinkVars({
+			gray900: '#212338',
+			reverse: '#212338',
+			white: '#ffffff',
+			emphasisInactive: '#eef0f2',
+			danger: '#d42b26',
+			transparent: 'transparent',
+		});
+
+		// This is the regression guard: before it existed, the dark-surface
+		// colour was computed correctly and then reachable only through a class
+		// no consumer had applied. `backgroundColor="gray900"` is what all eight
+		// MFE headers already render.
+		it('gives a dark-filled Box the dark-surface link colour, unprompted', () => {
+			expect(applied.gray900.vars).toBe(darkSurfaceLinkVars);
+			expect(applied.reverse.vars).toBe(darkSurfaceLinkVars);
+		});
+
+		it('resets on a pale Box, so nesting inside a dark one recovers', () => {
+			expect(applied.white.vars).toBe(lightSurfaceLinkVars);
+			expect(applied.emphasisInactive.vars).toBe(lightSurfaceLinkVars);
+		});
+
+		it('stays out of the way on a fill it cannot judge', () => {
+			expect(applied.danger).not.toHaveProperty('vars');
+			expect(applied.transparent).not.toHaveProperty('vars');
+		});
+
+		it('leaves the background itself untouched', () => {
+			expect(applied.gray900.backgroundColor).toBe('#212338');
+			expect(applied.danger.backgroundColor).toBe('#d42b26');
+		});
+	});
+
+	// A surface repoints links at `linkOnLight`/`linkOnDark` in EVERY theme,
+	// branded or not. A theme that moves its link colour but leaves the pair
+	// inherited from base would paint base green links inside a dark Box next
+	// to its own colour everywhere else — flat_red and neutral both move it.
+	describe.each(themes)(
+		'$name keeps its own link colour on every surface',
+		({ tokens }) => {
+			it('matches linkOnLight to the theme link colour', () => {
+				expect(tokens.color.interactive.linkOnLight).toBe(
+					tokens.colours.foreground.link,
+				);
+			});
+
+			it('matches linkOnDark to the theme link colour', () => {
+				expect(tokens.color.interactive.linkOnDark).toBe(
+					tokens.colours.foreground.link,
+				);
+			});
+		},
+	);
+});

--- a/lib/styles/surfaceLinkVars.ts
+++ b/lib/styles/surfaceLinkVars.ts
@@ -1,0 +1,92 @@
+import { mapValues } from 'es-toolkit';
+
+import { overdriveTokens as tokens } from '../themes/theme.css';
+
+/**
+ * A tenant brand reaches the app as one inline CSS var on the provider, so a
+ * single link colour has to serve both a white page and a gray-900 header —
+ * and no value clears 4.5:1 on both. `useColorOverrides` derives two from the
+ * same hue and writes them to `linkOnLight` / `linkOnDark`; a painted surface
+ * then points the vars links actually read at whichever of the two suits it.
+ *
+ * Both directions are declared, not just the dark one: a pale card nested
+ * inside a dark header has to reset, or it inherits the header's link colour.
+ */
+const linkVarsPointingAt = (link: string, onLink: string) => ({
+	// eslint-disable-next-line no-restricted-syntax -- RETAINED: these are the vars today's links and `focusOutline` actually read; a surface has to redeclare them until C-final deletes the legacy contract (docs/ds2026-plan/track-c.md §1.9).
+	[tokens.colours.foreground.link]: link,
+	// eslint-disable-next-line no-restricted-syntax -- RETAINED: same as above; read by TextLink and the `colour="link"` sprinkle.
+	[tokens.typography.colour.link]: link,
+	[tokens.color.interactive.link]: link,
+	// Anything drawn ON a link-coloured fill — TextLink `muted`'s hover, which
+	// floods the line with the link colour. The link is shaded away from its
+	// surface, so on a pale surface it is dark and wants pale content, and on a
+	// dark surface it is light and wants dark content.
+	[tokens.color.interactive.onLink]: onLink,
+});
+
+export const darkSurfaceLinkVars = linkVarsPointingAt(
+	tokens.color.interactive.linkOnDark,
+	tokens.color.foreground.primary,
+);
+
+export const lightSurfaceLinkVars = linkVarsPointingAt(
+	tokens.color.interactive.linkOnLight,
+	tokens.color.foreground.reverse,
+);
+
+/**
+ * The surfaces each derived link colour is guaranteed on.
+ *
+ * Membership is by luminance against the black/white poles — the same test
+ * `deriveLinkForSurface` uses to choose a shading direction — and each list is
+ * bounded by what one colour can actually serve. `useColorOverrides` tunes
+ * `linkOnLight` against the *darkest* member of the light list and `linkOnDark`
+ * against the *lightest* member of the dark list, so every surface named here
+ * clears 4.5:1, not just the one the derivation happened to be pointed at.
+ *
+ * The mid greys (gray400–gray600) are in neither list on purpose. A link tuned
+ * to clear AA on gray400 has to go almost black, and one tuned for gray500 has
+ * to go almost white — either abandons the brand. They declare nothing and
+ * inherit, as do tinted fills (danger, info, a tenant brand), where no derived
+ * value is tuned for the hue and claiming one would be a guess.
+ */
+export const lightSurfaceValues = [
+	'white',
+	'gray100',
+	'gray200',
+	'gray300',
+	'page', // color.surface.page — white
+	'default', // color.background.default — white
+	'inactive', // color.background.inactive — gray300
+	'emphasisInactive', // color.background.emphasisInactive — gray200
+	'emphasisLight', // color.background.emphasisLight — gray100
+] as const;
+
+export const darkSurfaceValues = [
+	'gray700',
+	'gray800',
+	'gray900',
+	'black900', // deprecated alias of gray900
+	'hard', // color.surface.hard — gray900
+	'soft', // color.surface.soft — gray700
+	'reverse', // color.background.reverse — gray900
+] as const;
+
+const dark = new Set<string>(darkSurfaceValues);
+const light = new Set<string>(lightSurfaceValues);
+
+/**
+ * A link's legibility is decided by the nearest painted ancestor, not by the
+ * page. Every background value we can classify therefore carries the link vars
+ * suited to its own fill, so `<Box backgroundColor="gray900">` gets the
+ * dark-surface link colour with no opt-in and no class to remember.
+ */
+export const withSurfaceLinkVars = (values: Record<string, string>) =>
+	mapValues(values, (backgroundColor, name) => {
+		if (dark.has(name))
+			return { backgroundColor, vars: darkSurfaceLinkVars };
+		if (light.has(name))
+			return { backgroundColor, vars: lightSurfaceLinkVars };
+		return { backgroundColor };
+	});

--- a/lib/themes/base/tokens.ts
+++ b/lib/themes/base/tokens.ts
@@ -150,6 +150,8 @@ export const tokens = {
 			surfaceDisabled: colourMap.gray['400'],
 			contentDisabled: colourMap.gray['600'],
 			link: colourMap.green['600'],
+			onLink: colourMap.white,
+			linkOnLight: colourMap.green['600'],
 			linkOnDark: colourMap.green['600'],
 			linkVisited: colourMap.green['700'],
 			overlayBg: colourMap.gray['300'],

--- a/lib/themes/base/tokens.ts
+++ b/lib/themes/base/tokens.ts
@@ -150,6 +150,7 @@ export const tokens = {
 			surfaceDisabled: colourMap.gray['400'],
 			contentDisabled: colourMap.gray['600'],
 			link: colourMap.green['600'],
+			linkOnDark: colourMap.green['600'],
 			linkVisited: colourMap.green['700'],
 			overlayBg: colourMap.gray['300'],
 			overlayContainer: colourMap.white,

--- a/lib/themes/flat_red/tokens.ts
+++ b/lib/themes/flat_red/tokens.ts
@@ -66,14 +66,19 @@ const colours = {
 const flatElevation = '0 0 0 0 rgba(0, 0, 0, 0.0)';
 
 export const tokens = deepmerge(baseTokens, {
-	// The only DS-2026 `color` token this theme overrides — see the same note in
-	// `neutral`. This theme redefines its own green ramp, so `green.600` here is
-	// `#00c400` rather than base's `#01c68c`; without this, a
+	// The only DS-2026 `color` tokens this theme overrides — see the same note
+	// in `neutral`. This theme redefines its own green ramp, so `green.600`
+	// here is `#00c400` rather than base's `#01c68c`; without these, a
 	// `color.focus.ring` consumer would ring base green beside every other
-	// component's flat-red green.
+	// component's flat-red green, and a dark-surface Box would swap this
+	// theme's link green for base green via the inherited `linkOnDark`.
 	color: {
 		focus: {
 			ring: colours.green['600'],
+		},
+		interactive: {
+			linkOnLight: colours.green['600'],
+			linkOnDark: colours.green['600'],
 		},
 	},
 	colours: {

--- a/lib/themes/helpers.spec.ts
+++ b/lib/themes/helpers.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	canMeasureContrast,
+	getContrastRatio,
+	getRGBValues,
+	passesAccessibilityContrast,
+} from './helpers';
+
+// #ffc001 in five notations. Before colord, only the first two parsed; the rest
+// returned null and measured as black, so every contrast check about them was
+// answered about a colour nobody supplied.
+const amber = { r: 255, g: 192, b: 1 };
+
+describe('getRGBValues', () => {
+	it.each([
+		['6-digit hex', '#ffc001', amber],
+		['3-digit hex', '#fc0', { r: 255, g: 204, b: 0 }],
+		['rgb()', 'rgb(255, 192, 1)', amber],
+		['hsl()', 'hsl(45, 100%, 50%)', { r: 255, g: 191, b: 0 }],
+		['a CSS named colour', 'gold', { r: 255, g: 215, b: 0 }],
+	])('reads %s', (_label, input, expected) => {
+		expect(getRGBValues(input)).toEqual(expected);
+	});
+
+	it('reads 8-digit hex, dropping the alpha it cannot composite', () => {
+		expect(getRGBValues('#ffc001aa')).toEqual(amber);
+	});
+
+	it.each(['var(--brand)', 'currentColor', 'notacolour', ''])(
+		'returns null for %s rather than measuring it as black',
+		(input) => {
+			expect(getRGBValues(input)).toBeNull();
+		},
+	);
+});
+
+describe('canMeasureContrast', () => {
+	it.each([
+		'#ffc001',
+		'rgb(255,192,1)',
+		'hsl(45,100%,50%)',
+		'gold',
+		'#ffc001aa',
+	])('accepts %s', (input) => {
+		expect(canMeasureContrast(input)).toBe(true);
+	});
+
+	it.each(['var(--brand)', 'currentColor', 'notacolour'])(
+		'rejects %s',
+		(input) => {
+			expect(canMeasureContrast(input)).toBe(false);
+		},
+	);
+});
+
+describe('contrast on notations that used to measure as black', () => {
+	// The regression this guards: an unparsed colour has luminance 0, so it
+	// looks like black — maximal contrast on white, and every AA check passes.
+	it.each(['hsl(45, 100%, 50%)', 'gold', '#ffc001aa'])(
+		'%s fails AA on white, as its hex twin does',
+		(input) => {
+			expect(
+				passesAccessibilityContrast({
+					colour1: input,
+					colour2: '#ffffff',
+					level: 'AA',
+					textSize: 'SMALL',
+				}),
+			).toBe(false);
+		},
+	);
+
+	it('agrees across notations of the same colour', () => {
+		const asHex = getContrastRatio('#ffc001', '#ffffff');
+		expect(getContrastRatio('rgb(255, 192, 1)', '#ffffff')).toBeCloseTo(
+			asHex,
+			5,
+		);
+	});
+});

--- a/lib/themes/helpers.ts
+++ b/lib/themes/helpers.ts
@@ -1,5 +1,10 @@
 import type { CSSVarFunction } from '@vanilla-extract/private';
-import { colord } from 'colord';
+import { colord, extend } from 'colord';
+import namesPlugin from 'colord/plugins/names';
+
+// CSS named colours ('gold', 'navy') are a form tenants do supply. Without this
+// they parse to nothing, and an unparsed colour used to measure as black.
+extend([namesPlugin]);
 
 /**
  * Utility type that extracts the raw token type from a vanilla-extract theme contract.
@@ -64,33 +69,47 @@ export const shadedColour = ({
 		.toHex();
 };
 
+/**
+ * Shade towards black or white, said plainly.
+ *
+ * `shadedColour` expresses this as `direction` crossed with `isDarkTheme`, so a
+ * caller that just wants "darker" has to pass a theme flag it does not care
+ * about and rely on the mapping never changing. These say what they do.
+ */
+export const darkenColour = (colour: string, intensity: number): string =>
+	colord(colour).darken(intensity).toHex();
+
+export const lightenColour = (colour: string, intensity: number): string =>
+	colord(colour).lighten(intensity).toHex();
+
 type RGBNumbers = { r: number; g: number; b: number } | null;
 
-export const hexToRGB = (hex: string): RGBNumbers => {
-	const shorthandRegex = /^#?([\da-f])([\da-f])([\da-f])$/i;
-	hex = hex.replace(shorthandRegex, (_, r, g, b) => r + r + g + g + b + b);
-
-	const result = /^#?([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
-	return result
-		? {
-				r: Number.parseInt(result[1], 16),
-				g: Number.parseInt(result[2], 16),
-				b: Number.parseInt(result[3], 16),
-			}
-		: null;
+/**
+ * Every CSS colour form, or `null` when the string is not a colour at all —
+ * `var(--brand)`, `currentColor`, a typo.
+ *
+ * This used to be two hand-rolled parsers that understood 3- and 6-digit hex
+ * and `rgb()` only. Anything else — `hsl()`, a named colour, 8-digit hex —
+ * returned `null`, which `getColourLuminance` reads as luminance 0, i.e. black.
+ * Every contrast decision downstream was then made about a colour nobody
+ * supplied, and made silently.
+ */
+export const getRGBValues = (colour: string): RGBNumbers => {
+	const parsed = colord(colour);
+	if (!parsed.isValid()) return null;
+	// Alpha is dropped rather than composited: contrast against a translucent
+	// colour depends on what is behind it, which is not knowable here.
+	const { r, g, b } = parsed.toRgb();
+	return { r, g, b };
 };
 
-export const rgbStrToRGB = (rgb: string): RGBNumbers => {
-	const components = rgb.replaceAll(/[^\d,]/g, '').split(',');
-	return {
-		r: Number.parseInt(components[0]),
-		g: Number.parseInt(components[1]),
-		b: Number.parseInt(components[2]),
-	};
-};
-
-export const getRGBValues = (hexOrRGB: string): RGBNumbers =>
-	hexOrRGB.startsWith('rgb') ? rgbStrToRGB(hexOrRGB) : hexToRGB(hexOrRGB);
+/**
+ * Whether a contrast decision about this colour would be measured or guessed.
+ * Callers that shade or pick a colour by luminance should check first, rather
+ * than accept the black that an unparseable string silently measures as.
+ */
+export const canMeasureContrast = (colour: string): boolean =>
+	colord(colour).isValid();
 
 export const getColourLuminance = (rgb: RGBNumbers) => {
 	if (!rgb) return 0;

--- a/lib/themes/neutral/tokens.ts
+++ b/lib/themes/neutral/tokens.ts
@@ -80,14 +80,21 @@ export const tokens = deepmerge(baseTokens, {
 	// `space` intentionally omitted: inherited from baseTokens via deepmerge
 	// so the DS-2026 spacing scale lives in one place and can't drift.
 	//
-	// The only DS-2026 `color` token this theme overrides. Everything else in
+	// The only DS-2026 `color` tokens this theme overrides. Everything else in
 	// that contract is inherited from base. The ring has to be overridden
 	// because the legacy `focusOutlineStyle` every other component uses reads
 	// `colours.foreground.link`, which this theme moves to blue — leaving a
-	// `color.focus.ring` consumer ringing base green next to a blue one.
+	// `color.focus.ring` consumer ringing base green next to a blue one. The
+	// per-surface link pair has to follow for the same reason: a dark-surface
+	// Box repoints links at `linkOnDark`, which would otherwise inherit base
+	// green beside this theme's blue links.
 	color: {
 		focus: {
 			ring: colours.blue['500'],
+		},
+		interactive: {
+			linkOnLight: colours.blue['500'],
+			linkOnDark: colours.blue['500'],
 		},
 	},
 	colours: {

--- a/lib/themes/theme.css.ts
+++ b/lib/themes/theme.css.ts
@@ -147,6 +147,8 @@ const THEME_CONTRACT = {
 			surfaceDisabled: 'color-interactive-surface-disabled',
 			contentDisabled: 'color-interactive-content-disabled',
 			link: 'color-interactive-link',
+			onLink: 'color-interactive-on-link',
+			linkOnLight: 'color-interactive-link-on-light',
 			linkOnDark: 'color-interactive-link-on-dark',
 			linkVisited: 'color-interactive-link-visited',
 			overlayBg: 'color-interactive-overlay-bg',

--- a/lib/themes/theme.css.ts
+++ b/lib/themes/theme.css.ts
@@ -147,6 +147,7 @@ const THEME_CONTRACT = {
 			surfaceDisabled: 'color-interactive-surface-disabled',
 			contentDisabled: 'color-interactive-content-disabled',
 			link: 'color-interactive-link',
+			linkOnDark: 'color-interactive-link-on-dark',
 			linkVisited: 'color-interactive-link-visited',
 			overlayBg: 'color-interactive-overlay-bg',
 			overlayContainer: 'color-interactive-overlay-container',


### PR DESCRIPTION
## Summary

`colorOverrides.linkColor` was written into the theme verbatim. Because it reaches the app as a **single inline CSS var on the provider `<div>`**, one value had to serve every surface in the app — and no colour clears 4.5:1 on both a white page and a `gray900` header.

FPAY-202 aliased that key to the brand fill (`linkColor: branding.primaryBackground`) — a colour chosen to sit *behind* white text. For a light tenant brand that landed as low as **1.6:1** as link text. `focusOutline` reads the same token, so it also took **every focus ring in the library** below WCAG 1.4.11 (3:1 non-text), keyboard navigation included.

Overdrive already measured this and warned in dev (`useColorOverrides.ts`), then wrote the failing value anyway.

### The approach

`useColorOverrides` now derives **two** values from the supplied hue, shading each away from its surface until it clears 4.5:1:

```
brand #FFC001  ├─ light surfaces →  #8b6800   (white 5.15, gray200 4.51)   darkened 23%
               └─ dark surfaces  →  #ffc001   (navy 9.39)                  unchanged

brand #0e893c  ├─ light surfaces →  #0d7b36   (white 5.38, gray200 4.71)   darkened 3%
               └─ dark surfaces  →  #10a046   (navy 4.51)                  lightened 5%
```

Hue is preserved (45°→45°, 142°→142/143°), so the correction is proportional — a well-chosen brand barely moves, a dangerous one moves a lot. A colour already legible on a surface is passed through untouched.

Two details worth flagging for review:

- **The light side is tuned against `background.emphasisInactive` (gray200), not the page background.** Tuning against white alone leaves a link that scrapes 4.50 on white and then fails on a grey card — and grey cards are used across the MFEs.
- **If a hue cannot reach AA without ceasing to be the brand** (capped at 60% shade), that side keeps the theme's own link colour and warns. The two sides resolve independently, so a pale pastel can fall back on light surfaces while staying branded on dark ones.

### Architecture

- **New token `color.interactive.linkOnDark`** on the **semantic** contract, not legacy `colours.*` — that contract is deleted at C-final (`docs/ds2026-plan/track-c.md`), and `color.interactive.link` is already TextLink's and Anchor's repoint target. Base value is seeded to the current link colour, so unbranded consumers are unchanged.
- **New `darkSurface` class** (`@autoguru/overdrive/styles`) opts a dark-filled region into that value for its subtree. Vanilla Extract `style({ vars })` reassigning contract vars — no new dependency, no hardcoded colour.
- **`focusOutline.css.ts` is untouched.** C-P9 deliberately froze it until the major and its Chromatic gate covers 14+ consumers. Because it reads `colours.foreground.link`, redefining that var inside the scope makes focus rings follow for free.

```tsx
<Box as="header" backgroundColor="gray900" color="white" className={darkSurface}>
```

### Testing

- 6 new tests in `useColorOverrides.spec.ts` — darkens a light brand and clears AA on the palest card; leaves it alone for dark surfaces; lightens a dark brand for dark surfaces; leaves it alone on pale ones; hue preserved; unreachable hue falls back on that side only and warns.
- `darkSurface.spec.ts` guards VE compilation — an invalid contract var key fails as a consumer build break, not a test failure, so importing it is the assertion.
- `branding.stories.tsx` gains a navy panel, and Amber now passes the **raw** brand so the derivation is visible rather than pre-baked.

**Full suite: 934 tests / 94 files pass. `yarn lint` clean. `yarn build` compiles.** No snapshot churn — the signal that unbranded output is unchanged.

⚠️ **Chromatic gate:** every story except the branding ones must show **zero diff**. Base `linkOnDark` is seeded to today's `green600`, so unbranded output should be byte-identical. The branding stories *will* diff, intentionally.

### Follow-ups (not in this PR)

1. **Branding never reaches `color.interactive.link`.** `useColorOverrides` writes only the legacy link vars. The moment W3c-P2 repoints TextLink to the semantic token, branded links silently stop being branded on light surfaces. Worth closing before that package lands.
2. **MFE consumption is blocked on this release.** The MFE resolves Overdrive from the registry (4.64.0). Once published it is one line per file across **8** dark headers — `fla`/`fls`/`fmo` booking × desktop/tablet — adding `className={darkSurface}` beside the existing `color="white"`.
3. **`successText` links on those headers are already broken**, independent of branding: `#00574c` on navy is **1.81:1**. Hardcoded text colour with a themed focus ring.
4. **Base link on white.** Legacy `colours.foreground.link` green600 is 2.22:1, and `contrastGuide.ts` already marks `green-600 on white` as `icon-only`. Needs design input.

## Breaking Changes

None. The new token is additive and seeded to the current value; `darkSurface` is opt-in. Branded consumers will see their link and focus-ring colour shift — that is the fix.
