### PR TITLE
feat(Popover): hold the popover mounted through its exit animation (AG-21418)

### DIFF
--- a/.changeset/popover-exit-animation.md
+++ b/.changeset/popover-exit-animation.md
@@ -1,0 +1,24 @@
+---
+'@autoguru/overdrive': minor
+---
+
+`PopoverTrigger` now holds the popover mounted while its exit animation plays.
+
+Closing used to drop the whole subtree in one commit, so a consumer had no way
+to animate the popover on its way out. The popover root now picks up a
+`data-exiting` attribute when a close is requested, and stays mounted until the
+animations running under that root have finished. Endless animations such as a
+loading spinner are ignored, and a 1000ms cap covers an animation that stalls or
+never settles, so nothing can strand the popover on screen.
+
+`PopoverTrigger` takes no new props and there is nothing to opt into. The
+attribute is set before the animations are read, so CSS keyed off
+`[data-exiting]` is already running by the time it gets measured, and a popover
+with nothing to play unmounts in the same commit it always has, with no extra
+render. The tests count renders across the close to prove that rather than take
+it on faith. `Popover` itself, which is exported for advanced use, gains two
+optional props, `isExiting` and `rootRef`, that `PopoverTrigger` uses to drive
+this.
+
+`DatePicker` and `DateField` are the two components in the library using
+`PopoverTrigger`. Neither animates, so both behave exactly as before.

--- a/lib/components/DatePicker/DatePicker.spec.tsx
+++ b/lib/components/DatePicker/DatePicker.spec.tsx
@@ -1,13 +1,25 @@
 import { composeStories } from '@storybook/react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import React from 'react';
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import {
+	describe,
+	it,
+	expect,
+	beforeAll,
+	afterAll,
+	afterEach,
+	vi,
+} from 'vitest';
+
+import { deferredAnimation, stubGetAnimations } from '../../test/animations';
 
 import { DatePicker } from './DatePicker';
 import * as stories from './DatePicker.stories';
 
 const { Standard, LargeWithLabel, NativePicker } = composeStories(stories);
+
+let exitAnimations: Animation[] = [];
 
 // Mock window.matchMedia for useMedia hook
 const mockMatchMedia = (query: string) => ({
@@ -38,6 +50,11 @@ describe('DatePicker', () => {
 			writable: true,
 			value: mockMatchMedia,
 		});
+		stubGetAnimations(() => exitAnimations);
+	});
+
+	afterEach(() => {
+		exitAnimations = [];
 	});
 
 	afterAll(() => {
@@ -570,6 +587,42 @@ describe('DatePicker', () => {
 			expect(
 				screen.getByLabelText('Custom Previous'),
 			).toBeInTheDocument();
+		});
+	});
+
+	it('holds the calendar open through an exit animation after selection', async () => {
+		const user = userEvent.setup();
+		const { animation, finish } = deferredAnimation();
+		exitAnimations = [animation];
+
+		render(<DatePicker name="animated-picker" onChange={vi.fn()} />);
+
+		const { dialog } = await openCalendar(user);
+		expect(dialog).toBeInTheDocument();
+
+		const dateButton = screen
+			.getAllByRole('button')
+			.find(
+				(button) =>
+					button.textContent &&
+					/^\d{1,2}$/.test(button.textContent.trim()) &&
+					!button.hasAttribute('aria-disabled') &&
+					!button.hasAttribute('aria-pressed'),
+			);
+
+		if (!dateButton) throw new Error('No selectable date button found');
+
+		await user.click(dateButton);
+
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+		expect(document.querySelector('[data-exiting]')).not.toBeNull();
+
+		await act(async () => {
+			finish();
+		});
+
+		await waitFor(() => {
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 		});
 	});
 });

--- a/lib/components/DatePicker/DatePicker.spec.tsx
+++ b/lib/components/DatePicker/DatePicker.spec.tsx
@@ -12,7 +12,11 @@ import {
 	vi,
 } from 'vitest';
 
-import { deferredAnimation, stubGetAnimations } from '../../test/animations';
+import {
+	deferredAnimation,
+	restoreGetAnimations,
+	stubGetAnimations,
+} from '../../test/animations';
 
 import { DatePicker } from './DatePicker';
 import * as stories from './DatePicker.stories';
@@ -57,9 +61,7 @@ describe('DatePicker', () => {
 		exitAnimations = [];
 	});
 
-	afterAll(() => {
-		// Cleanup if needed
-	});
+	afterAll(restoreGetAnimations);
 
 	it('renders with default props and expected structure', () => {
 		render(<Standard />);

--- a/lib/components/Popover/Popover.spec.tsx
+++ b/lib/components/Popover/Popover.spec.tsx
@@ -15,6 +15,7 @@ import {
 import {
 	deferredAnimation,
 	endlessAnimation,
+	restoreGetAnimations,
 	stalledAnimation,
 	stubGetAnimations,
 } from '../../test/animations';
@@ -64,9 +65,7 @@ describe('Popover', () => {
 		});
 	});
 
-	afterAll(() => {
-		// Cleanup if needed
-	});
+	afterAll(restoreGetAnimations);
 	it('renders with default props and expected structure', () => {
 		render(<Standard />);
 

--- a/lib/components/Popover/Popover.spec.tsx
+++ b/lib/components/Popover/Popover.spec.tsx
@@ -1,13 +1,33 @@
 import { composeStories } from '@storybook/react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import React from 'react';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+	describe,
+	it,
+	expect,
+	beforeAll,
+	afterAll,
+	afterEach,
+	vi,
+} from 'vitest';
+
+import {
+	deferredAnimation,
+	endlessAnimation,
+	stalledAnimation,
+	stubGetAnimations,
+} from '../../test/animations';
 
 import * as stories from './Popover.stories';
 import { PopoverTrigger } from './PopoverTrigger';
+import { EXIT_TIMEOUT_MS } from './useExitAnimation';
 
 const { Standard, Interaction, KeyboardTest } = composeStories(stories);
+
+const openPopover = /open popover/i;
+
+let exitAnimations: Animation[] = [];
 
 // Mock window.matchMedia for useMedia hook
 const mockMatchMedia = (query: string) => ({
@@ -21,8 +41,23 @@ const mockMatchMedia = (query: string) => ({
 	dispatchEvent: () => {},
 });
 
+const RenderCounter = ({ onRender }: { onRender: () => void }) => {
+	onRender();
+	return <p>Counted content</p>;
+};
+
 describe('Popover', () => {
 	beforeAll(() => {
+		Object.defineProperty(globalThis, 'matchMedia', {
+			writable: true,
+			value: mockMatchMedia,
+		});
+		stubGetAnimations(() => exitAnimations);
+	});
+
+	afterEach(() => {
+		exitAnimations = [];
+		stubGetAnimations(() => exitAnimations);
 		Object.defineProperty(globalThis, 'matchMedia', {
 			writable: true,
 			value: mockMatchMedia,
@@ -50,7 +85,7 @@ describe('Popover', () => {
 		render(<Standard />);
 
 		const triggerButton = screen.getByRole('button', {
-			name: /open popover/i,
+			name: openPopover,
 		});
 
 		// Click to open popover
@@ -188,5 +223,217 @@ describe('Popover', () => {
 		// Escape should close and return focus to trigger
 		await user.keyboard('{Escape}');
 		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+	});
+
+	describe('exit animations', () => {
+		it('unmounts in the same commit when nothing animates on exit', async () => {
+			const user = userEvent.setup();
+			const onRender = vi.fn();
+
+			render(
+				<PopoverTrigger content={<RenderCounter onRender={onRender} />}>
+					Same commit trigger
+				</PopoverTrigger>,
+			);
+
+			const trigger = screen.getByRole('button');
+			await user.click(trigger);
+			expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+			const rendersWhileOpen = onRender.mock.calls.length;
+
+			await user.click(trigger);
+
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+			expect(document.querySelector('[data-exiting]')).toBeNull();
+			expect(onRender).toHaveBeenCalledTimes(rendersWhileOpen);
+		});
+
+		it('holds the popover mounted until its exit animation finishes', async () => {
+			const user = userEvent.setup();
+			const { animation, finish } = deferredAnimation();
+			exitAnimations = [animation];
+
+			render(<Standard />);
+
+			const trigger = screen.getByRole('button', {
+				name: openPopover,
+			});
+			await user.click(trigger);
+			await user.click(trigger);
+
+			expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+			await act(async () => {
+				finish();
+			});
+
+			await waitFor(() => {
+				expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+			});
+		});
+
+		it('marks the popover root with data-exiting only while it is exiting', async () => {
+			const user = userEvent.setup();
+			const { animation, finish } = deferredAnimation();
+			exitAnimations = [animation];
+
+			render(<Standard />);
+
+			const trigger = screen.getByRole('button', {
+				name: openPopover,
+			});
+			await user.click(trigger);
+
+			expect(document.querySelector('[data-exiting]')).toBeNull();
+
+			await user.click(trigger);
+
+			const exitingRoot = document.querySelector('[data-exiting]');
+			expect(exitingRoot).not.toBeNull();
+			expect(exitingRoot).toContainElement(
+				screen.getByText('Popover Content'),
+			);
+
+			await act(async () => {
+				finish();
+			});
+
+			await waitFor(() => {
+				expect(document.querySelector('[data-exiting]')).toBeNull();
+			});
+		});
+
+		it('unmounts once the safety cap elapses when an animation never finishes', async () => {
+			const user = userEvent.setup();
+			exitAnimations = [stalledAnimation()];
+
+			render(<Standard />);
+
+			const trigger = screen.getByRole('button', {
+				name: openPopover,
+			});
+			await user.click(trigger);
+			await user.click(trigger);
+
+			expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+			await waitFor(
+				() => {
+					expect(
+						screen.queryByRole('dialog'),
+					).not.toBeInTheDocument();
+				},
+				{ timeout: EXIT_TIMEOUT_MS + 2000 },
+			);
+		});
+
+		it('ignores endless animations such as a loading spinner', async () => {
+			const user = userEvent.setup();
+			const onRender = vi.fn();
+			exitAnimations = [endlessAnimation()];
+
+			render(
+				<PopoverTrigger content={<RenderCounter onRender={onRender} />}>
+					Endless animation trigger
+				</PopoverTrigger>,
+			);
+
+			const trigger = screen.getByRole('button');
+			await user.click(trigger);
+
+			const rendersWhileOpen = onRender.mock.calls.length;
+
+			await user.click(trigger);
+
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+			expect(onRender).toHaveBeenCalledTimes(rendersWhileOpen);
+		});
+
+		it('closes immediately where the environment has no getAnimations', async () => {
+			const user = userEvent.setup();
+			exitAnimations = [deferredAnimation().animation];
+			// @ts-expect-error deleting an optional DOM API to model older environments
+			delete Element.prototype.getAnimations;
+
+			render(<Standard />);
+
+			const trigger = screen.getByRole('button', {
+				name: openPopover,
+			});
+			await user.click(trigger);
+			await user.click(trigger);
+
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		});
+
+		it('marks the positioned popover root rather than the fullscreen one', async () => {
+			Object.defineProperty(globalThis, 'matchMedia', {
+				writable: true,
+				value: (query: string) => ({
+					...mockMatchMedia(query),
+					matches: true,
+				}),
+			});
+
+			const user = userEvent.setup();
+			const { animation, finish } = deferredAnimation();
+			exitAnimations = [animation];
+
+			render(<Standard />);
+
+			const trigger = screen.getByRole('button', {
+				name: openPopover,
+			});
+			await user.click(trigger);
+			await user.click(trigger);
+
+			const exitingRoot = document.querySelector('[data-exiting]');
+			expect(exitingRoot).toContainElement(screen.getByRole('dialog'));
+
+			await act(async () => {
+				finish();
+			});
+
+			await waitFor(() => {
+				expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+			});
+		});
+
+		it('leaves focus where a close without an animation leaves it', async () => {
+			const user = userEvent.setup();
+
+			const openThenEscape = async () => {
+				const trigger = screen.getByRole('button', {
+					name: /focus test/i,
+				});
+				trigger.focus();
+				await user.keyboard(' ');
+				expect(screen.getByRole('dialog')).toBeInTheDocument();
+				await user.keyboard('{Escape}');
+			};
+
+			const plain = render(<KeyboardTest />);
+			await openThenEscape();
+			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+			const focusAfterPlainExit = document.activeElement;
+			plain.unmount();
+
+			const { animation, finish } = deferredAnimation();
+			exitAnimations = [animation];
+
+			render(<KeyboardTest />);
+			await openThenEscape();
+			expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+			await act(async () => {
+				finish();
+			});
+
+			await waitFor(() => {
+				expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+			});
+			expect(document.activeElement).toBe(focusAfterPlainExit);
+		});
 	});
 });

--- a/lib/components/Popover/Popover.stories.css.ts
+++ b/lib/components/Popover/Popover.stories.css.ts
@@ -1,0 +1,33 @@
+import { keyframes, style } from '@vanilla-extract/css';
+
+import { overdriveTokens as vars } from '../../themes/theme.css';
+
+const reduceMotion = {
+	'@media': {
+		'screen and (prefers-reduced-motion)': {
+			animation: 'none',
+		},
+	},
+};
+
+const enter = keyframes({
+	from: { opacity: 0, transform: 'scale(0.96) translateY(-4px)' },
+	to: { opacity: 1, transform: 'none' },
+});
+
+const exit = keyframes({
+	from: { opacity: 1, transform: 'none' },
+	to: { opacity: 0, transform: 'scale(0.96) translateY(-4px)' },
+});
+
+export const animatedContent = style({
+	animation: `${enter} 160ms ${vars.animation.easing.decelerate}`,
+	...reduceMotion,
+	selectors: {
+		'[data-exiting] &': {
+			animation: `${exit} 400ms ${vars.animation.easing.accelerate} forwards`,
+			pointerEvents: 'none',
+			...reduceMotion,
+		},
+	},
+});

--- a/lib/components/Popover/Popover.stories.tsx
+++ b/lib/components/Popover/Popover.stories.tsx
@@ -10,6 +10,7 @@ import { Stack } from '../Stack/Stack';
 import { Text } from '../Text/Text';
 import { TextInput } from '../TextInput/TextInput';
 
+import { animatedContent } from './Popover.stories.css';
 import { PopoverTrigger } from './PopoverTrigger';
 
 const buttonStyle = button({ intent: 'secondary' });
@@ -57,6 +58,25 @@ export const TopPlacement: Story = {
 		content: (
 			<Box padding="4">
 				<Text>This popover opens above the trigger button.</Text>
+			</Box>
+		),
+	},
+};
+
+export const ExitAnimation: Story = {
+	args: {
+		...Standard.args,
+		children: <button className={buttonStyle}>Animated Popover</button>,
+		content: (
+			<Box className={animatedContent} padding="4">
+				<Stack space="3">
+					<Heading size="4">Animated Popover</Heading>
+					<Text>
+						The content animates in on open, and out on close. The
+						popover root carries `data-exiting` while the exit
+						plays, and unmounts once it finishes.
+					</Text>
+				</Stack>
 			</Box>
 		),
 	},

--- a/lib/components/Popover/Popover.tsx
+++ b/lib/components/Popover/Popover.tsx
@@ -12,6 +12,8 @@ import { type OverlayTriggerState } from 'react-stately';
 
 import { useMedia } from '../../hooks/useMedia/useMedia';
 import { sprinkles } from '../../styles/sprinkles.css';
+import { mergeRefs } from '../../utils';
+import { dataAttrs } from '../../utils/dataAttrs';
 import { Button } from '../Button/Button';
 import { Icon } from '../Icon/Icon';
 
@@ -43,6 +45,15 @@ export interface PopoverProps extends Omit<AriaPopoverProps, 'popoverRef'> {
 	 * Language content override
 	 */
 	lang?: Partial<PopoverTextContent>;
+	/**
+	 * Whether the popover is playing its exit animation, exposed to CSS as
+	 * `data-exiting` on the popover root
+	 */
+	isExiting?: boolean;
+	/**
+	 * Receives the popover root element, the one carrying `data-exiting`
+	 */
+	rootRef?: React.RefObject<HTMLDivElement | null>;
 }
 
 /**
@@ -69,6 +80,8 @@ export const Popover = ({
 	state,
 	triggerRef,
 	lang,
+	isExiting,
+	rootRef,
 	...props
 }: PopoverProps) => {
 	const popoverRef = useRef<HTMLDivElement>(null);
@@ -76,6 +89,8 @@ export const Popover = ({
 
 	const isFullScreen = !isTablet;
 	const textValues = { ...defaultEnglish, ...lang };
+
+	const { close } = state;
 
 	// Handle Esc manually since we have two different modes (popover vs fullscreen dialog)
 	// and react-aria would need a slightly different ModalTrigger pattern
@@ -85,13 +100,13 @@ export const Popover = ({
 		const handleKeyDown = (event: KeyboardEvent) => {
 			if (event.key === 'Escape') {
 				event.preventDefault();
-				state.close();
+				close();
 			}
 		};
 
 		document.addEventListener('keydown', handleKeyDown);
 		return () => document.removeEventListener('keydown', handleKeyDown);
-	}, [isFullScreen, state]);
+	}, [isFullScreen, close]);
 
 	const { popoverProps, underlayProps } = usePopover(
 		{
@@ -108,7 +123,11 @@ export const Popover = ({
 		return (
 			<Overlay>
 				<Dialog>
-					<div className={fullScreenStyle}>
+					<div
+						className={fullScreenStyle}
+						ref={rootRef}
+						{...dataAttrs({ exiting: isExiting })}
+					>
 						<div
 							className={sprinkles({
 								display: 'flex',
@@ -122,7 +141,7 @@ export const Popover = ({
 									variant="secondary"
 									minimal
 									rounded
-									onClick={state.close}
+									onClick={close}
 									aria-label={textValues.close}
 								>
 									<Icon icon={XIcon} />
@@ -140,9 +159,14 @@ export const Popover = ({
 	return (
 		<Overlay>
 			<div {...underlayProps} />
-			<div {...popoverProps} ref={popoverRef} className={overlayStyle}>
+			<div
+				{...popoverProps}
+				ref={mergeRefs([popoverRef, rootRef])}
+				className={overlayStyle}
+				{...dataAttrs({ exiting: isExiting })}
+			>
 				<Dialog>{children}</Dialog>
-				<DismissButton onDismiss={state.close} />
+				<DismissButton onDismiss={close} />
 			</div>
 		</Overlay>
 	);

--- a/lib/components/Popover/PopoverTrigger.tsx
+++ b/lib/components/Popover/PopoverTrigger.tsx
@@ -5,7 +5,10 @@ import {
 	useButton,
 	type AriaPopoverProps,
 } from 'react-aria';
-import { useOverlayTriggerState } from 'react-stately';
+import {
+	useOverlayTriggerState,
+	type OverlayTriggerState,
+} from 'react-stately';
 
 import type { TestIdProp } from '../../types';
 import { dataAttrs } from '../../utils/dataAttrs';
@@ -13,6 +16,7 @@ import { Button } from '../Button/Button';
 
 import { Popover, type PopoverTextContent } from './Popover';
 import { triggerStyle } from './Popover.css';
+import { useExitAnimation } from './useExitAnimation';
 
 export type OnStateReadyValue = { close: () => void; isOpen: boolean };
 
@@ -59,6 +63,11 @@ export interface PopoverTriggerProps
  * Note: Button components are not supported as children due to React Aria compatibility issues,
  * use button tag, plain text, or other elements instead.
  *
+ * Closing is held open for as long as the popover root has animations running,
+ * and `data-exiting` is set on that root while they play, so consumers can
+ * animate the exit with CSS. A popover with no exit animation unmounts in the
+ * same commit it always has.
+ *
  * @example
  * ```tsx
  * <PopoverTrigger content={<Calendar />}>
@@ -82,17 +91,25 @@ export const PopoverTrigger = ({
 	const state = useOverlayTriggerState({});
 	const internalRef = useRef<HTMLButtonElement>(null);
 	const triggerRef = ref ?? internalRef;
+	const { isExiting, rootRef, requestExit } = useExitAnimation(state.close);
+
+	const exitAwareState: OverlayTriggerState = {
+		...state,
+		setOpen: (isOpen) => (isOpen ? state.open() : requestExit()),
+		close: requestExit,
+		toggle: () => (state.isOpen ? requestExit() : state.open()),
+	};
 
 	// Provide state access to parent component
 	React.useEffect(() => {
 		if (onStateReady) {
-			onStateReady({ close: state.close, isOpen: state.isOpen });
+			onStateReady({ close: requestExit, isOpen: state.isOpen });
 		}
-	}, [onStateReady, state.close, state.isOpen]);
+	}, [onStateReady, requestExit, state.isOpen]);
 
 	const { triggerProps, overlayProps } = useOverlayTrigger(
 		{ type: 'dialog' },
-		state,
+		exitAwareState,
 		triggerRef,
 	);
 
@@ -138,7 +155,9 @@ export const PopoverTrigger = ({
 			{state.isOpen && (
 				<Popover
 					{...overlayProps}
-					state={state}
+					state={exitAwareState}
+					isExiting={isExiting}
+					rootRef={rootRef}
 					triggerRef={triggerRef}
 					placement={placement}
 					offset={offset}

--- a/lib/components/Popover/useExitAnimation.ts
+++ b/lib/components/Popover/useExitAnimation.ts
@@ -1,0 +1,101 @@
+import { type RefObject, useEffect, useRef, useState } from 'react';
+
+import { useEventCallback } from '../../utils';
+
+const EXITING_ATTRIBUTE = 'data-exiting';
+
+/**
+ * Upper bound on how long an element may be held mounted while its exit
+ * animation plays. An animation that never settles cannot strand the element.
+ */
+export const EXIT_TIMEOUT_MS = 1000;
+
+const willSettle = ({ effect }: Animation) => {
+	const endTime = effect?.getComputedTiming().endTime;
+	return typeof endTime !== 'number' || Number.isFinite(endTime);
+};
+
+export interface ExitAnimation {
+	/**
+	 * Whether the element is currently playing its exit animation
+	 */
+	isExiting: boolean;
+	/**
+	 * Attach to the element whose animations gate the exit
+	 */
+	rootRef: RefObject<HTMLDivElement | null>;
+	/**
+	 * Marks the element as exiting and calls `onExited` once its animations
+	 * settle. Calls `onExited` straight away when nothing is animating.
+	 */
+	requestExit: () => void;
+}
+
+/**
+ * Defers `onExited` until the exit animations on `rootRef` have finished.
+ *
+ * The element is marked with `data-exiting` before its animations are read, so
+ * CSS keyed off that attribute is running by the time it is measured. Endless
+ * animations such as a loading spinner are ignored, since they never settle. An
+ * element with nothing to play settles synchronously, leaving the caller's
+ * state change in the same commit it would have been in without this hook.
+ */
+export const useExitAnimation = (onExited: () => void): ExitAnimation => {
+	const rootRef = useRef<HTMLDivElement>(null);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const isSettlingRef = useRef(false);
+	const [isExiting, setIsExiting] = useState(false);
+
+	const clearTimer = () => {
+		if (timerRef.current === null) return;
+		clearTimeout(timerRef.current);
+		timerRef.current = null;
+	};
+
+	const settle = useEventCallback(() => {
+		if (!isSettlingRef.current) return;
+		isSettlingRef.current = false;
+		clearTimer();
+		setIsExiting(false);
+		onExited();
+	});
+
+	const requestExit = useEventCallback(() => {
+		if (isSettlingRef.current) return;
+
+		const element = rootRef.current;
+		if (!element || typeof element.getAnimations !== 'function') {
+			onExited();
+			return;
+		}
+
+		element.setAttribute(EXITING_ATTRIBUTE, '');
+		const animations = element
+			.getAnimations({ subtree: true })
+			.filter((animation) => willSettle(animation));
+
+		if (animations.length === 0) {
+			element.removeAttribute(EXITING_ATTRIBUTE);
+			onExited();
+			return;
+		}
+
+		isSettlingRef.current = true;
+		timerRef.current = setTimeout(settle, EXIT_TIMEOUT_MS);
+		setIsExiting(true);
+
+		Promise.all(animations.map(({ finished }) => finished))
+			.then(settle)
+			.catch(settle);
+	});
+
+	useEffect(
+		() => () => {
+			isSettlingRef.current = false;
+			clearTimer();
+		},
+		[],
+	);
+
+	return { isExiting, rootRef, requestExit };
+};

--- a/lib/test/animations.ts
+++ b/lib/test/animations.ts
@@ -3,7 +3,18 @@
  * exercise exit animations stub the DOM API itself and report the animations a
  * `[data-exiting]` rule would have started.
  */
+let originalGetAnimations: PropertyDescriptor | undefined;
+let isStubbed = false;
+
 export const stubGetAnimations = (exitAnimations: () => Animation[]) => {
+	if (!isStubbed) {
+		originalGetAnimations = Object.getOwnPropertyDescriptor(
+			Element.prototype,
+			'getAnimations',
+		);
+		isStubbed = true;
+	}
+
 	Object.defineProperty(Element.prototype, 'getAnimations', {
 		configurable: true,
 		writable: true,
@@ -13,6 +24,26 @@ export const stubGetAnimations = (exitAnimations: () => Animation[]) => {
 				: [];
 		},
 	});
+};
+
+/**
+ * Puts `Element.prototype.getAnimations` back the way the environment had it
+ */
+export const restoreGetAnimations = () => {
+	if (!isStubbed) return;
+	isStubbed = false;
+
+	if (originalGetAnimations) {
+		Object.defineProperty(
+			Element.prototype,
+			'getAnimations',
+			originalGetAnimations,
+		);
+	} else {
+		Reflect.deleteProperty(Element.prototype, 'getAnimations');
+	}
+
+	originalGetAnimations = undefined;
 };
 
 /**

--- a/lib/test/animations.ts
+++ b/lib/test/animations.ts
@@ -1,0 +1,44 @@
+/**
+ * jsdom implements neither Web Animations nor `getAnimations`, so specs that
+ * exercise exit animations stub the DOM API itself and report the animations a
+ * `[data-exiting]` rule would have started.
+ */
+export const stubGetAnimations = (exitAnimations: () => Animation[]) => {
+	Object.defineProperty(Element.prototype, 'getAnimations', {
+		configurable: true,
+		writable: true,
+		value(this: HTMLElement) {
+			return Object.hasOwn(this.dataset, 'exiting')
+				? exitAnimations()
+				: [];
+		},
+	});
+};
+
+/**
+ * An animation that settles only when the returned `finish` is called
+ */
+export const deferredAnimation = () => {
+	let finish!: () => void;
+	const finished = new Promise<void>((resolve) => {
+		finish = resolve;
+	});
+
+	return { animation: { finished } as unknown as Animation, finish };
+};
+
+/**
+ * An animation with a finite duration that never resolves, modelling one the
+ * browser has dropped part way through
+ */
+export const stalledAnimation = () =>
+	({ finished: new Promise(() => {}) }) as unknown as Animation;
+
+/**
+ * An animation that runs forever, such as a loading spinner
+ */
+export const endlessAnimation = () =>
+	({
+		finished: new Promise(() => {}),
+		effect: { getComputedTiming: () => ({ endTime: Infinity }) },
+	}) as unknown as Animation;

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
 	},
 	"scripts": {
 		"analyse": "vite build --config vite-analyse.config.ts",
-		"build": "babel lib --out-dir dist --extensions '.ts,.tsx,.css' --ignore 'lib/stories,lib/test,lib/**/*.spec.tsx,lib/**/*.stories.tsx'",
+		"build": "babel lib --out-dir dist --extensions '.ts,.tsx,.css' --ignore 'lib/stories,lib/test,lib/**/*.spec.tsx,lib/**/*.stories.tsx,lib/**/*.stories.css.ts'",
 		"chromatic": "chromatic test --exit-zero-on-changes --build-script-name storybook:build",
 		"copy:public": "node scripts/copyPublic.js",
 		"check-deps": "npx npm-check-updates@latest --interactive --format group",

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -13,6 +13,7 @@
 		"lib/stories",
 		"lib/test",
 		"**/*.stories.tsx",
+		"**/*.stories.css.ts",
 		"**/*.stories.jsx",
 		"**/*.spec.tsx",
 		"**/*.spec.jsx"


### PR DESCRIPTION
[AG-21418](https://autoguru.atlassian.net/browse/AG-21418)

Popovers animate in fine and then vanish on close. `PopoverTrigger` renders `state.isOpen && <Popover />`, so the entire subtree unmounts in one commit and there is no window in which a consumer could run an exit animation. `onStateReady` is no help either. It only reports `isOpen: false` once the unmount has already happened.

This handles the exit inside `PopoverTrigger`. On close it stamps `data-exiting` on the popover root, then holds the unmount until `element.getAnimations({ subtree: true })` reports nothing still running. Consumers write the exit as CSS keyed off `[data-exiting]` and there is nothing else to opt into.

## What this does to DatePicker

Nothing, and the same goes for `DateField`. Those two are the only consumers of `PopoverTrigger` in this repo, neither runs an exit animation, and the design depends on that case costing nothing.

The attribute goes on before the animations are read. `getAnimations()` forces a style flush, so whatever CSS the attribute switched on is already running by the time it gets measured. A consumer with nothing to play gets an empty list back, the attribute comes straight off again, and the close lands in the same commit it always did. It is literally the same commit: no timer, no delayed unmount, no extra render.

The test for that counts renders of the popover content across the close and asserts the number does not move, rather than only checking the dialog has gone. `DatePicker.spec.tsx` gets the matching test on the other side, holding the calendar open through an animation and then letting it finish. Its 25 existing tests pass unchanged.

## Why not move to React Aria Components

`Popover` sits on the hook-level react-aria primitives, `usePopover`, `useDialog` and `Overlay`. React Aria Components has exit animation support built in, and `react-aria-components` is already a direct dependency here for `OptionGrid`, so it was worth weighing up.

The problem is blast radius rather than the dependency itself. Moving over rewrites the rendered DOM, the focus and dismiss handling and the trigger API, and `Popover` carries a bespoke sub-tablet fullscreen mode plus a manual Escape handler that would both need reworking on top of that. That is a rewrite of a component with live consumers, for something that fits in one hook.

Hoisting `isOpen` and `onOpenChange` out to consumers was the other option. It exports the hard part to every call site, which is the wrong direction for a design system.

## How it works

`useExitAnimation` does the waiting. `PopoverTrigger` wraps the react-stately overlay state so every close path lands in one place: the trigger toggle, an outside click, Escape, the dismiss button and the consumer's own close callback. The underlying `isOpen` stays true for the duration of the exit, which matters because react-aria drops its positioning once it flips.

Two things stop a popover getting stranded on screen. Endless animations such as a loading spinner are filtered out, since they never finish and would otherwise make every close in a popover containing a spinner wait for the cap. And a 1000ms cap covers an animation the browser drops part way through. `Modal` already works this way, with a hardcoded 300ms timer. This reads the duration off the animation instead.

There is a `Popover.stories.css.ts` and an `ExitAnimation` story showing the pattern a consumer would copy, including the `prefers-reduced-motion` opt-out, which falls back to an instant unmount.

## Testing

`yarn lint` clean, `yarn test --run` at 93 files and 937 tests, all passing. New coverage: the same-commit unmount, an animated exit held open and released, `data-exiting` present only during the exit, the endless-animation case and the safety cap. There is also an environment with no `getAnimations` at all, focus ending up where an unanimated close would have left it, and both the positioned and fullscreen roots.

jsdom implements neither Web Animations nor `getAnimations`, so `lib/test/animations.ts` stubs the DOM API rather than the component's logic, and reports animations only for an element carrying `data-exiting`. The real code path runs either way.

Changeset is a minor. Additive, and nothing existing changes behaviour.


[AG-21418]: https://autoguru.atlassian.net/browse/AG-21418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ