### PR TITLE
feat(themes): brand the DS-2026 color.link ramp per tenant and theme (AG-20713)

### DIFF
--- a/.changeset/link-token-branding.md
+++ b/.changeset/link-token-branding.md
@@ -1,0 +1,25 @@
+---
+'@autoguru/overdrive': minor
+---
+
+feat(themes): brand the DS-2026 `color.link.*` ramp per tenant and theme
+(AG-20713)
+
+`color.link.*` was the only link token family that neither `OverdriveProvider`'s
+`colorOverrides` nor the alternate themes reached, so anything reading it
+rendered base green regardless of branding.
+
+- `useColorOverrides` now derives `color.link.{primary,hover,pressed}` from the
+  tenant's `linkColor`. `primary` is the same surface-corrected value that
+  already backs `color.interactive.link`; `hover` and `pressed` step lighter by
+  the same lightness deltas base uses between its own link states.
+- `neutral` adds the brand trio in blue. Its gray and red ramps match base, so
+  `secondary` and the `critical*` leaves stay inherited.
+- `flat_red` adds the full set, because it redefines every ramp it uses — an
+  inherited `secondary` would be base's `#212338` rather than its own `#263238`.
+
+`secondary` and `critical`/`criticalHover`/`criticalPressed` are deliberately
+not tenant-brandable: one is neutral ink, the others are semantic danger reds.
+
+No current rendering changes — the base theme is untouched and no component
+reads `color.link.*` yet.

--- a/lib/components/OverdriveProvider/useColorOverrides.ts
+++ b/lib/components/OverdriveProvider/useColorOverrides.ts
@@ -203,6 +203,16 @@ const warnOnLowContrast = (
 const maxShadeSteps = 60;
 const shadeStep = 0.01;
 
+/**
+ * How far linked text travels from its resting colour on hover and press,
+ * as a lightness delta.
+ *
+ * Taken from base's own `color.link` ramp — `primary` `#18856f` (L 31) →
+ * `hover` `#03af83` (L 35) → `pressed` `#36e5aa` (L 55) — so a tenant brand
+ * covers the same distance rather than an invented one.
+ */
+const linkStateStep = { hover: 0.04, pressed: 0.24 } as const;
+
 const shade = (
 	colour: string,
 	towards: 'darker' | 'lighter',
@@ -372,6 +382,28 @@ export const useColorOverrides = (
 			? deriveLinkForSurface(linkColor, theme.darkSurface)
 			: null;
 
+		// Linked text moves its label and underline to a lighter tint as it is
+		// hovered and pressed. Derived from the resolved link colour rather
+		// than the raw brand so the whole ramp sits on the surface-corrected
+		// value, and stepped by `linkStateStep` so a tenant's brand travels the
+		// same distance base does.
+		const linkHover = linkOnLight
+			? shadedColour({
+					colour: linkOnLight,
+					isDarkTheme,
+					direction: 'forward',
+					intensity: linkStateStep.hover,
+				})
+			: null;
+		const linkPressed = linkOnLight
+			? shadedColour({
+					colour: linkOnLight,
+					isDarkTheme,
+					direction: 'forward',
+					intensity: linkStateStep.pressed,
+				})
+			: null;
+
 		if (process.env.NODE_ENV !== 'production') {
 			warnOnLowContrast(primaryBackground, 'primaryBackground', theme);
 			if (linkColor)
@@ -401,6 +433,18 @@ export const useColorOverrides = (
 					// the brand only inside a Box and the theme default outside.
 					//@ts-expect-error no undefined
 					link: linkOnLight ?? undefined,
+				},
+				// The DS-2026 linked-text ramp. Only the three brand-derived
+				// leaves are branded: `secondary` is neutral ink and
+				// `critical`/`criticalHover`/`criticalPressed` are the semantic
+				// danger reds, which a tenant should not be able to repaint.
+				link: {
+					//@ts-expect-error no undefined
+					primary: linkOnLight ?? undefined,
+					//@ts-expect-error no undefined
+					hover: linkHover ?? undefined,
+					//@ts-expect-error no undefined
+					pressed: linkPressed ?? undefined,
 				},
 				button: {
 					primary: {

--- a/lib/themes/flat_red/tokens.ts
+++ b/lib/themes/flat_red/tokens.ts
@@ -80,6 +80,20 @@ export const tokens = deepmerge(baseTokens, {
 			linkOnLight: colours.green['600'],
 			linkOnDark: colours.green['600'],
 		},
+		// DS-2026 linked text reads `color.link`. Unlike `neutral`, this theme
+		// redefines every ramp it uses, so the whole set is overridden — an
+		// inherited `secondary` would be base's gray900 `#212338` rather than
+		// this theme's `#263238`, and the `critical*` trio would be base's reds
+		// rather than the flat-red ones.
+		link: {
+			primary: colours.green['600'],
+			secondary: colours.gray['900'],
+			hover: colours.green['500'],
+			pressed: colours.green['400'],
+			critical: colours.red['700'],
+			criticalHover: colours.red['500'],
+			criticalPressed: colours.red['300'],
+		},
 	},
 	colours: {
 		gamut: {

--- a/lib/themes/neutral/tokens.ts
+++ b/lib/themes/neutral/tokens.ts
@@ -87,7 +87,9 @@ export const tokens = deepmerge(baseTokens, {
 	// `color.focus.ring` consumer ringing base green next to a blue one. The
 	// per-surface link pair has to follow for the same reason: a dark-surface
 	// Box repoints links at `linkOnDark`, which would otherwise inherit base
-	// green beside this theme's blue links.
+	// green beside this theme's blue links. `color.link` follows for the third
+	// time: DS-2026 linked text reads it, and would otherwise render base green
+	// beside everything else this theme paints blue.
 	color: {
 		focus: {
 			ring: colours.blue['500'],
@@ -95,6 +97,14 @@ export const tokens = deepmerge(baseTokens, {
 		interactive: {
 			linkOnLight: colours.blue['500'],
 			linkOnDark: colours.blue['500'],
+		},
+		// Only the brand-derived leaves. This theme's gray and red ramps are
+		// identical to base, so `secondary` and the `critical*` trio already
+		// resolve correctly through inheritance.
+		link: {
+			primary: colours.blue['500'],
+			hover: colours.blue['400'],
+			pressed: colours.blue['300'],
 		},
 	},
 	colours: {


### PR DESCRIPTION
## Summary

`color.link.*` is the one link token family **nothing brands**. `useColorOverrides` reaches `colours.foreground.link`, `typography.colour.link` and `color.interactive.link*`; `neutral` and `flat_red` override those plus `color.focus.ring`. None of them touched `color.link.*`, so anything reading it rendered base green under every tenant and every theme.

This is the blocker that stops DS-2026 linked text becoming the default appearance. Flipping it today would silently drop tenant link branding and turn `neutral`'s blue links green — so this lands the token plumbing first, ahead of any default change.

**Nothing renders differently today.** Base is untouched, and no component reads `color.link.*` yet (the `variant` path that will is #1384).

## What changed

**`useColorOverrides`** derives `color.link.{primary,hover,pressed}` from the tenant's `linkColor`:

- `primary` reuses `linkOnLight` — the same surface-corrected value already backing `color.interactive.link` and `colours.foreground.link` — so the resting link colour matches the rest of the link system exactly rather than being a second, slightly different derivation of the same brand.
- `hover`/`pressed` step lighter by the **same lightness deltas base uses between its own states** (`#18856f` L31 → `#03af83` L35 → `#36e5aa` L55, i.e. +4 and +24), so a tenant brand travels the same distance rather than an invented one.

Verified against the `WithBrandedLinks` story (tenant `#6d39a8`):

| var | value |
|---|---|
| `--od-color-link-primary` | `#613395` — identical to `--od-color-interactive-link` ✅ |
| `--od-color-link-hover` | `#6b38a4` |
| `--od-color-link-pressed` | `#9e73cf` |

**`neutral`** adds the brand trio in blue (`500`/`400`/`300`). Its gray and red ramps are byte-identical to base, so `secondary` and the `critical*` leaves stay correctly inherited — I diffed every ramp to confirm rather than overriding blindly.

**`flat_red`** adds the **full** set, because it redefines every ramp it uses. An inherited `secondary` would be base's `#212338` rather than its own `#263238`, and the `critical*` trio would be base's reds rather than the flat-red ones.

Generated theme vars after the change:

| theme | primary | secondary | critical |
|---|---|---|---|
| base | `#18856f` | `#212338` | `#b51e1a` | 
| neutral | `#0d59fc` | `#212338` (inherited, correct) | `#b51e1a` (inherited, correct) |
| flat_red | `#00c400` | `#263238` (own) | `#fb1e0d` (own) |

## Deliberate scope

`secondary` and `critical`/`criticalHover`/`criticalPressed` are **not** tenant-brandable — one is neutral ink, the others are semantic danger reds, and neither is a brand's to repaint. Themes may still set them, and `flat_red` does, because a theme owns its whole palette.

## Testing

- 996/996 unit tests pass, `yarn lint` exit 0.
- Verified the emitted CSS custom properties for the tenant override path and for all three theme classes (tables above), plus a clean render of `WithBrandedLinks` with no console errors.

## Notes for review

- Follows the precedent already set in both theme files: each has a `color` block overriding `focus.ring` and `interactive.linkOnLight/OnDark` for exactly this reason, with a comment explaining it. `color.link` slots in alongside and the comments are extended rather than duplicated.
- The hover/pressed derivation reproduces base's *relationship*, not base's exact hues — base's green ramp isn't a pure lightness ramp, so `#18856f` lightened by 0.04 gives `#1b967d` rather than `#03af83`. Same lightness, slightly different hue. Matching lightness travel seemed more meaningful than trying to reproduce a hand-tuned ramp.
- `link.pressed` is intentionally light and can fall below AA as text — that matches base, which was confirmed as a deliberate design decision. The existing `warnOnLowContrast` / `warnOnLinkDerivation` dev warnings still cover the supplied colour.
- Third PR under AG-20713, alongside #1384 (TextLink linked-text variants) and #1385 (Button story docs). No file overlap with either, so merge order is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)